### PR TITLE
优化书架显示模式与列数设置

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/BrowseSourceScreen.kt
@@ -135,6 +135,7 @@ fun BrowseSourceContent(
                 mangaList = mangaList,
                 columns = columns,
                 contentPadding = contentPadding,
+                showTitle = displayMode is LibraryDisplayMode.CompactGrid,
                 showLibraryBadges = showLibraryBadges,
                 onMangaClick = onMangaClick,
                 onMangaLongClick = onMangaLongClick,

--- a/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/browse/components/BrowseSourceCompactGrid.kt
@@ -25,6 +25,7 @@ fun BrowseSourceCompactGrid(
     mangaList: LazyPagingItems<StateFlow<Manga>>,
     columns: GridCells,
     contentPadding: PaddingValues,
+    showTitle: Boolean = true,
     showLibraryBadges: Boolean,
     onMangaClick: (Manga) -> Unit,
     onMangaLongClick: (Manga) -> Unit,
@@ -46,6 +47,7 @@ fun BrowseSourceCompactGrid(
             val manga by mangaList[index]?.collectAsState() ?: return@items
             BrowseSourceCompactGridItem(
                 manga = manga,
+                showTitle = showTitle,
                 showLibraryBadges = showLibraryBadges,
                 onClick = { onMangaClick(manga) },
                 onLongClick = { onMangaLongClick(manga) },
@@ -63,13 +65,14 @@ fun BrowseSourceCompactGrid(
 @Composable
 private fun BrowseSourceCompactGridItem(
     manga: Manga,
+    showTitle: Boolean,
     showLibraryBadges: Boolean,
     onClick: () -> Unit = {},
     onLongClick: () -> Unit = onClick,
 ) {
     val isLibraryManga = showLibraryBadges && manga.favorite
     MangaCompactGridItem(
-        title = manga.title,
+        title = manga.title.takeIf { showTitle },
         coverData = MangaCover(
             mangaId = manga.id,
             sourceId = manga.source,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -36,9 +36,34 @@ object SettingsLibraryScreen : SearchableSettings {
         val libraryPreferences = remember { Injekt.get<LibraryPreferences>() }
 
         return listOf(
+            getDisplayGroup(libraryPreferences),
             getGlobalUpdateGroup(libraryPreferences),
             getChapterSettingsGroup(libraryPreferences),
             getBehaviorGroup(libraryPreferences),
+        )
+    }
+
+    @Composable
+    private fun getDisplayGroup(
+        libraryPreferences: LibraryPreferences,
+    ): Preference.PreferenceGroup {
+        val columnsPref = libraryPreferences.portraitColumns
+        val columns by columnsPref.collectAsState()
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_category_display),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SliderPreference(
+                    value = columns.coerceIn(LibraryColumnsRange),
+                    title = stringResource(MR.strings.pref_library_columns),
+                    valueString = libraryColumnsValueString(columns),
+                    valueRange = LibraryColumnsRange,
+                    onValueChanged = {
+                        columnsPref.set(it)
+                        libraryPreferences.landscapeColumns.set(it)
+                    },
+                ),
+            ),
         )
     }
 
@@ -192,5 +217,16 @@ object SettingsLibraryScreen : SearchableSettings {
                 ),
             ),
         )
+    }
+}
+
+private val LibraryColumnsRange = 0..10
+
+@Composable
+private fun libraryColumnsValueString(columns: Int): String {
+    return if (columns > 0) {
+        columns.toString()
+    } else {
+        stringResource(MR.strings.label_auto)
     }
 }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
@@ -73,6 +74,7 @@ import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.screens.LoadingScreen
+import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlin.math.roundToInt
@@ -119,6 +121,7 @@ data class KomgaLibraryScreen(
             )
         }
         val state by screenModel.state.collectAsState()
+        val columns by libraryPreferences.portraitColumns.collectAsState()
 
         val navigator = LocalNavigator.currentOrThrow
         val navigateUp: () -> Unit = {
@@ -247,7 +250,7 @@ data class KomgaLibraryScreen(
                 BrowseSourceContent(
                     source = screenModel.source,
                     mangaList = mangaList,
-                    columns = screenModel.getColumnsPreference(LocalConfiguration.current.orientation),
+                    columns = libraryGridCellsForColumns(columns),
                     displayMode = screenModel.displayMode,
                     snackbarHostState = snackbarHostState,
                     contentPadding = paddingValues,
@@ -314,5 +317,14 @@ data class KomgaLibraryScreen(
     sealed class SearchType(val txt: String) {
         class Text(txt: String) : SearchType(txt)
         class Genre(txt: String) : SearchType(txt)
+    }
+}
+
+private fun libraryGridCellsForColumns(columns: Int): GridCells {
+    val coercedColumns = columns.coerceIn(0, 10)
+    return if (coercedColumns == 0) {
+        GridCells.Adaptive(128.dp)
+    } else {
+        GridCells.Fixed(coercedColumns)
     }
 }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -1,13 +1,10 @@
 package koharia.komga.ui.library
 
 import android.content.SharedPreferences
-import android.content.res.Configuration
 import android.util.Log
-import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.unit.dp
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -131,16 +128,6 @@ class KomgaLibraryScreenModel(
         }
     }
         .cachedIn(ioCoroutineScope)
-
-    fun getColumnsPreference(orientation: Int): GridCells {
-        val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
-        val columns = if (isLandscape) {
-            libraryPreferences.landscapeColumns
-        } else {
-            libraryPreferences.portraitColumns
-        }.get()
-        return if (columns == 0) GridCells.Adaptive(128.dp) else GridCells.Fixed(columns)
-    }
 
     fun resetFilters() {
         if (source !is CatalogueSource) return

--- a/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
+++ b/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
@@ -93,6 +93,13 @@ fun KomgaLibraryToolbar(
                     onDisplayModeChange(LibraryDisplayMode.CompactGrid)
                 }
                 RadioMenuItem(
+                    text = { Text(text = stringResource(MR.strings.action_display_cover_only_grid)) },
+                    isChecked = displayMode == LibraryDisplayMode.CoverOnlyGrid,
+                ) {
+                    selectingDisplayMode = false
+                    onDisplayModeChange(LibraryDisplayMode.CoverOnlyGrid)
+                }
+                RadioMenuItem(
                     text = { Text(text = stringResource(MR.strings.action_display_list)) },
                     isChecked = displayMode == LibraryDisplayMode.List,
                 ) {


### PR DESCRIPTION
- 在书架显示模式中增加只显示封面的封面网格选项
- 将书架每行显示数量集中到设置页，并取消横竖屏区分
- 让当前书架页实时读取每行数量设置