### PR TITLE
为章节列表添加封面显示模式

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -31,6 +31,7 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.manga.model.downloadedFilter
 import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
+import koharia.source.komga.KomgaSource
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.manga.model.Manga
@@ -61,6 +62,7 @@ fun ChapterSettingsDialog(
     onResetToDefault: () -> Unit,
 ) {
     var showSetAsDefaultDialog by rememberSaveable { mutableStateOf(false) }
+    val supportsChapterCoverDisplay = manga?.source == KomgaSource.ID
     if (showSetAsDefaultDialog) {
         SetAsDefaultDialog(
             onDismissRequest = { showSetAsDefaultDialog = false },
@@ -124,6 +126,7 @@ fun ChapterSettingsDialog(
                 2 -> {
                     DisplayPage(
                         displayMode = manga?.displayMode ?: 0,
+                        supportsChapterCoverDisplay = supportsChapterCoverDisplay,
                         chapterCoverDisplayMode = manga?.chapterCoverDisplayMode ?: 0,
                         onDisplayModeSelected = onDisplayModeChanged,
                         onChapterCoverDisplayModeSelected = onChapterCoverDisplayModeChanged,
@@ -221,26 +224,29 @@ private fun ColumnScope.SortPage(
 @Composable
 private fun ColumnScope.DisplayPage(
     displayMode: Long,
+    supportsChapterCoverDisplay: Boolean,
     chapterCoverDisplayMode: Long,
     onDisplayModeSelected: (Long) -> Unit,
     onChapterCoverDisplayModeSelected: (Long) -> Unit,
 ) {
-    Text(
-        text = stringResource(MR.strings.chapter_cover_display_mode),
-        modifier = Modifier.padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary,
-    )
-    listOf(
-        MR.strings.action_display_chapter_text_only to Manga.CHAPTER_COVER_DISPLAY_TEXT,
-        MR.strings.action_display_chapter_cover_only to Manga.CHAPTER_COVER_DISPLAY_COVER,
-        MR.strings.action_display_chapter_cover_and_title to Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE,
-    ).map { (titleRes, mode) ->
-        RadioItem(
-            label = stringResource(titleRes),
-            selected = chapterCoverDisplayMode == mode,
-            onClick = { onChapterCoverDisplayModeSelected(mode) },
+    if (supportsChapterCoverDisplay) {
+        Text(
+            text = stringResource(MR.strings.chapter_cover_display_mode),
+            modifier = Modifier.padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
         )
+        listOf(
+            MR.strings.action_display_chapter_text_only to Manga.CHAPTER_COVER_DISPLAY_TEXT,
+            MR.strings.action_display_chapter_cover_only to Manga.CHAPTER_COVER_DISPLAY_COVER,
+            MR.strings.action_display_chapter_cover_and_title to Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE,
+        ).map { (titleRes, mode) ->
+            RadioItem(
+                label = stringResource(titleRes),
+                selected = chapterCoverDisplayMode == mode,
+                onClick = { onChapterCoverDisplayModeSelected(mode) },
+            )
+        }
     }
 
     Text(

--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -56,6 +56,7 @@ fun ChapterSettingsDialog(
     onScanlatorFilterClicked: (() -> Unit),
     onSortModeChanged: (Long) -> Unit,
     onDisplayModeChanged: (Long) -> Unit,
+    onChapterCoverDisplayModeChanged: (Long) -> Unit,
     onSetAsDefault: (applyToExistingManga: Boolean) -> Unit,
     onResetToDefault: () -> Unit,
 ) {
@@ -123,7 +124,9 @@ fun ChapterSettingsDialog(
                 2 -> {
                     DisplayPage(
                         displayMode = manga?.displayMode ?: 0,
-                        onItemSelected = onDisplayModeChanged,
+                        chapterCoverDisplayMode = manga?.chapterCoverDisplayMode ?: 0,
+                        onDisplayModeSelected = onDisplayModeChanged,
+                        onChapterCoverDisplayModeSelected = onChapterCoverDisplayModeChanged,
                     )
                 }
             }
@@ -218,8 +221,34 @@ private fun ColumnScope.SortPage(
 @Composable
 private fun ColumnScope.DisplayPage(
     displayMode: Long,
-    onItemSelected: (Long) -> Unit,
+    chapterCoverDisplayMode: Long,
+    onDisplayModeSelected: (Long) -> Unit,
+    onChapterCoverDisplayModeSelected: (Long) -> Unit,
 ) {
+    Text(
+        text = stringResource(MR.strings.chapter_cover_display_mode),
+        modifier = Modifier.padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+    )
+    listOf(
+        MR.strings.action_display_chapter_text_only to Manga.CHAPTER_COVER_DISPLAY_TEXT,
+        MR.strings.action_display_chapter_cover_only to Manga.CHAPTER_COVER_DISPLAY_COVER,
+        MR.strings.action_display_chapter_cover_and_title to Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE,
+    ).map { (titleRes, mode) ->
+        RadioItem(
+            label = stringResource(titleRes),
+            selected = chapterCoverDisplayMode == mode,
+            onClick = { onChapterCoverDisplayModeSelected(mode) },
+        )
+    }
+
+    Text(
+        text = stringResource(MR.strings.chapter_title_display_mode),
+        modifier = Modifier.padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+    )
     listOf(
         MR.strings.show_title to Manga.CHAPTER_DISPLAY_NAME,
         MR.strings.show_chapter_number to Manga.CHAPTER_DISPLAY_NUMBER,
@@ -227,7 +256,7 @@ private fun ColumnScope.DisplayPage(
         RadioItem(
             label = stringResource(titleRes),
             selected = displayMode == mode,
-            onClick = { onItemSelected(mode) },
+            onClick = { onDisplayModeSelected(mode) },
         )
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -2,6 +2,7 @@ package eu.kanade.presentation.manga
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -17,6 +18,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
@@ -43,10 +48,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
 import eu.kanade.presentation.components.relativeDateText
+import eu.kanade.presentation.library.components.CommonMangaItemDefaults
+import eu.kanade.presentation.library.components.MangaCompactGridItem
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.ChapterHeader
 import eu.kanade.presentation.manga.components.ExpandableMangaDescription
@@ -69,12 +77,15 @@ import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.FastScrollLazyVerticalGrid
 import tachiyomi.presentation.core.components.TwoPanelBox
 import tachiyomi.presentation.core.components.VerticalFastScroller
 import tachiyomi.presentation.core.components.material.PullRefresh
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.shouldExpandFAB
+import androidx.compose.foundation.lazy.grid.items as gridItems
+import tachiyomi.domain.manga.model.MangaCover as MangaCoverModel
 @Composable
 fun MangaScreen(
     state: MangaScreenModel.State.Success,
@@ -82,6 +93,7 @@ fun MangaScreen(
     isTabletUi: Boolean,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
+    chapterCoverGridColumns: Int,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
@@ -135,6 +147,7 @@ fun MangaScreen(
             snackbarHostState = snackbarHostState,
             chapterSwipeStartAction = chapterSwipeStartAction,
             chapterSwipeEndAction = chapterSwipeEndAction,
+            chapterCoverGridColumns = chapterCoverGridColumns,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -169,6 +182,7 @@ fun MangaScreen(
             snackbarHostState = snackbarHostState,
             chapterSwipeStartAction = chapterSwipeStartAction,
             chapterSwipeEndAction = chapterSwipeEndAction,
+            chapterCoverGridColumns = chapterCoverGridColumns,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -206,6 +220,7 @@ private fun MangaScreenSmallImpl(
     snackbarHostState: SnackbarHostState,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
+    chapterCoverGridColumns: Int,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -248,6 +263,8 @@ private fun MangaScreenSmallImpl(
     onInvertSelection: () -> Unit,
 ) {
     val chapterListState = rememberLazyListState()
+    val chapterGridState = rememberLazyGridState()
+    val useChapterCoverGrid = state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
 
     val (chapters, listItem, isAnySelected) = remember(state) {
         Triple(
@@ -267,10 +284,22 @@ private fun MangaScreenSmallImpl(
                 chapters.count { it.selected }
             }
             val isFirstItemVisible by remember {
-                derivedStateOf { chapterListState.firstVisibleItemIndex == 0 }
+                derivedStateOf {
+                    if (useChapterCoverGrid) {
+                        chapterGridState.firstVisibleItemIndex == 0
+                    } else {
+                        chapterListState.firstVisibleItemIndex == 0
+                    }
+                }
             }
             val isFirstItemScrolled by remember {
-                derivedStateOf { chapterListState.firstVisibleItemScrollOffset > 0 }
+                derivedStateOf {
+                    if (useChapterCoverGrid) {
+                        chapterGridState.firstVisibleItemScrollOffset > 0
+                    } else {
+                        chapterListState.firstVisibleItemScrollOffset > 0
+                    }
+                }
             }
             val titleAlpha by animateFloatAsState(
                 if (!isFirstItemVisible) 1f else 0f,
@@ -331,7 +360,13 @@ private fun MangaScreenSmallImpl(
                 },
                 icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
                 onClick = onContinueReading,
-                expanded = chapterListState.shouldExpandFAB(),
+                expanded = if (useChapterCoverGrid) {
+                    chapterGridState.lastScrolledBackward ||
+                        !chapterGridState.canScrollForward ||
+                        !chapterGridState.canScrollBackward
+                } else {
+                    chapterListState.shouldExpandFAB()
+                },
                 modifier = Modifier.animateFloatingActionButton(
                     visible = isFABVisible,
                     alignment = Alignment.BottomEnd,
@@ -348,92 +383,90 @@ private fun MangaScreenSmallImpl(
             indicatorPadding = PaddingValues(top = topPadding),
         ) {
             val layoutDirection = LocalLayoutDirection.current
-            VerticalFastScroller(
-                listState = chapterListState,
-                topContentPadding = topPadding,
-                endContentPadding = contentPadding.calculateEndPadding(layoutDirection),
-            ) {
-                LazyColumn(
+            if (useChapterCoverGrid) {
+                FastScrollLazyVerticalGrid(
+                    columns = GridCells.Fixed(chapterCoverGridColumns.coerceIn(2, 6)),
                     modifier = Modifier.fillMaxHeight(),
-                    state = chapterListState,
+                    state = chapterGridState,
                     contentPadding = PaddingValues(
-                        start = contentPadding.calculateStartPadding(layoutDirection),
-                        end = contentPadding.calculateEndPadding(layoutDirection),
+                        start = contentPadding.calculateStartPadding(layoutDirection) + 12.dp,
+                        end = contentPadding.calculateEndPadding(layoutDirection) + 12.dp,
                         bottom = contentPadding.calculateBottomPadding(),
                     ),
+                    topContentPadding = topPadding,
+                    endContentPadding = contentPadding.calculateEndPadding(layoutDirection),
+                    verticalArrangement = Arrangement.spacedBy(CommonMangaItemDefaults.GridVerticalSpacer),
+                    horizontalArrangement = Arrangement.spacedBy(CommonMangaItemDefaults.GridHorizontalSpacer),
                 ) {
-                    item(
-                        key = MangaScreenItem.INFO_BOX,
-                        contentType = MangaScreenItem.INFO_BOX,
+                    sharedMangaDetailHeaderGridItems(
+                        state = state,
+                        topPadding = topPadding,
+                        isAnySelected = isAnySelected,
+                        chapters = chapters,
+                        onAddToLibraryClicked = onAddToLibraryClicked,
+                        onWebViewClicked = onWebViewClicked,
+                        onWebViewLongClicked = onWebViewLongClicked,
+                        onEditCategoryClicked = onEditCategoryClicked,
+                        onSearch = onSearch,
+                        onCoverClicked = onCoverClicked,
+                        onTagSearch = onTagSearch,
+                        onCopyTagToClipboard = onCopyTagToClipboard,
+                        onEditNotesClicked = onEditNotesClicked,
+                        onFilterClicked = onFilterClicked,
+                    )
+                    sharedChapterGridItems(
+                        manga = state.manga,
+                        chapters = listItem,
+                        isAnyChapterSelected = chapters.fastAny { it.selected },
+                        onChapterClicked = onChapterClicked,
+                        onChapterSelected = onChapterSelected,
+                    )
+                }
+            } else {
+                VerticalFastScroller(
+                    listState = chapterListState,
+                    topContentPadding = topPadding,
+                    endContentPadding = contentPadding.calculateEndPadding(layoutDirection),
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxHeight(),
+                        state = chapterListState,
+                        contentPadding = PaddingValues(
+                            start = contentPadding.calculateStartPadding(layoutDirection),
+                            end = contentPadding.calculateEndPadding(layoutDirection),
+                            bottom = contentPadding.calculateBottomPadding(),
+                        ),
                     ) {
-                        MangaInfoBox(
-                            isTabletUi = false,
-                            appBarPadding = topPadding,
-                            manga = state.manga,
-                            sourceName = remember {
-                                if (state.source.id == KomgaSource.ID) "" else state.source.getNameForMangaInfo()
-                            },
-                            isStubSource = remember { state.source is StubSource },
-                            onCoverClick = onCoverClicked,
-                            doSearch = onSearch,
-                        )
-                    }
-
-                    item(
-                        key = MangaScreenItem.ACTION_ROW,
-                        contentType = MangaScreenItem.ACTION_ROW,
-                    ) {
-                        MangaActionRow(
-                            favorite = state.manga.favorite,
+                        sharedMangaDetailHeaderListItems(
+                            state = state,
+                            topPadding = topPadding,
+                            isAnySelected = isAnySelected,
+                            chapters = chapters,
                             onAddToLibraryClicked = onAddToLibraryClicked,
                             onWebViewClicked = onWebViewClicked,
                             onWebViewLongClicked = onWebViewLongClicked,
-                            onEditCategory = onEditCategoryClicked,
-                        )
-                    }
-
-                    item(
-                        key = MangaScreenItem.DESCRIPTION_WITH_TAG,
-                        contentType = MangaScreenItem.DESCRIPTION_WITH_TAG,
-                    ) {
-                        ExpandableMangaDescription(
-                            defaultExpandState = state.isFromSource,
-                            description = state.manga.description,
-                            tagsProvider = { state.manga.genre },
-                            notes = state.manga.notes,
+                            onEditCategoryClicked = onEditCategoryClicked,
+                            onSearch = onSearch,
+                            onCoverClicked = onCoverClicked,
                             onTagSearch = onTagSearch,
                             onCopyTagToClipboard = onCopyTagToClipboard,
-                            onEditNotes = onEditNotesClicked,
+                            onEditNotesClicked = onEditNotesClicked,
+                            onFilterClicked = onFilterClicked,
+                        )
+
+                        sharedChapterItems(
+                            manga = state.manga,
+                            chapters = listItem,
+                            isKomgaCacheMode = isKomgaCacheMode,
+                            isAnyChapterSelected = chapters.fastAny { it.selected },
+                            chapterSwipeStartAction = chapterSwipeStartAction,
+                            chapterSwipeEndAction = chapterSwipeEndAction,
+                            onChapterClicked = onChapterClicked,
+                            onDownloadChapter = onDownloadChapter,
+                            onChapterSelected = onChapterSelected,
+                            onChapterSwipe = onChapterSwipe,
                         )
                     }
-
-                    item(
-                        key = MangaScreenItem.CHAPTER_HEADER,
-                        contentType = MangaScreenItem.CHAPTER_HEADER,
-                    ) {
-                        val missingChapterCount = remember(chapters) {
-                            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
-                        }
-                        ChapterHeader(
-                            enabled = !isAnySelected,
-                            chapterCount = chapters.size,
-                            missingChapterCount = missingChapterCount,
-                            onClick = onFilterClicked,
-                        )
-                    }
-
-                    sharedChapterItems(
-                        manga = state.manga,
-                        chapters = listItem,
-                        isKomgaCacheMode = isKomgaCacheMode,
-                        isAnyChapterSelected = chapters.fastAny { it.selected },
-                        chapterSwipeStartAction = chapterSwipeStartAction,
-                        chapterSwipeEndAction = chapterSwipeEndAction,
-                        onChapterClicked = onChapterClicked,
-                        onDownloadChapter = onDownloadChapter,
-                        onChapterSelected = onChapterSelected,
-                        onChapterSwipe = onChapterSwipe,
-                    )
                 }
             }
         }
@@ -446,6 +479,7 @@ fun MangaScreenLargeImpl(
     snackbarHostState: SnackbarHostState,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
+    chapterCoverGridColumns: Int,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -489,6 +523,7 @@ fun MangaScreenLargeImpl(
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
+    val useChapterCoverGrid = state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
 
     val (chapters, listItem, isAnySelected) = remember(state) {
         Triple(
@@ -502,6 +537,7 @@ fun MangaScreenLargeImpl(
     var topBarHeight by remember { mutableIntStateOf(0) }
 
     val chapterListState = rememberLazyListState()
+    val chapterGridState = rememberLazyGridState()
 
     BackHandler(enabled = isAnySelected) {
         onAllChapterSelected(false)
@@ -571,7 +607,13 @@ fun MangaScreenLargeImpl(
                 },
                 icon = { Icon(imageVector = Icons.Filled.PlayArrow, contentDescription = null) },
                 onClick = onContinueReading,
-                expanded = chapterListState.shouldExpandFAB(),
+                expanded = if (useChapterCoverGrid) {
+                    chapterGridState.lastScrolledBackward ||
+                        !chapterGridState.canScrollForward ||
+                        !chapterGridState.canScrollBackward
+                } else {
+                    chapterListState.shouldExpandFAB()
+                },
                 modifier = Modifier.animateFloatingActionButton(
                     visible = isFABVisible,
                     alignment = Alignment.BottomEnd,
@@ -630,45 +672,66 @@ fun MangaScreenLargeImpl(
                     }
                 },
                 endContent = {
-                    VerticalFastScroller(
-                        listState = chapterListState,
-                        topContentPadding = contentPadding.calculateTopPadding(),
-                    ) {
-                        LazyColumn(
+                    if (useChapterCoverGrid) {
+                        FastScrollLazyVerticalGrid(
+                            columns = GridCells.Fixed(chapterCoverGridColumns.coerceIn(2, 6)),
                             modifier = Modifier.fillMaxHeight(),
-                            state = chapterListState,
+                            state = chapterGridState,
                             contentPadding = PaddingValues(
+                                start = 12.dp,
                                 top = contentPadding.calculateTopPadding(),
+                                end = 12.dp,
                                 bottom = contentPadding.calculateBottomPadding(),
                             ),
+                            topContentPadding = contentPadding.calculateTopPadding(),
+                            verticalArrangement = Arrangement.spacedBy(CommonMangaItemDefaults.GridVerticalSpacer),
+                            horizontalArrangement = Arrangement.spacedBy(CommonMangaItemDefaults.GridHorizontalSpacer),
                         ) {
-                            item(
-                                key = MangaScreenItem.CHAPTER_HEADER,
-                                contentType = MangaScreenItem.CHAPTER_HEADER,
-                            ) {
-                                val missingChapterCount = remember(chapters) {
-                                    chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
-                                }
-                                ChapterHeader(
-                                    enabled = !isAnySelected,
-                                    chapterCount = chapters.size,
-                                    missingChapterCount = missingChapterCount,
-                                    onClick = onFilterButtonClicked,
-                                )
-                            }
-
-                            sharedChapterItems(
+                            chapterHeaderGridItem(
+                                enabled = !isAnySelected,
+                                chapters = chapters,
+                                onClick = onFilterButtonClicked,
+                            )
+                            sharedChapterGridItems(
                                 manga = state.manga,
                                 chapters = listItem,
-                                isKomgaCacheMode = isKomgaCacheMode,
                                 isAnyChapterSelected = chapters.fastAny { it.selected },
-                                chapterSwipeStartAction = chapterSwipeStartAction,
-                                chapterSwipeEndAction = chapterSwipeEndAction,
                                 onChapterClicked = onChapterClicked,
-                                onDownloadChapter = onDownloadChapter,
                                 onChapterSelected = onChapterSelected,
-                                onChapterSwipe = onChapterSwipe,
                             )
+                        }
+                    } else {
+                        VerticalFastScroller(
+                            listState = chapterListState,
+                            topContentPadding = contentPadding.calculateTopPadding(),
+                        ) {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxHeight(),
+                                state = chapterListState,
+                                contentPadding = PaddingValues(
+                                    top = contentPadding.calculateTopPadding(),
+                                    bottom = contentPadding.calculateBottomPadding(),
+                                ),
+                            ) {
+                                chapterHeaderListItem(
+                                    enabled = !isAnySelected,
+                                    chapters = chapters,
+                                    onClick = onFilterButtonClicked,
+                                )
+
+                                sharedChapterItems(
+                                    manga = state.manga,
+                                    chapters = listItem,
+                                    isKomgaCacheMode = isKomgaCacheMode,
+                                    isAnyChapterSelected = chapters.fastAny { it.selected },
+                                    chapterSwipeStartAction = chapterSwipeStartAction,
+                                    chapterSwipeEndAction = chapterSwipeEndAction,
+                                    onChapterClicked = onChapterClicked,
+                                    onDownloadChapter = onDownloadChapter,
+                                    onChapterSelected = onChapterSelected,
+                                    onChapterSwipe = onChapterSwipe,
+                                )
+                            }
                         }
                     }
                 },
@@ -801,6 +864,265 @@ private fun LazyListScope.sharedChapterItems(
                 )
             }
         }
+    }
+}
+
+private fun LazyListScope.sharedMangaDetailHeaderListItems(
+    state: MangaScreenModel.State.Success,
+    topPadding: androidx.compose.ui.unit.Dp,
+    isAnySelected: Boolean,
+    chapters: List<ChapterList.Item>,
+    onAddToLibraryClicked: (() -> Unit)?,
+    onWebViewClicked: (() -> Unit)?,
+    onWebViewLongClicked: (() -> Unit)?,
+    onEditCategoryClicked: (() -> Unit)?,
+    onSearch: (query: String, global: Boolean) -> Unit,
+    onCoverClicked: () -> Unit,
+    onTagSearch: (String) -> Unit,
+    onCopyTagToClipboard: (tag: String) -> Unit,
+    onEditNotesClicked: () -> Unit,
+    onFilterClicked: () -> Unit,
+) {
+    item(
+        key = MangaScreenItem.INFO_BOX,
+        contentType = MangaScreenItem.INFO_BOX,
+    ) {
+        MangaInfoBox(
+            isTabletUi = false,
+            appBarPadding = topPadding,
+            manga = state.manga,
+            sourceName = remember {
+                if (state.source.id == KomgaSource.ID) "" else state.source.getNameForMangaInfo()
+            },
+            isStubSource = remember { state.source is StubSource },
+            onCoverClick = onCoverClicked,
+            doSearch = onSearch,
+        )
+    }
+
+    item(
+        key = MangaScreenItem.ACTION_ROW,
+        contentType = MangaScreenItem.ACTION_ROW,
+    ) {
+        MangaActionRow(
+            favorite = state.manga.favorite,
+            onAddToLibraryClicked = onAddToLibraryClicked,
+            onWebViewClicked = onWebViewClicked,
+            onWebViewLongClicked = onWebViewLongClicked,
+            onEditCategory = onEditCategoryClicked,
+        )
+    }
+
+    item(
+        key = MangaScreenItem.DESCRIPTION_WITH_TAG,
+        contentType = MangaScreenItem.DESCRIPTION_WITH_TAG,
+    ) {
+        ExpandableMangaDescription(
+            defaultExpandState = state.isFromSource,
+            description = state.manga.description,
+            tagsProvider = { state.manga.genre },
+            notes = state.manga.notes,
+            onTagSearch = onTagSearch,
+            onCopyTagToClipboard = onCopyTagToClipboard,
+            onEditNotes = onEditNotesClicked,
+        )
+    }
+
+    chapterHeaderListItem(
+        enabled = !isAnySelected,
+        chapters = chapters,
+        onClick = onFilterClicked,
+    )
+}
+
+private fun LazyGridScope.sharedMangaDetailHeaderGridItems(
+    state: MangaScreenModel.State.Success,
+    topPadding: androidx.compose.ui.unit.Dp,
+    isAnySelected: Boolean,
+    chapters: List<ChapterList.Item>,
+    onAddToLibraryClicked: (() -> Unit)?,
+    onWebViewClicked: (() -> Unit)?,
+    onWebViewLongClicked: (() -> Unit)?,
+    onEditCategoryClicked: (() -> Unit)?,
+    onSearch: (query: String, global: Boolean) -> Unit,
+    onCoverClicked: () -> Unit,
+    onTagSearch: (String) -> Unit,
+    onCopyTagToClipboard: (tag: String) -> Unit,
+    onEditNotesClicked: () -> Unit,
+    onFilterClicked: () -> Unit,
+) {
+    item(
+        key = MangaScreenItem.INFO_BOX,
+        span = { GridItemSpan(maxLineSpan) },
+        contentType = MangaScreenItem.INFO_BOX,
+    ) {
+        MangaInfoBox(
+            isTabletUi = false,
+            appBarPadding = topPadding,
+            manga = state.manga,
+            sourceName = remember {
+                if (state.source.id == KomgaSource.ID) "" else state.source.getNameForMangaInfo()
+            },
+            isStubSource = remember { state.source is StubSource },
+            onCoverClick = onCoverClicked,
+            doSearch = onSearch,
+        )
+    }
+
+    item(
+        key = MangaScreenItem.ACTION_ROW,
+        span = { GridItemSpan(maxLineSpan) },
+        contentType = MangaScreenItem.ACTION_ROW,
+    ) {
+        MangaActionRow(
+            favorite = state.manga.favorite,
+            onAddToLibraryClicked = onAddToLibraryClicked,
+            onWebViewClicked = onWebViewClicked,
+            onWebViewLongClicked = onWebViewLongClicked,
+            onEditCategory = onEditCategoryClicked,
+        )
+    }
+
+    item(
+        key = MangaScreenItem.DESCRIPTION_WITH_TAG,
+        span = { GridItemSpan(maxLineSpan) },
+        contentType = MangaScreenItem.DESCRIPTION_WITH_TAG,
+    ) {
+        ExpandableMangaDescription(
+            defaultExpandState = state.isFromSource,
+            description = state.manga.description,
+            tagsProvider = { state.manga.genre },
+            notes = state.manga.notes,
+            onTagSearch = onTagSearch,
+            onCopyTagToClipboard = onCopyTagToClipboard,
+            onEditNotes = onEditNotesClicked,
+        )
+    }
+
+    chapterHeaderGridItem(
+        enabled = !isAnySelected,
+        chapters = chapters,
+        onClick = onFilterClicked,
+    )
+}
+
+private fun LazyListScope.chapterHeaderListItem(
+    enabled: Boolean,
+    chapters: List<ChapterList.Item>,
+    onClick: () -> Unit,
+) {
+    item(
+        key = MangaScreenItem.CHAPTER_HEADER,
+        contentType = MangaScreenItem.CHAPTER_HEADER,
+    ) {
+        val missingChapterCount = remember(chapters) {
+            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+        }
+        ChapterHeader(
+            enabled = enabled,
+            chapterCount = chapters.size,
+            missingChapterCount = missingChapterCount,
+            onClick = onClick,
+        )
+    }
+}
+
+private fun LazyGridScope.chapterHeaderGridItem(
+    enabled: Boolean,
+    chapters: List<ChapterList.Item>,
+    onClick: () -> Unit,
+) {
+    item(
+        key = MangaScreenItem.CHAPTER_HEADER,
+        span = { GridItemSpan(maxLineSpan) },
+        contentType = MangaScreenItem.CHAPTER_HEADER,
+    ) {
+        val missingChapterCount = remember(chapters) {
+            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+        }
+        ChapterHeader(
+            enabled = enabled,
+            chapterCount = chapters.size,
+            missingChapterCount = missingChapterCount,
+            onClick = onClick,
+        )
+    }
+}
+
+private fun LazyGridScope.sharedChapterGridItems(
+    manga: Manga,
+    chapters: List<ChapterList>,
+    isAnyChapterSelected: Boolean,
+    onChapterClicked: (Chapter) -> Unit,
+    onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
+) {
+    gridItems(
+        items = chapters,
+        key = { item ->
+            when (item) {
+                is ChapterList.MissingCount -> "missing-count-${item.id}"
+                is ChapterList.Item -> "chapter-${item.id}"
+            }
+        },
+        span = { item ->
+            when (item) {
+                is ChapterList.MissingCount -> GridItemSpan(maxLineSpan)
+                is ChapterList.Item -> GridItemSpan(1)
+            }
+        },
+        contentType = { MangaScreenItem.CHAPTER },
+    ) { item ->
+        val haptic = LocalHapticFeedback.current
+
+        when (item) {
+            is ChapterList.MissingCount -> {
+                MissingChapterCountListItem(count = item.count)
+            }
+            is ChapterList.Item -> {
+                MangaCompactGridItem(
+                    coverData = MangaCoverModel(
+                        mangaId = item.chapter.id,
+                        sourceId = manga.source,
+                        isMangaFavorite = false,
+                        url = item.chapter.url
+                            .takeIf { manga.source == KomgaSource.ID }
+                            ?.let { "$it/thumbnail" },
+                        lastModified = item.chapter.dateUpload,
+                    ),
+                    title = chapterTitle(manga, item)
+                        .takeIf { manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE },
+                    isSelected = item.selected,
+                    coverAlpha = if (item.chapter.read) 0.38f else 1f,
+                    onLongClick = {
+                        onChapterSelected(item, !item.selected, true)
+                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    },
+                    onClick = {
+                        onChapterItemClick(
+                            chapterItem = item,
+                            isAnyChapterSelected = isAnyChapterSelected,
+                            onToggleSelection = { onChapterSelected(item, !item.selected, false) },
+                            onChapterClicked = onChapterClicked,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun chapterTitle(
+    manga: Manga,
+    item: ChapterList.Item,
+): String {
+    return if (manga.displayMode == Manga.CHAPTER_DISPLAY_NUMBER) {
+        stringResource(
+            MR.strings.display_mode_chapter,
+            formatChapterNumber(item.chapter.chapterNumber),
+        )
+    } else {
+        item.chapter.name
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -264,7 +264,8 @@ private fun MangaScreenSmallImpl(
 ) {
     val chapterListState = rememberLazyListState()
     val chapterGridState = rememberLazyGridState()
-    val useChapterCoverGrid = state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
+    val useChapterCoverGrid = state.manga.source == KomgaSource.ID &&
+        state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
 
     val (chapters, listItem, isAnySelected) = remember(state) {
         Triple(
@@ -283,7 +284,7 @@ private fun MangaScreenSmallImpl(
             val selectedChapterCount: Int = remember(chapters) {
                 chapters.count { it.selected }
             }
-            val isFirstItemVisible by remember {
+            val isFirstItemVisible by remember(useChapterCoverGrid) {
                 derivedStateOf {
                     if (useChapterCoverGrid) {
                         chapterGridState.firstVisibleItemIndex == 0
@@ -292,7 +293,7 @@ private fun MangaScreenSmallImpl(
                     }
                 }
             }
-            val isFirstItemScrolled by remember {
+            val isFirstItemScrolled by remember(useChapterCoverGrid) {
                 derivedStateOf {
                     if (useChapterCoverGrid) {
                         chapterGridState.firstVisibleItemScrollOffset > 0
@@ -523,7 +524,8 @@ fun MangaScreenLargeImpl(
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val density = LocalDensity.current
-    val useChapterCoverGrid = state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
+    val useChapterCoverGrid = state.manga.source == KomgaSource.ID &&
+        state.manga.chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT
 
     val (chapters, listItem, isAnySelected) = remember(state) {
         Triple(
@@ -1089,8 +1091,11 @@ private fun LazyGridScope.sharedChapterGridItems(
                             ?.let { "$it/thumbnail" },
                         lastModified = item.chapter.dateUpload,
                     ),
-                    title = chapterTitle(manga, item)
-                        .takeIf { manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE },
+                    title = if (manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE) {
+                        chapterTitle(manga, item)
+                    } else {
+                        null
+                    },
                     isSelected = item.selected,
                     coverAlpha = if (item.chapter.read) 0.38f else 1f,
                     onLongClick = {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -112,6 +112,11 @@ object SettingsLibraryScreen : SearchableSettings {
     private fun getBehaviorGroup(
         libraryPreferences: LibraryPreferences,
     ): Preference.PreferenceGroup {
+        val displayChapterByNameOrNumberEntries = persistentMapOf(
+            Manga.CHAPTER_DISPLAY_NAME to stringResource(MR.strings.show_title),
+            Manga.CHAPTER_DISPLAY_NUMBER to stringResource(MR.strings.show_chapter_number),
+        )
+        val displayChapterByNameOrNumber by libraryPreferences.displayChapterByNameOrNumber.collectAsState()
         val chapterCoverDisplayModeEntries = persistentMapOf(
             Manga.CHAPTER_COVER_DISPLAY_TEXT to stringResource(MR.strings.action_display_chapter_text_only),
             Manga.CHAPTER_COVER_DISPLAY_COVER to stringResource(MR.strings.action_display_chapter_cover_only),
@@ -125,6 +130,12 @@ object SettingsLibraryScreen : SearchableSettings {
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_behavior),
             preferenceItems = persistentListOf(
+                Preference.PreferenceItem.ListPreference(
+                    preference = libraryPreferences.displayChapterByNameOrNumber,
+                    entries = displayChapterByNameOrNumberEntries,
+                    title = stringResource(MR.strings.chapter_title_display_mode),
+                    subtitle = displayChapterByNameOrNumberEntries[displayChapterByNameOrNumber],
+                ),
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.chapterCoverDisplayMode,
                     entries = chapterCoverDisplayModeEntries,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -18,6 +18,7 @@ import tachiyomi.domain.library.service.LibraryPreferences.Companion.DEVICE_ONLY
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_HAS_UNREAD
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_COMPLETED
 import tachiyomi.domain.library.service.LibraryPreferences.Companion.MANGA_NON_READ
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
@@ -111,9 +112,33 @@ object SettingsLibraryScreen : SearchableSettings {
     private fun getBehaviorGroup(
         libraryPreferences: LibraryPreferences,
     ): Preference.PreferenceGroup {
+        val chapterCoverDisplayModeEntries = persistentMapOf(
+            Manga.CHAPTER_COVER_DISPLAY_TEXT to stringResource(MR.strings.action_display_chapter_text_only),
+            Manga.CHAPTER_COVER_DISPLAY_COVER to stringResource(MR.strings.action_display_chapter_cover_only),
+            Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE to
+                stringResource(MR.strings.action_display_chapter_cover_and_title),
+        )
+        val chapterCoverDisplayMode by libraryPreferences.chapterCoverDisplayMode.collectAsState()
+        val chapterCoverGridColumnsPref = libraryPreferences.chapterCoverGridColumns
+        val chapterCoverGridColumns by chapterCoverGridColumnsPref.collectAsState()
+
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_behavior),
             preferenceItems = persistentListOf(
+                Preference.PreferenceItem.ListPreference(
+                    preference = libraryPreferences.chapterCoverDisplayMode,
+                    entries = chapterCoverDisplayModeEntries,
+                    title = stringResource(MR.strings.pref_default_chapter_list_style),
+                    subtitle = chapterCoverDisplayModeEntries[chapterCoverDisplayMode],
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = chapterCoverGridColumns,
+                    title = stringResource(MR.strings.pref_chapter_grid_columns),
+                    valueString = stringResource(MR.strings.chapter_grid_columns, chapterCoverGridColumns),
+                    valueRange = 2..6,
+                    enabled = chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT,
+                    onValueChanged = { chapterCoverGridColumnsPref.set(it) },
+                ),
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.swipeToStartAction,
                     entries = persistentMapOf(

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -37,6 +37,7 @@ object SettingsLibraryScreen : SearchableSettings {
 
         return listOf(
             getGlobalUpdateGroup(libraryPreferences),
+            getChapterSettingsGroup(libraryPreferences),
             getBehaviorGroup(libraryPreferences),
         )
     }
@@ -109,7 +110,7 @@ object SettingsLibraryScreen : SearchableSettings {
     }
 
     @Composable
-    private fun getBehaviorGroup(
+    private fun getChapterSettingsGroup(
         libraryPreferences: LibraryPreferences,
     ): Preference.PreferenceGroup {
         val displayChapterByNameOrNumberEntries = persistentMapOf(
@@ -128,7 +129,7 @@ object SettingsLibraryScreen : SearchableSettings {
         val chapterCoverGridColumns by chapterCoverGridColumnsPref.collectAsState()
 
         return Preference.PreferenceGroup(
-            title = stringResource(MR.strings.pref_behavior),
+            title = stringResource(MR.strings.chapter_settings),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.displayChapterByNameOrNumber,
@@ -150,6 +151,17 @@ object SettingsLibraryScreen : SearchableSettings {
                     enabled = chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT,
                     onValueChanged = { chapterCoverGridColumnsPref.set(it) },
                 ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getBehaviorGroup(
+        libraryPreferences: LibraryPreferences,
+    ): Preference.PreferenceGroup {
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_behavior),
+            preferenceItems = persistentListOf(
                 Preference.PreferenceItem.ListPreference(
                     preference = libraryPreferences.swipeToStartAction,
                     entries = persistentMapOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -84,6 +84,7 @@ class MangaScreen(
         }
 
         val state by screenModel.state.collectAsStateWithLifecycle()
+        val chapterCoverGridColumns by screenModel.chapterCoverGridColumns
 
         if (state is MangaScreenModel.State.Loading) {
             LoadingScreen()
@@ -99,6 +100,7 @@ class MangaScreen(
             isTabletUi = isTabletUi(),
             chapterSwipeStartAction = screenModel.chapterSwipeStartAction,
             chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
+            chapterCoverGridColumns = chapterCoverGridColumns,
             navigateUp = navigator::pop,
             onChapterClicked = { openChapter(context, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
@@ -184,6 +186,7 @@ class MangaScreen(
                 onBookmarkedFilterChanged = screenModel::setBookmarkedFilter,
                 onSortModeChanged = screenModel::setSorting,
                 onDisplayModeChanged = screenModel::setDisplayMode,
+                onChapterCoverDisplayModeChanged = screenModel::setChapterCoverDisplayMode,
                 onSetAsDefault = screenModel::setCurrentSettingsAsDefault,
                 onResetToDefault = screenModel::resetToDefaultSettings,
                 scanlatorFilterActive = successState.scanlatorFilterActive,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -145,6 +145,7 @@ class MangaScreenModel(
 
     val chapterSwipeStartAction = libraryPreferences.swipeToEndAction.get()
     val chapterSwipeEndAction = libraryPreferences.swipeToStartAction.get()
+    val chapterCoverGridColumns = libraryPreferences.chapterCoverGridColumns.asState(screenModelScope)
     var autoTrackState = trackPreferences.autoUpdateTrackOnMarkRead.get()
 
     private val skipFiltered by readerPreferences.skipFiltered.asState(screenModelScope)
@@ -943,6 +944,14 @@ class MangaScreenModel(
 
         screenModelScope.launchNonCancellable {
             setMangaChapterFlags.awaitSetDisplayMode(manga, mode)
+        }
+    }
+
+    fun setChapterCoverDisplayMode(mode: Long) {
+        val manga = successState?.manga ?: return
+
+        screenModelScope.launchNonCancellable {
+            setMangaChapterFlags.awaitSetChapterCoverDisplayMode(manga, mode)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/SetMangaDefaultChapterFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/SetMangaDefaultChapterFlags.kt
@@ -23,6 +23,7 @@ class SetMangaDefaultChapterFlags(
                     sortingMode = sortChapterBySourceOrNumber.get(),
                     sortingDirection = sortChapterByAscendingOrDescending.get(),
                     displayMode = displayChapterByNameOrNumber.get(),
+                    chapterCoverDisplayMode = chapterCoverDisplayMode.get(),
                 )
             }
         }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -172,6 +172,16 @@ class LibraryPreferences(
         Manga.CHAPTER_DISPLAY_NAME,
     )
 
+    val chapterCoverDisplayMode: Preference<Long> = preferenceStore.getLong(
+        "default_chapter_cover_display_mode",
+        Manga.CHAPTER_COVER_DISPLAY_TEXT,
+    )
+
+    val chapterCoverGridColumns: Preference<Int> = preferenceStore.getInt(
+        "default_chapter_cover_grid_columns",
+        3,
+    )
+
     val sortChapterByAscendingOrDescending: Preference<Long> = preferenceStore.getLong(
         "default_chapter_sort_by_ascending_or_descending",
         Manga.CHAPTER_SORT_DESC,
@@ -183,6 +193,7 @@ class LibraryPreferences(
         filterChapterByBookmarked.set(manga.bookmarkedFilterRaw)
         sortChapterBySourceOrNumber.set(manga.sorting)
         displayChapterByNameOrNumber.set(manga.displayMode)
+        chapterCoverDisplayMode.set(manga.chapterCoverDisplayMode)
         sortChapterByAscendingOrDescending.set(
             if (manga.sortDescending()) Manga.CHAPTER_SORT_DESC else Manga.CHAPTER_SORT_ASC,
         )

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/SetMangaChapterFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/SetMangaChapterFlags.kt
@@ -44,6 +44,15 @@ class SetMangaChapterFlags(
         )
     }
 
+    suspend fun awaitSetChapterCoverDisplayMode(manga: Manga, flag: Long): Boolean {
+        return mangaRepository.update(
+            MangaUpdate(
+                id = manga.id,
+                chapterFlags = manga.chapterFlags.setFlag(flag, Manga.CHAPTER_COVER_DISPLAY_MASK),
+            ),
+        )
+    }
+
     suspend fun awaitSetSortingModeOrFlipOrder(manga: Manga, flag: Long): Boolean {
         val newFlags = manga.chapterFlags.let {
             if (manga.sorting == flag) {
@@ -77,6 +86,7 @@ class SetMangaChapterFlags(
         sortingMode: Long,
         sortingDirection: Long,
         displayMode: Long,
+        chapterCoverDisplayMode: Long,
     ): Boolean {
         return mangaRepository.update(
             MangaUpdate(
@@ -86,7 +96,8 @@ class SetMangaChapterFlags(
                     .setFlag(bookmarkedFilter, Manga.CHAPTER_BOOKMARKED_MASK)
                     .setFlag(sortingMode, Manga.CHAPTER_SORTING_MASK)
                     .setFlag(sortingDirection, Manga.CHAPTER_SORT_DIR_MASK)
-                    .setFlag(displayMode, Manga.CHAPTER_DISPLAY_MASK),
+                    .setFlag(displayMode, Manga.CHAPTER_DISPLAY_MASK)
+                    .setFlag(chapterCoverDisplayMode, Manga.CHAPTER_COVER_DISPLAY_MASK),
             ),
         )
     }

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -49,6 +49,9 @@ data class Manga(
     val displayMode: Long
         get() = chapterFlags and CHAPTER_DISPLAY_MASK
 
+    val chapterCoverDisplayMode: Long
+        get() = chapterFlags and CHAPTER_COVER_DISPLAY_MASK
+
     val unreadFilterRaw: Long
         get() = chapterFlags and CHAPTER_UNREAD_MASK
 
@@ -105,6 +108,11 @@ data class Manga(
         const val CHAPTER_DISPLAY_NAME = 0x00000000L
         const val CHAPTER_DISPLAY_NUMBER = 0x00100000L
         const val CHAPTER_DISPLAY_MASK = 0x00100000L
+
+        const val CHAPTER_COVER_DISPLAY_TEXT = 0x00000000L
+        const val CHAPTER_COVER_DISPLAY_COVER = 0x00200000L
+        const val CHAPTER_COVER_DISPLAY_COVER_AND_TITLE = 0x00400000L
+        const val CHAPTER_COVER_DISPLAY_MASK = 0x00600000L
 
         fun create() = Manga(
             id = -1L,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -339,6 +339,9 @@
     <string name="exclude">Exclude: %s</string>
 
     <string name="pref_behavior">Behavior</string>
+    <string name="pref_default_chapter_list_style">Default chapter list style</string>
+    <string name="pref_chapter_grid_columns">Chapters per row</string>
+    <string name="chapter_grid_columns">%d per row</string>
     <!-- This should be to the left for RTL locales -->
     <string name="pref_chapter_swipe_end">Chapter on swipe to right</string>
     <!-- This should be to the right for RTL locales -->
@@ -794,6 +797,11 @@
     <string name="chapter_paused">Paused</string>
     <string name="show_title">Source title</string>
     <string name="show_chapter_number">Chapter number</string>
+    <string name="chapter_cover_display_mode">Chapter list style</string>
+    <string name="chapter_title_display_mode">Title text</string>
+    <string name="action_display_chapter_text_only">Text title</string>
+    <string name="action_display_chapter_cover_only">Preview cover</string>
+    <string name="action_display_chapter_cover_and_title">Cover + text title</string>
     <string name="sort_by_source">By source</string>
     <string name="sort_by_number">By chapter number</string>
     <string name="sort_by_upload_date">By upload date</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -238,6 +238,11 @@
     <string name="chapter_paused">已暂停</string>
     <string name="show_title">图源标题</string>
     <string name="show_chapter_number">章节编号</string>
+    <string name="chapter_cover_display_mode">章节列表样式</string>
+    <string name="chapter_title_display_mode">标题文字</string>
+    <string name="action_display_chapter_text_only">文字标题</string>
+    <string name="action_display_chapter_cover_only">预览封面</string>
+    <string name="action_display_chapter_cover_and_title">封面 + 文字标题</string>
     <string name="sort_by_source">按图源</string>
     <string name="sort_by_number">按章节编号</string>
     <string name="manga_download">下载</string>
@@ -767,6 +772,9 @@
     <string name="pref_page_rotate_invert">旋转横向图片时反转方向</string>
     <string name="pref_debug_info">调试信息</string>
     <string name="pref_chapter_swipe_end">向右滑动章节</string>
+    <string name="pref_default_chapter_list_style">默认章节列表样式</string>
+    <string name="pref_chapter_grid_columns">每行章节数量</string>
+    <string name="chapter_grid_columns">每行 %d 个</string>
     <string name="pref_chapter_swipe_start">向左滑动章节</string>
     <string name="pref_double_tap_zoom">双击放大</string>
     <string name="pref_update_only_in_release_period">预测下次更新时间</string>


### PR DESCRIPTION
新增作品详情页章节列表的文字、封面、封面加标题三种显示方式。

在书架设置中加入默认章节列表样式和每行章节数量设置，并仅在封面模式下显示数量设置。

复用现有章节设置默认值逻辑，并补充中英文资源文案。