### PR TITLE
修复 Komga 阅读进度同步

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         applicationId = "app.koharia"
 
         versionCode = 2
-        versionName = "0.1.6"
+        versionName = "0.1.7"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -144,6 +144,7 @@ class KomgaApi(
                     .content
                     .map { book ->
                         SeriesBookProgress(
+                            seriesUrl = url,
                             url = "$baseUrl/api/v1/books/${book.id}",
                             readProgress = book.readProgress,
                         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -33,8 +33,10 @@ class KomgaProgressSyncService(
         if (!manga.isKomgaSeries()) return
 
         runCatching {
+            val remoteBooks = trackerManager.komga.api.getSeriesBookProgress(manga.url)
             applyRemoteProgress(
-                remoteBooks = trackerManager.komga.api.getSeriesBookProgress(manga.url),
+                syncName = "series sync",
+                remoteBooks = remoteBooks,
                 localMangaBySeriesUrl = mapOf(manga.url to manga),
             )
         }.onFailure { error ->
@@ -48,16 +50,21 @@ class KomgaProgressSyncService(
             if (remoteBooks.isEmpty()) {
                 return
             }
-
-            val localMangaBySeriesUrl = remoteBooks
+            val remoteSeriesUrls = remoteBooks
                 .mapNotNull { it.seriesUrl }
                 .distinct()
+
+            val localMangaBySeriesUrl = remoteSeriesUrls
                 .mapNotNull { seriesUrl ->
                     mangaRepository.getMangaByUrlAndSourceId(seriesUrl, KomgaSource.ID)?.let { seriesUrl to it }
                 }
                 .toMap()
 
-            applyRemoteProgress(remoteBooks, localMangaBySeriesUrl)
+            applyRemoteProgress(
+                syncName = "history sync",
+                remoteBooks = remoteBooks,
+                localMangaBySeriesUrl = localMangaBySeriesUrl,
+            )
         }.onFailure { error ->
             logcat(LogPriority.WARN, error) { "Failed to sync Komga continue reading from server" }
         }
@@ -90,12 +97,15 @@ class KomgaProgressSyncService(
     }
 
     private suspend fun applyRemoteProgress(
+        syncName: String,
         remoteBooks: List<KomgaApi.SeriesBookProgress>,
         localMangaBySeriesUrl: Map<String, Manga>,
     ) {
         val localChaptersByMangaId = mutableMapOf<Long, Map<String, Chapter>>()
         val historyUpdates = mutableListOf<HistoryUpdate>()
         val chapterUpdates = mutableListOf<ChapterUpdate>()
+        val missingSeriesSamples = mutableListOf<String>()
+        val missingChapterSamples = mutableListOf<String>()
         var matchedSeriesCount = 0
         var matchedChapterCount = 0
         var missingSeriesCount = 0
@@ -107,11 +117,13 @@ class KomgaProgressSyncService(
             val seriesUrl = remote.seriesUrl
             if (seriesUrl == null) {
                 missingSeriesCount++
+                missingSeriesSamples.addSample(remote.url)
                 return@forEach
             }
             val localManga = localMangaBySeriesUrl[seriesUrl]
             if (localManga == null) {
                 missingSeriesCount++
+                missingSeriesSamples.addSample(seriesUrl)
                 return@forEach
             }
             matchedSeriesCount++
@@ -121,6 +133,7 @@ class KomgaProgressSyncService(
             val localChapter = localChapters[remote.url]
             if (localChapter == null) {
                 missingChapterCount++
+                missingChapterSamples.addSample(remote.url)
                 return@forEach
             }
             matchedChapterCount++
@@ -155,12 +168,22 @@ class KomgaProgressSyncService(
             refreshedChapterSets > 0
         ) {
             logcat(LogPriority.INFO) {
-                "Komga history sync result: remoteBooks=${remoteBooks.size}, matchedSeries=$matchedSeriesCount, matchedChapters=$matchedChapterCount, missingSeries=$missingSeriesCount, missingChapters=$missingChapterCount, refreshedChapterSets=$refreshedChapterSets, chapterUpdates=${chapterUpdates.size}, historyUpdates=${historyUpdates.size}"
+                "Komga $syncName result: remoteBooks=${remoteBooks.size}, matchedSeries=$matchedSeriesCount, matchedChapters=$matchedChapterCount, missingSeries=$missingSeriesCount, missingChapters=$missingChapterCount, refreshedChapterSets=$refreshedChapterSets, chapterUpdates=${chapterUpdates.size}, historyUpdates=${historyUpdates.size}"
             }
         }
-        if (historyUpdates.isEmpty()) {
+        if (missingSeriesSamples.isNotEmpty()) {
+            logcat(LogPriority.INFO) {
+                "Komga $syncName: missing series samples=${missingSeriesSamples.joinToString()}"
+            }
+        }
+        if (missingChapterSamples.isNotEmpty()) {
+            logcat(LogPriority.INFO) {
+                "Komga $syncName: missing chapter samples=${missingChapterSamples.joinToString()}"
+            }
+        }
+        if (matchedChapterCount > 0 && historyUpdates.isEmpty()) {
             logcat(LogPriority.WARN) {
-                "Komga history sync: remote in-progress books were returned, but no local history rows were written"
+                "Komga $syncName: remote books were returned, but no local history rows were written"
             }
         }
     }
@@ -202,4 +225,10 @@ class KomgaProgressSyncService(
         val chapters: Map<String, Chapter>,
         val refreshed: Boolean,
     )
+}
+
+private fun MutableList<String>.addSample(value: String) {
+    if (size < 3) {
+        add(value)
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -253,7 +253,7 @@ class MangaScreenModel(
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
 
-            syncKomgaProgressInBackground(manga, source)
+            syncKomgaProgressInBackground(source)
         }
     }
 
@@ -266,16 +266,21 @@ class MangaScreenModel(
             )
             fetchFromSourceTasks.awaitAll()
             updateSuccessState { it.copy(isRefreshingData = false) }
-            successState?.let { syncKomgaProgressInBackground(it.manga, it.source) }
+            successState?.let { syncKomgaProgressInBackground(it.source) }
         }
     }
 
-    private fun syncKomgaProgressInBackground(manga: Manga, source: Source) {
+    private fun syncKomgaProgressInBackground(source: Source) {
         if (source.id != KomgaSource.ID) return
 
         screenModelScope.launchIO {
-            addTracks.bindEnhancedTrackers(manga, source)
-            komgaProgressSyncService.syncFromServer(manga)
+            runCatching {
+                val latestManga = getMangaAndChapters.awaitManga(mangaId)
+                addTracks.bindEnhancedTrackers(latestManga, source)
+                komgaProgressSyncService.syncFromServer(latestManga)
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) { "Failed to sync Komga progress in background for mangaId=$mangaId" }
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -250,13 +250,10 @@ class MangaScreenModel(
                 fetchFromSourceTasks.awaitAll()
             }
 
-            if (source.id == KomgaSource.ID) {
-                addTracks.bindEnhancedTrackers(manga, source)
-                komgaProgressSyncService.syncFromServer(manga)
-            }
-
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
+
+            syncKomgaProgressInBackground(manga, source)
         }
     }
 
@@ -269,6 +266,16 @@ class MangaScreenModel(
             )
             fetchFromSourceTasks.awaitAll()
             updateSuccessState { it.copy(isRefreshingData = false) }
+            successState?.let { syncKomgaProgressInBackground(it.manga, it.source) }
+        }
+    }
+
+    private fun syncKomgaProgressInBackground(manga: Manga, source: Source) {
+        if (source.id != KomgaSource.ID) return
+
+        screenModelScope.launchIO {
+            addTracks.bindEnhancedTrackers(manga, source)
+            komgaProgressSyncService.syncFromServer(manga)
         }
     }
 
@@ -587,10 +594,6 @@ class MangaScreenModel(
 
                 if (manualFetch) {
                     downloadNewChapters(newChapters)
-                }
-
-                if (state.source.id == KomgaSource.ID) {
-                    komgaProgressSyncService.syncFromServer(state.manga)
                 }
             }
         } catch (e: Throwable) {

--- a/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
@@ -133,6 +133,7 @@ class KomgaSseClient(
         if (type == null) return
         when (type) {
             "ReadProgressChanged", "ReadProgressDeleted" -> {
+                logcat(LogPriority.DEBUG) { "Komga SSE: received $type, scheduling history sync" }
                 appScope?.launch(Dispatchers.IO) {
                     komgaProgressSyncService.value.syncHistoryFromServer()
                 }


### PR DESCRIPTION
修复作品详情页同步远端阅读进度时缺少 seriesUrl 导致本地章节无法匹配的问题。

将 Komga 进度同步移到详情页首屏加载完成后的后台任务，减少进入作品详情页时的卡顿。

收敛临时诊断日志，仅保留同步异常、缺失样本和有效汇总日志，并将版本号更新为 0.1.7。