### PR TITLE
Optimize Komga offline caching behavior

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDownloadScreen.kt
@@ -59,6 +59,11 @@ object SettingsDownloadScreen : SearchableSettings {
                 subtitle = stringResource(MR.strings.pref_download_concurrent_pages_summary),
                 onValueChanged = { downloadPreferences.parallelPageLimit.set(it) },
             ),
+            Preference.PreferenceItem.SwitchPreference(
+                preference = downloadPreferences.cacheCurrentChapterWhileReading,
+                title = stringResource(MR.strings.pref_cache_current_chapter_while_reading),
+                subtitle = stringResource(MR.strings.pref_cache_current_chapter_while_reading_summary),
+            ),
             getDeleteChaptersGroup(
                 downloadPreferences = downloadPreferences,
                 categories = allCategories,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -155,6 +155,10 @@ class DownloadManager(
         startQueuedDownloadsOnly()
     }
 
+    fun startOfflineCacheNow(chapterId: Long) {
+        startDownloadNow(chapterId)
+    }
+
     /**
      * Reorders the download queue.
      *
@@ -178,6 +182,22 @@ class DownloadManager(
         mode: Download.Mode? = null,
     ) {
         downloader.queueChapters(manga, chapters, autoStart, mode)
+    }
+
+    fun cacheChaptersForOffline(
+        manga: Manga,
+        chapters: List<Chapter>,
+        autoStart: Boolean = true,
+    ) {
+        downloadChapters(manga, chapters, autoStart)
+    }
+
+    fun cacheChapterPagesForOffline(
+        manga: Manga,
+        chapter: Chapter,
+        autoStart: Boolean = true,
+    ) {
+        downloadChapters(manga, listOf(chapter), autoStart, Download.Mode.PAGE_CACHE)
     }
 
     /**
@@ -282,6 +302,10 @@ class DownloadManager(
                 deleteManga(manga, source, removeQueued = false)
             }
         }
+    }
+
+    fun removeOfflineCache(chapters: List<Chapter>, manga: Manga, source: Source) {
+        deleteChapters(chapters, manga, source)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -894,7 +894,6 @@ class Downloader(
         }
         val extension = ImageUtil.findImageType(cacheFile.inputStream()) ?: return tmpFile
         tmpFile.renameTo("$filename.${extension.extension}")
-        cacheFile.delete()
         return tmpFile
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -219,8 +219,9 @@ class MangaScreenModel(
                 setMangaDefaultChapterFlags.await(manga)
             }
 
-            val needRefreshInfo = !manga.initialized
-            val needRefreshChapter = chapters.isEmpty()
+            val shouldRefreshKomga = source.id == KomgaSource.ID
+            val needRefreshInfo = !manga.initialized || shouldRefreshKomga
+            val needRefreshChapter = chapters.isEmpty() || shouldRefreshKomga
 
             // Show what we have earlier
             mutableState.update {
@@ -673,7 +674,7 @@ class MangaScreenModel(
         screenModelScope.launchNonCancellable {
             if (startNow) {
                 val chapterId = chapters.singleOrNull()?.id ?: return@launchNonCancellable
-                downloadManager.startDownloadNow(chapterId)
+                downloadManager.startOfflineCacheNow(chapterId)
             } else {
                 downloadChapters(chapters)
             }
@@ -806,7 +807,7 @@ class MangaScreenModel(
      */
     private fun downloadChapters(chapters: List<Chapter>) {
         val manga = successState?.manga ?: return
-        downloadManager.downloadChapters(manga, chapters)
+        downloadManager.cacheChaptersForOffline(manga, chapters)
         toggleAllSelection(false)
     }
 
@@ -833,7 +834,7 @@ class MangaScreenModel(
         screenModelScope.launchNonCancellable {
             try {
                 successState?.let { state ->
-                    downloadManager.deleteChapters(
+                    downloadManager.removeOfflineCache(
                         chapters,
                         state.manga,
                         state.source,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -145,6 +145,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private var chapterReadStartTime: Long? = null
 
     private var chapterToDownload: Download? = null
+    private val currentChapterAutoCacheRequests = mutableSetOf<Long>()
 
     private val unfilteredChapterList by lazy {
         val manga = manga!!
@@ -228,6 +229,7 @@ class ReaderViewModel @JvmOverloads constructor(
 
     private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading.get()
+    private val cacheCurrentChapterWhileReading = downloadPreferences.cacheCurrentChapterWhileReading.get()
 
     init {
         // To save state
@@ -242,6 +244,7 @@ class ReaderViewModel @JvmOverloads constructor(
                     currentChapter.requestedPage = currentChapter.chapter.last_page_read
                 }
                 chapterId = currentChapter.chapter.id!!
+                cacheCurrentChapterForOffline(currentChapter)
             }
             .launchIn(viewModelScope)
     }
@@ -491,11 +494,38 @@ class ReaderViewModel @JvmOverloads constructor(
                 }
             }.take(downloadAheadAmount)
 
-            downloadManager.downloadChapters(
+            downloadManager.cacheChaptersForOffline(
                 manga,
                 chaptersToDownload,
-                mode = Download.Mode.PAGE_CACHE,
             )
+        }
+    }
+
+    private fun cacheCurrentChapterForOffline(currentChapter: ReaderChapter) {
+        if (!cacheCurrentChapterWhileReading) return
+        if (currentChapter.pageLoader is DownloadPageLoader) return
+
+        val manga = manga ?: return
+        val chapter = currentChapter.chapter.toDomainChapter() ?: return
+        val chapterId = chapter.id
+        synchronized(currentChapterAutoCacheRequests) {
+            if (!currentChapterAutoCacheRequests.add(chapterId)) return
+        }
+
+        viewModelScope.launchIO {
+            val isDownloaded = downloadManager.isChapterDownloaded(
+                chapter.name,
+                chapter.scanlator,
+                chapter.url,
+                manga.title,
+                manga.source,
+                skipCache = true,
+            )
+            if (isDownloaded || downloadManager.getQueuedDownloadOrNull(chapterId) != null) {
+                return@launchIO
+            }
+
+            downloadManager.cacheChapterPagesForOffline(manga, chapter)
         }
     }
 

--- a/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
@@ -6,6 +6,8 @@ import koharia.komga.api.dto.ClientSettingDto
 import koharia.komga.api.dto.CollectionDto
 import koharia.komga.api.dto.LibraryDto
 import koharia.komga.api.dto.PageWrapperDto
+import koharia.source.komga.KomgaCachePolicy
+import koharia.source.komga.komgaCachePolicy
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
@@ -26,7 +28,11 @@ class KomgaApiClient(
     @PublishedApi internal val json: Json,
 ) {
 
-    fun popularRequest(page: Int, defaultLibraries: Set<String>): Request {
+    fun popularRequest(
+        page: Int,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ): Request {
         return searchRequest(
             page = page,
             query = "",
@@ -34,10 +40,15 @@ class KomgaApiClient(
             defaultLibraries = defaultLibraries,
             sortIndex = 1,
             sortAscending = true,
+            cachePolicy = cachePolicy,
         )
     }
 
-    fun latestRequest(page: Int, defaultLibraries: Set<String>): Request {
+    fun latestRequest(
+        page: Int,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ): Request {
         return searchRequest(
             page = page,
             query = "",
@@ -45,6 +56,7 @@ class KomgaApiClient(
             defaultLibraries = defaultLibraries,
             sortIndex = 3,
             sortAscending = false,
+            cachePolicy = cachePolicy,
         )
     }
 
@@ -63,6 +75,7 @@ class KomgaApiClient(
         tags: Set<String> = emptySet(),
         publishers: Set<String> = emptySet(),
         authors: List<Pair<String, String>> = emptyList(),
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
     ): Request {
         val typePath = when {
             collectionId != null -> "collections/$collectionId/series"
@@ -106,19 +119,37 @@ class KomgaApiClient(
         }
 
         return GET(url.build(), headers)
+            .newBuilder()
+            .komgaCachePolicy(cachePolicy)
+            .build()
     }
 
-    fun detailsRequest(url: String): Request = GET(url, headers)
+    fun detailsRequest(url: String, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Request =
+        GET(url, headers)
+            .newBuilder()
+            .komgaCachePolicy(cachePolicy)
+            .build()
 
-    fun chapterListRequest(url: String, isBook: Boolean): Request {
-        return if (isBook) {
+    fun chapterListRequest(
+        url: String,
+        isBook: Boolean,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ): Request {
+        val request = if (isBook) {
             GET("$url?unpaged=true&media_status=READY&deleted=false", headers)
         } else {
             GET("$url/books?unpaged=true&media_status=READY&deleted=false", headers)
         }
+        return request.newBuilder()
+            .komgaCachePolicy(cachePolicy)
+            .build()
     }
 
-    fun pageListRequest(url: String): Request = GET("$url/pages", headers)
+    fun pageListRequest(url: String, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Request =
+        GET("$url/pages", headers)
+            .newBuilder()
+            .komgaCachePolicy(cachePolicy)
+            .build()
 
     fun bookFileRequest(url: String, rangeStart: Long? = null): Request {
         val request = GET("$url/file", headers)
@@ -131,11 +162,21 @@ class KomgaApiClient(
         }
     }
 
-    suspend fun getLibraries(): List<LibraryDto> =
-        client.newCall(GET("$baseUrl/api/v1/libraries", headers)).executeAndParse()
+    suspend fun getLibraries(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): List<LibraryDto> =
+        client.newCall(
+            GET("$baseUrl/api/v1/libraries", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        ).executeAndParse()
 
-    suspend fun getLibraryOrders(): Map<String, Int> {
-        val settings = client.newCall(GET("$baseUrl/api/v1/client-settings/user/list", headers))
+    suspend fun getLibraryOrders(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Map<String, Int> {
+        val settings = client.newCall(
+            GET("$baseUrl/api/v1/client-settings/user/list", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        )
             .executeAndParse<Map<String, ClientSettingDto>>()
         val librariesValue = settings["webui.libraries"]?.value?.takeIf { it.isNotBlank() } ?: return emptyMap()
         val librariesOrder = json.parseToJsonElement(librariesValue).jsonObject
@@ -147,22 +188,45 @@ class KomgaApiClient(
         }.toMap()
     }
 
-    suspend fun getCollections(): List<CollectionDto> =
+    suspend fun getCollections(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): List<CollectionDto> =
         client.newCall(
-            GET("$baseUrl/api/v1/collections?unpaged=true", headers),
+            GET("$baseUrl/api/v1/collections?unpaged=true", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
         ).executeAndParse<PageWrapperDto<CollectionDto>>().content
 
-    suspend fun getGenres(): Set<String> =
-        client.newCall(GET("$baseUrl/api/v1/genres", headers)).executeAndParse()
+    suspend fun getGenres(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Set<String> =
+        client.newCall(
+            GET("$baseUrl/api/v1/genres", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        ).executeAndParse()
 
-    suspend fun getTags(): Set<String> =
-        client.newCall(GET("$baseUrl/api/v1/tags", headers)).executeAndParse()
+    suspend fun getTags(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Set<String> =
+        client.newCall(
+            GET("$baseUrl/api/v1/tags", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        ).executeAndParse()
 
-    suspend fun getPublishers(): Set<String> =
-        client.newCall(GET("$baseUrl/api/v1/publishers", headers)).executeAndParse()
+    suspend fun getPublishers(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Set<String> =
+        client.newCall(
+            GET("$baseUrl/api/v1/publishers", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        ).executeAndParse()
 
-    suspend fun getAuthors(): Map<String, List<AuthorDto>> =
-        client.newCall(GET("$baseUrl/api/v1/authors", headers)).executeAndParse<List<AuthorDto>>().groupBy { it.role }
+    suspend fun getAuthors(cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Map<String, List<AuthorDto>> =
+        client.newCall(
+            GET("$baseUrl/api/v1/authors", headers)
+                .newBuilder()
+                .komgaCachePolicy(cachePolicy)
+                .build(),
+        ).executeAndParse<List<AuthorDto>>().groupBy { it.role }
 
     fun isReadList(url: String): Boolean = url.contains("/api/v1/readlists")
 

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -19,6 +19,7 @@ import koharia.komga.api.dto.toSManga
 import koharia.source.komga.AuthorGroup
 import koharia.source.komga.CollectionSelect
 import koharia.source.komga.InProgressFilter
+import koharia.source.komga.KomgaCachePolicy
 import koharia.source.komga.LibraryFilter
 import koharia.source.komga.ReadFilter
 import koharia.source.komga.SeriesSort
@@ -35,13 +36,25 @@ class KomgaRepository(
     private val apiClient: KomgaApiClient,
 ) {
 
-    fun popularMangaRequest(page: Int, defaultLibraries: Set<String>) =
-        apiClient.popularRequest(page, defaultLibraries)
+    fun popularMangaRequest(
+        page: Int,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ) = apiClient.popularRequest(page, defaultLibraries, cachePolicy)
 
-    fun latestUpdatesRequest(page: Int, defaultLibraries: Set<String>) =
-        apiClient.latestRequest(page, defaultLibraries)
+    fun latestUpdatesRequest(
+        page: Int,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ) = apiClient.latestRequest(page, defaultLibraries, cachePolicy)
 
-    fun searchMangaRequest(page: Int, query: String, filters: FilterList, defaultLibraries: Set<String>) =
+    fun searchMangaRequest(
+        page: Int,
+        query: String,
+        filters: FilterList,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ) =
         apiClient.searchRequest(
             page = page,
             query = query,
@@ -57,6 +70,7 @@ class KomgaRepository(
             tags = filters.multiSelectIds("Tags"),
             publishers = filters.multiSelectIds("Publishers"),
             authors = filters.selectedAuthors(),
+            cachePolicy = cachePolicy,
         )
 
     fun parseMangasPage(response: okhttp3.Response): MangasPage {
@@ -82,7 +96,8 @@ class KomgaRepository(
         return MangasPage(mangas, !data.last)
     }
 
-    fun mangaDetailsRequest(manga: SManga) = apiClient.detailsRequest(manga.url)
+    fun mangaDetailsRequest(manga: SManga, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default) =
+        apiClient.detailsRequest(manga.url, cachePolicy)
 
     fun mangaDetailsParse(response: okhttp3.Response): SManga =
         response.use {
@@ -93,8 +108,8 @@ class KomgaRepository(
             }
         }
 
-    fun chapterListRequest(manga: SManga) =
-        apiClient.chapterListRequest(manga.url, apiClient.isBook(manga.url))
+    fun chapterListRequest(manga: SManga, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default) =
+        apiClient.chapterListRequest(manga.url, apiClient.isBook(manga.url), cachePolicy)
 
     fun chapterListParse(response: okhttp3.Response, chapterNameTemplate: String): List<SChapter> =
         response.use {
@@ -114,7 +129,8 @@ class KomgaRepository(
                 .sortedByDescending { chapter -> chapter.chapter_number }
         }
 
-    fun pageListRequest(chapter: SChapter) = apiClient.pageListRequest(chapter.url)
+    fun pageListRequest(chapter: SChapter, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default) =
+        apiClient.pageListRequest(chapter.url, cachePolicy)
 
     fun pageListParse(response: okhttp3.Response): List<Page> =
         response.use {
@@ -125,16 +141,17 @@ class KomgaRepository(
             }
         }
 
-    suspend fun fetchFilterOptions(): KomgaFilterOptions = withIOContext {
-        val libraryOrders = apiClient.getLibraryOrders()
+    suspend fun fetchFilterOptions(forceRefresh: Boolean = false): KomgaFilterOptions = withIOContext {
+        val cachePolicy = if (forceRefresh) KomgaCachePolicy.NetworkFirst else KomgaCachePolicy.Default
+        val libraryOrders = apiClient.getLibraryOrders(cachePolicy)
         KomgaFilterOptions(
-            libraries = apiClient.getLibraries()
+            libraries = apiClient.getLibraries(cachePolicy)
                 .sortedBy { libraryOrders[it.id] ?: Int.MAX_VALUE },
-            collections = apiClient.getCollections(),
-            genres = apiClient.getGenres(),
-            tags = apiClient.getTags(),
-            publishers = apiClient.getPublishers(),
-            authors = apiClient.getAuthors(),
+            collections = apiClient.getCollections(cachePolicy),
+            genres = apiClient.getGenres(cachePolicy),
+            tags = apiClient.getTags(cachePolicy),
+            publishers = apiClient.getPublishers(cachePolicy),
+            authors = apiClient.getAuthors(cachePolicy),
         )
     }
 

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -92,11 +92,11 @@ class KomgaLibraryScreenModel(
             komgaSettingsChangeListener = source.registerServerSettingsChangeListener {
                 screenModelScope.launchIO {
                     source.invalidateBrowseCache()
-                    reloadKomgaState(source, showRefreshing = true, resetSelection = true)
+                    reloadKomgaState(source, showRefreshing = true, resetSelection = true, forceRefresh = true)
                 }
             }
             screenModelScope.launchIO {
-                reloadKomgaState(source, showRefreshing = false, resetSelection = true)
+                reloadKomgaState(source, showRefreshing = false, resetSelection = true, forceRefresh = true)
             }
         }
 
@@ -256,7 +256,12 @@ class KomgaLibraryScreenModel(
         if (komgaSource != null) {
             screenModelScope.launchIO {
                 komgaSource.invalidateBrowseCache()
-                reloadKomgaState(komgaSource, showRefreshing = true, resetSelection = false)
+                reloadKomgaState(
+                    komgaSource = komgaSource,
+                    showRefreshing = true,
+                    resetSelection = false,
+                    forceRefresh = true,
+                )
             }
         } else {
             refreshSignal.value += 1
@@ -274,12 +279,15 @@ class KomgaLibraryScreenModel(
                 toolbarQuery = null,
             )
         }
+        komgaSource.refreshBrowseRequests()
+        refreshSignal.value += 1
     }
 
     private suspend fun reloadKomgaState(
         komgaSource: KomgaSource,
         showRefreshing: Boolean,
         resetSelection: Boolean,
+        forceRefresh: Boolean,
     ) {
         if (showRefreshing) {
             mutableState.update { it.copy(isRefreshing = true) }
@@ -301,7 +309,7 @@ class KomgaLibraryScreenModel(
         }
 
         try {
-            val libraries = komgaSource.getBrowseLibraries()
+            val libraries = komgaSource.getBrowseLibraries(forceRefresh)
             val selectedLibraryId = if (resetSelection) {
                 null
             } else {
@@ -318,6 +326,9 @@ class KomgaLibraryScreenModel(
                     selectedKomgaLibraryId = selectedLibraryId,
                     toolbarQuery = null,
                 )
+            }
+            if (forceRefresh) {
+                komgaSource.refreshBrowseRequests()
             }
         } catch (e: Exception) {
             if (resetSelection) {

--- a/app/src/main/java/koharia/source/komga/KomgaCachePolicy.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaCachePolicy.kt
@@ -1,0 +1,20 @@
+package koharia.source.komga
+
+import okhttp3.CacheControl
+import okhttp3.Request
+
+enum class KomgaCachePolicy {
+    Default,
+    NetworkFirst,
+}
+
+internal fun Request.Builder.komgaCachePolicy(policy: KomgaCachePolicy): Request.Builder {
+    tag(KomgaCachePolicy::class.java, policy)
+    if (policy == KomgaCachePolicy.NetworkFirst) {
+        cacheControl(CacheControl.FORCE_NETWORK)
+    }
+    return this
+}
+
+internal val Request.komgaCachePolicy: KomgaCachePolicy
+    get() = tag(KomgaCachePolicy::class.java) ?: KomgaCachePolicy.Default

--- a/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
@@ -9,7 +9,6 @@ import okhttp3.ResponseBody.Companion.toResponseBody
 import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
 import java.io.File
 import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
 
 internal class KomgaMetadataCacheStore(
     context: Context,
@@ -66,12 +65,7 @@ internal class KomgaMetadataCacheStore(
                 return null
             }
 
-            val savedAt = metadata[2].toLongOrNull() ?: return null
-            if (System.currentTimeMillis() - savedAt > MAX_STALE_MILLIS) {
-                bodyFile.delete()
-                metaFile.delete()
-                return null
-            }
+            metadata[2].toLongOrNull() ?: return null
 
             CacheEntry(
                 contentType = metadata[1].ifBlank { null }?.toMediaTypeOrNull(),
@@ -124,8 +118,6 @@ internal class KomgaMetadataCacheStore(
     )
 
     companion object {
-        private val MAX_STALE_MILLIS = TimeUnit.DAYS.toMillis(7)
-
         fun isEligibleUrl(url: String): Boolean {
             if (!url.contains("/api/v1/")) return false
             if (url.endsWith("/file")) return false

--- a/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
@@ -18,7 +18,6 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
         val isOnline = context.isOnline()
-        val cachePolicy = originalRequest.komgaCachePolicy
         val request = if (isOnline) {
             originalRequest
         } else {
@@ -59,7 +58,7 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
                 if (response.code >= 500) {
                     response.close()
                     retryCount++
-                    response = if (retryCount >= maxRetries && cachePolicy == KomgaCachePolicy.NetworkFirst) {
+                    response = if (retryCount >= maxRetries) {
                         metadataCacheStore.load(originalRequest)
                     } else {
                         null

--- a/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
@@ -16,22 +16,21 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
     private val metadataCacheStore = KomgaMetadataCacheStore(context.applicationContext)
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        var request = chain.request()
+        val originalRequest = chain.request()
         val isOnline = context.isOnline()
-
-        // 如果没有网络，强制从缓存中读取，允许读取最多 7 天的旧缓存
-        if (!isOnline) {
-            logcat(LogPriority.INFO) { "无网络连接，强制使用本地缓存: ${request.url}" }
-            val cacheControl = CacheControl.Builder()
-                .onlyIfCached()
-                .maxStale(7, TimeUnit.DAYS)
-                .build()
-            request = request.newBuilder()
-                .cacheControl(cacheControl)
-                .build()
+        val cachePolicy = originalRequest.komgaCachePolicy
+        val request = if (isOnline) {
+            originalRequest
         } else {
-            // 如果有网络，但也尝试使用 ETag/Last-Modified 进行缓存验证
-            // OkHttp 会自动处理，这里可以针对 Komga API 进行策略优化
+            logcat(LogPriority.INFO) { "No network, forcing Komga cache read: ${originalRequest.url}" }
+            originalRequest.newBuilder()
+                .cacheControl(
+                    CacheControl.Builder()
+                        .onlyIfCached()
+                        .maxStale(Int.MAX_VALUE, TimeUnit.SECONDS)
+                        .build(),
+                )
+                .build()
         }
 
         var response: Response? = null
@@ -39,12 +38,11 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
         var retryCount = 0
         val maxRetries = 3
 
-        // 失败重试机制（仅在有网络时进行重试）
         while (retryCount < maxRetries) {
             try {
                 response = chain.proceed(request)
                 if (!isOnline && response.code == 504) {
-                    val fallbackResponse = metadataCacheStore.load(request)
+                    val fallbackResponse = metadataCacheStore.load(originalRequest)
                     if (fallbackResponse != null) {
                         response.close()
                         response = fallbackResponse
@@ -57,40 +55,48 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
                 }
                 if (response.isSuccessful || !isOnline) {
                     break
-                } else if (response.code >= 500) {
-                    // 服务端错误，可以重试
+                }
+                if (response.code >= 500) {
                     response.close()
                     retryCount++
+                    response = if (retryCount >= maxRetries && cachePolicy == KomgaCachePolicy.NetworkFirst) {
+                        metadataCacheStore.load(originalRequest)
+                    } else {
+                        null
+                    }
+                    if (response != null) break
                     continue
-                } else {
-                    break
                 }
+                break
             } catch (e: IOException) {
                 exception = e
                 if (!isOnline) {
-                    break // 无网络不重试
+                    break
                 }
                 retryCount++
                 if (retryCount >= maxRetries) {
-                    // 网络请求全部失败，尝试从本地缓存降级读取
-                    logcat(LogPriority.INFO) { "网络请求失败，尝试降级读取本地缓存: ${request.url}" }
-                    val fallbackCacheControl = CacheControl.Builder()
-                        .onlyIfCached()
-                        .maxStale(7, TimeUnit.DAYS)
-                        .build()
+                    logcat(LogPriority.INFO) { "Komga network request failed, trying local cache: ${request.url}" }
+                    response = metadataCacheStore.load(originalRequest)
+                    if (response != null) break
+
                     val fallbackRequest = request.newBuilder()
-                        .cacheControl(fallbackCacheControl)
+                        .cacheControl(
+                            CacheControl.Builder()
+                                .onlyIfCached()
+                                .maxStale(Int.MAX_VALUE, TimeUnit.SECONDS)
+                                .build(),
+                        )
                         .build()
                     try {
                         response = chain.proceed(fallbackRequest)
-                    } catch (fallbackEx: IOException) {
-                        // 忽略降级失败，保留原始异常
+                    } catch (_: IOException) {
+                        // Keep the original exception below.
                     }
                     break
                 }
                 try {
-                    Thread.sleep(1000L * retryCount) // 简单退避
-                } catch (ie: InterruptedException) {
+                    Thread.sleep(1000L * retryCount)
+                } catch (_: InterruptedException) {
                     Thread.currentThread().interrupt()
                 }
             }
@@ -100,7 +106,7 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
             if (!isOnline) {
                 throw IOException(context.stringResource(MR.strings.exception_offline))
             }
-            throw exception ?: IOException("请求失败，已重试 $maxRetries 次。")
+            throw exception ?: IOException("Request failed after $maxRetries retries")
         }
 
         return response

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -38,6 +38,7 @@ import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.security.MessageDigest
 import java.util.Locale
+import java.util.concurrent.atomic.AtomicLong
 
 class KomgaSource :
     HttpSource(),
@@ -77,6 +78,7 @@ class KomgaSource :
 
     private val repository: KomgaRepository
         get() = KomgaRepository(baseUrl, apiClient)
+    private val forceBrowseRequestsUntil = AtomicLong(0L)
 
     fun currentHeaders(): Headers = headersBuilder().build()
 
@@ -104,33 +106,35 @@ class KomgaSource :
             .dns(Dns.SYSTEM)
             .build()
 
-    override fun popularMangaRequest(page: Int): Request = repository.popularMangaRequest(page, defaultLibraries)
+    override fun popularMangaRequest(page: Int): Request =
+        repository.popularMangaRequest(page, defaultLibraries, consumeBrowseCachePolicy())
 
     override fun popularMangaParse(response: Response) = repository.parseMangasPage(response)
 
-    override fun latestUpdatesRequest(page: Int): Request = repository.latestUpdatesRequest(page, defaultLibraries)
+    override fun latestUpdatesRequest(page: Int): Request =
+        repository.latestUpdatesRequest(page, defaultLibraries, consumeBrowseCachePolicy())
 
     override fun latestUpdatesParse(response: Response) = repository.parseMangasPage(response)
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request =
-        repository.searchMangaRequest(page, query, filters, defaultLibraries)
+        repository.searchMangaRequest(page, query, filters, defaultLibraries, consumeBrowseCachePolicy())
 
     override fun searchMangaParse(response: Response) = repository.parseMangasPage(response)
 
     override fun getMangaUrl(manga: eu.kanade.tachiyomi.source.model.SManga): String = manga.url.replace("/api/v1", "")
 
     override fun mangaDetailsRequest(manga: eu.kanade.tachiyomi.source.model.SManga): Request =
-        repository.mangaDetailsRequest(manga)
+        repository.mangaDetailsRequest(manga, KomgaCachePolicy.NetworkFirst)
 
     override fun mangaDetailsParse(response: Response) = repository.mangaDetailsParse(response)
 
     override fun chapterListRequest(manga: eu.kanade.tachiyomi.source.model.SManga): Request =
-        repository.chapterListRequest(manga)
+        repository.chapterListRequest(manga, KomgaCachePolicy.NetworkFirst)
 
     override fun chapterListParse(response: Response) = repository.chapterListParse(response, chapterNameTemplate)
 
     override fun pageListRequest(chapter: eu.kanade.tachiyomi.source.model.SChapter): Request =
-        repository.pageListRequest(chapter)
+        repository.pageListRequest(chapter, KomgaCachePolicy.NetworkFirst)
 
     override fun pageListParse(response: Response) = repository.pageListParse(response)
 
@@ -258,14 +262,14 @@ class KomgaSource :
         )
     }
 
-    suspend fun getBrowseLibraries(): List<LibraryDto> {
+    suspend fun getBrowseLibraries(forceRefresh: Boolean = false): List<LibraryDto> {
         if (!hasValidBaseUrl()) {
             fetchFilterStatus = FetchFilterStatus.NOT_FETCHED
             return emptyList()
         }
 
         return try {
-            val options = repository.fetchFilterOptions()
+            val options = repository.fetchFilterOptions(forceRefresh)
             libraries = options.libraries
             collections = options.collections
             genres = options.genres
@@ -290,6 +294,10 @@ class KomgaSource :
         authors = emptyMap()
         fetchFilterStatus = FetchFilterStatus.NOT_FETCHED
         fetchFiltersAttempts = 0
+    }
+
+    fun refreshBrowseRequests() {
+        forceBrowseRequestsUntil.set(System.currentTimeMillis() + BROWSE_REFRESH_WINDOW_MILLIS)
     }
 
     fun registerServerSettingsChangeListener(
@@ -374,6 +382,14 @@ class KomgaSource :
         }
     }
 
+    private fun consumeBrowseCachePolicy(): KomgaCachePolicy {
+        return if (System.currentTimeMillis() <= forceBrowseRequestsUntil.get()) {
+            KomgaCachePolicy.NetworkFirst
+        } else {
+            KomgaCachePolicy.Default
+        }
+    }
+
     override fun chapterPageParse(response: Response) = throw UnsupportedOperationException()
 
     companion object {
@@ -383,6 +399,7 @@ class KomgaSource :
         const val TYPE_SERIES = "Series"
         const val TYPE_READ_LISTS = "Read lists"
         const val TYPE_BOOKS = "Books"
+        private const val BROWSE_REFRESH_WINDOW_MILLIS = 30_000L
 
         private val SERVER_SETTING_KEYS = setOf(
             PREF_ADDRESS,

--- a/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/download/service/DownloadPreferences.kt
@@ -18,6 +18,11 @@ class DownloadPreferences(
 
     val autoDownloadWhileReading: Preference<Int> = preferenceStore.getInt("auto_download_while_reading", 0)
 
+    val cacheCurrentChapterWhileReading: Preference<Boolean> = preferenceStore.getBoolean(
+        "cache_current_chapter_while_reading",
+        false,
+    )
+
     val removeAfterReadSlots: Preference<Int> = preferenceStore.getInt("remove_after_read_slots", -1)
 
     val removeAfterMarkedAsRead: Preference<Boolean> = preferenceStore.getBoolean(

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -556,6 +556,8 @@
     <string name="pref_download_concurrent_sources">Concurrent source downloads</string>
     <string name="pref_download_concurrent_pages">Concurrent page downloads</string>
     <string name="pref_download_concurrent_pages_summary">Pages downloaded simultaneously per source</string>
+    <string name="pref_cache_current_chapter_while_reading">Cache current chapter while reading</string>
+    <string name="pref_cache_current_chapter_while_reading_summary">Saves the current chapter for offline reading and marks it cached when complete</string>
 
     <!-- Tracking section -->
     <string name="tracking_guide">Tracking guide</string>
@@ -614,11 +616,11 @@
     <string name="pref_storage_usage">Storage usage</string>
     <string name="available_disk_space_info">Available: %1$s / Total: %2$s</string>
     <string name="pref_clear_chapter_cache">Clear chapter cache</string>
-    <string name="pref_manage_local_cache">Clear local cache</string>
+    <string name="pref_manage_local_cache">Clear temporary cache</string>
     <string name="pref_manage_local_cache_removed_manga">Deleted manga cache</string>
     <string name="pref_manage_local_cache_chapter">Chapter cache</string>
     <string name="pref_manage_local_cache_cover">Cover cache</string>
-    <string name="pref_manage_local_cache_temporary">All local temporary cache</string>
+    <string name="pref_manage_local_cache_temporary">All temporary cache (keeps offline chapters)</string>
     <string name="used_cache">Used: %1$s</string>
     <string name="cache_deleted">Cache cleared, %1$d files deleted</string>
     <string name="cache_delete_error">Error occurred while clearing</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -189,11 +189,11 @@
     <string name="restoring_backup">正在还原备份</string>
     <string name="creating_backup">正在创建备份</string>
     <string name="pref_clear_chapter_cache">清除章节缓存</string>
-    <string name="pref_manage_local_cache">清理本地缓存</string>
+    <string name="pref_manage_local_cache">清理临时缓存</string>
     <string name="pref_manage_local_cache_removed_manga">已被删除漫画缓存</string>
     <string name="pref_manage_local_cache_chapter">章节缓存</string>
     <string name="pref_manage_local_cache_cover">封面缓存</string>
-    <string name="pref_manage_local_cache_temporary">全部本地临时缓存</string>
+    <string name="pref_manage_local_cache_temporary">全部临时缓存（保留离线章节）</string>
     <string name="used_cache">已使用：%1$s</string>
     <string name="cache_deleted">已清除缓存，删除了 %1$d 个文件</string>
     <string name="cache_delete_error">清除时发生错误</string>
@@ -687,6 +687,8 @@
     <string name="download_ahead">预先下载</string>
     <string name="auto_download_while_reading">阅读时自动下载</string>
     <string name="download_ahead_info">要求当前章节和下一章节都已下载。</string>
+    <string name="pref_cache_current_chapter_while_reading">阅读时缓存当前章节</string>
+    <string name="pref_cache_current_chapter_while_reading_summary">阅读时保存当前章节用于离线阅读，完成后标记为已缓存</string>
     <string name="are_you_sure">你确定吗？</string>
     <string name="multi_lang">多语言</string>
     <string name="updates_last_update_info">书架更新时间：%s</string>


### PR DESCRIPTION
Add a setting to cache the current chapter while reading so completed page caches are packed and indexed for offline access.

Make Komga metadata refresh network-first with persistent local fallback, and clarify temporary cache cleanup wording.
