### PR TITLE
实现 Komga 共用目录模式下的跨服务器下载复用

### DIFF
--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SyncChaptersWithSource.kt
@@ -127,6 +127,7 @@ class SyncChaptersWithSource(
                         chapterNumber = chapter.chapterNumber,
                         scanlator = chapter.scanlator,
                         sourceOrder = chapter.sourceOrder,
+                        memo = chapter.memo,
                     )
 
                     if (chapter.dateUpload != 0L) {

--- a/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/model/Chapter.kt
@@ -13,6 +13,7 @@ fun Chapter.toSChapter(): SChapter {
         it.date_upload = dateUpload
         it.chapter_number = chapterNumber.toFloat()
         it.scanlator = scanlator
+        it.memo = memo
     }
 }
 
@@ -23,6 +24,7 @@ fun Chapter.copyFromSChapter(sChapter: SChapter): Chapter {
         dateUpload = sChapter.date_upload,
         chapterNumber = sChapter.chapter_number.toDouble(),
         scanlator = sChapter.scanlator?.ifBlank { null }?.trim(),
+        memo = sChapter.memo,
     )
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.core.net.toUri
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.source.Source
+import koharia.source.komga.DownloadDirectoryMode
 import koharia.source.komga.KomgaServerPreferences
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -171,6 +172,12 @@ class DownloadCache(
                 ).any { it in mangaDir.chapterDirs }
             }
         }
+
+        if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared) {
+            val source = sourceManager.getOrStub(sourceId)
+            return provider.findChapterDir(chapterName, chapterScanlator, chapterUrl, mangaTitle, source) != null
+        }
+
         return false
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -40,6 +40,7 @@ class DownloadManager(
     private val context: Context,
     private val provider: DownloadProvider = Injekt.get(),
     private val cache: DownloadCache = Injekt.get(),
+    private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager = Injekt.get(),
     private val getCategories: GetCategories = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
@@ -297,7 +298,10 @@ class DownloadManager(
             removeFromDownloadQueue(filteredChapters)
 
             val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
-            chapterDirs.forEach { it.delete() }
+            chapterDirs.distinctBy { it.uri.toString() }.forEach {
+                komgaSharedDownloadIndexManager.deleteIndexedPath(it)
+                it.delete()
+            }
             cache.removeChapters(filteredChapters, manga)
 
             // Delete manga directory if empty
@@ -323,7 +327,12 @@ class DownloadManager(
             if (removeQueued) {
                 downloader.removeFromQueue(manga)
             }
-            provider.findMangaDir(manga.title, source)?.delete()
+            provider.findMangaDir(manga.title, source)?.let { mangaDir ->
+                komgaSharedDownloadIndexManager.relativePathOf(mangaDir)?.let {
+                    komgaSharedDownloadIndexManager.deleteIndexedPathPrefix(it)
+                }
+                mangaDir.delete()
+            }
             cache.removeManga(manga)
 
             // Delete source directory if empty
@@ -424,6 +433,7 @@ class DownloadManager(
         downloader.removeFromQueue(manga)
 
         val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
+        val oldRelativePathPrefix = komgaSharedDownloadIndexManager.relativePathOf(oldFolder)
         if (capitalizationChanged) {
             val tempName = newName + Downloader.TMP_DIR_SUFFIX
             if (!oldFolder.renameTo(tempName)) {
@@ -433,7 +443,13 @@ class DownloadManager(
         }
 
         if (oldFolder.renameTo(newName)) {
-            cache.renameManga(manga, oldFolder, newTitle)
+            val renamedFolder = provider.findMangaDir(newTitle, source) ?: oldFolder
+            oldRelativePathPrefix?.let { oldPrefix ->
+                komgaSharedDownloadIndexManager.relativePathOf(renamedFolder)?.let { newPrefix ->
+                    komgaSharedDownloadIndexManager.updateIndexedPathPrefix(oldPrefix, newPrefix)
+                }
+            }
+            cache.renameManga(manga, renamedFolder, newTitle)
         } else {
             logcat(LogPriority.ERROR) { "Failed to rename manga download folder: ${oldFolder.name}" }
         }
@@ -466,9 +482,15 @@ class DownloadManager(
 
         if (oldDownload.name == newName) return
 
+        val oldRelativePath = komgaSharedDownloadIndexManager.relativePathOf(oldDownload)
         if (oldDownload.renameTo(newName)) {
             cache.removeChapter(oldChapter, manga)
             cache.addChapter(newName, mangaDir, manga)
+            oldRelativePath?.let { oldPath ->
+                mangaDir.findFile(newName)?.let { renamedFile ->
+                    komgaSharedDownloadIndexManager.updateIndexedPath(oldPath, renamedFile)
+                }
+            }
         } else {
             logcat(LogPriority.ERROR) { "Could not rename downloaded chapter: ${oldNames.joinToString()}" }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -327,6 +327,12 @@ class DownloadManager(
             if (removeQueued) {
                 downloader.removeFromQueue(manga)
             }
+            if (
+                source is KomgaSource &&
+                komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared
+            ) {
+                komgaSharedDownloadIndexManager.deleteMangaIndexedDownloads(manga.id, source.id)
+            }
             provider.findMangaDir(manga.title, source)?.let { mangaDir ->
                 komgaSharedDownloadIndexManager.relativePathOf(mangaDir)?.let {
                     komgaSharedDownloadIndexManager.deleteIndexedPathPrefix(it)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -32,7 +32,10 @@ class DownloadProvider(
     private val storageManager: StorageManager = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val komgaServerPreferences: KomgaServerPreferences = Injekt.get(),
+    private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager = Injekt.get(),
 ) {
+    private val sourceDirsCache = mutableMapOf<String, CacheEntry<List<UniFile>>>()
+
     private val disallowNonAsciiFilenames: Boolean
         get() = libraryPreferences.disallowNonAsciiFilenames.get()
 
@@ -83,10 +86,7 @@ class DownloadProvider(
      * @param source the source to query.
      */
     fun findSourceDir(source: Source): UniFile? {
-        val downloadsDir = downloadsDir ?: return null
-        return getSourceDirNames(source)
-            .asSequence()
-            .mapNotNull(downloadsDir::findFile)
+        return findSourceDirs(source)
             .firstOrNull()
     }
 
@@ -121,9 +121,16 @@ class DownloadProvider(
     ): UniFile? {
         val mangaDir = findMangaDir(mangaTitle, source)
         val validNames = getValidChapterDirNames(chapterName, chapterScanlator, chapterUrl)
-        val result = validNames.asSequence()
+        val directResult = validNames.asSequence()
             .mapNotNull { mangaDir?.findFile(it) }
             .firstOrNull()
+        val result = directResult ?: when {
+            source is KomgaSource &&
+                komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared -> {
+                komgaSharedDownloadIndexManager.findSharedChapterDir(chapterUrl, mangaTitle, source)
+            }
+            else -> null
+        }
 
         logcat {
             buildString {
@@ -132,8 +139,9 @@ class DownloadProvider(
                 append("mangaTitle=$mangaTitle ")
                 append("chapterName=$chapterName ")
                 append("chapterUrl=$chapterUrl ")
-                append("mangaDir=${mangaDir?.displayablePath ?: "<missing>"} ")
+                append("mangaDirName=${mangaDir?.name ?: "<missing>"} ")
                 append("hit=${result?.name ?: "<none>"} ")
+                append("directHit=${directResult?.name ?: "<none>"} ")
                 append("candidates=${validNames.joinToString(limit = 8, truncated = "...")}")
                 if (result == null) {
                     append(" hasMangaDir=${mangaDir != null}")
@@ -152,11 +160,9 @@ class DownloadProvider(
      * @param source the source of the chapter.
      */
     fun findChapterDirs(chapters: List<Chapter>, manga: Manga, source: Source): Pair<UniFile?, List<UniFile>> {
-        val mangaDir = findMangaDir(manga.title, source) ?: return null to emptyList()
+        val mangaDir = findMangaDir(manga.title, source)
         return mangaDir to chapters.mapNotNull { chapter ->
-            getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url).asSequence()
-                .mapNotNull { mangaDir.findFile(it) }
-                .firstOrNull()
+            findChapterDir(chapter.name, chapter.scanlator, chapter.url, manga.title, source)
         }
     }
 
@@ -181,10 +187,7 @@ class DownloadProvider(
 
     fun getSourceDirNames(source: Source): List<String> {
         val primaryName = getSourceDirName(source)
-        if (
-            source !is KomgaSource ||
-            komgaServerPreferences.downloadDirectoryMode.get() != DownloadDirectoryMode.Shared
-        ) {
+        if (!shouldIncludeLegacySharedDirsInLookup(source)) {
             return listOf(primaryName)
         }
 
@@ -318,6 +321,8 @@ class DownloadProvider(
         val SUPPORTED_CHAPTER_FILE_EXTENSIONS =
             setOf("cbz", "zip", "rar", "cbr", "7z", "cb7", "tar", "cbt", "epub", "pdf")
 
+        private const val CACHE_TTL_MS = 10_000L
+
         fun isSupportedChapterFileExtension(extension: String?): Boolean {
             return extension?.lowercase() in SUPPORTED_CHAPTER_FILE_EXTENSIONS
         }
@@ -325,9 +330,18 @@ class DownloadProvider(
 
     private fun findSourceDirs(source: Source): List<UniFile> {
         val downloadsDir = downloadsDir ?: return emptyList()
-        return getSourceDirNames(source)
-            .mapNotNull(downloadsDir::findFile)
-            .distinctBy { it.uri.toString() }
+        val cacheKey = buildSourceDirsCacheKey(downloadsDir, source)
+        return synchronized(sourceDirsCache) {
+            sourceDirsCache[cacheKey]
+                ?.takeUnless { it.isExpired() }
+                ?.value
+                ?: getSourceDirNames(source)
+                    .mapNotNull(downloadsDir::findFile)
+                    .distinctBy { it.uri.toString() }
+                    .also { dirs ->
+                        sourceDirsCache[cacheKey] = CacheEntry(dirs)
+                    }
+        }
     }
 
     private fun resolveSourceDir(downloadsDir: UniFile, source: Source, sourceDirName: String): UniFile? {
@@ -361,6 +375,7 @@ class DownloadProvider(
         }
 
         return downloadsDir.createDirectory(sourceDirName)
+            ?.also { invalidateSourceDirCache() }
     }
 
     private fun legacyKomgaSharedSourceDirNames(): List<String> {
@@ -377,5 +392,28 @@ class DownloadProvider(
             "$sourceName (${KomgaSource.SOURCE_LANG.uppercase()})",
             disallowNonAscii = disallowNonAsciiFilenames,
         )
+    }
+
+    private fun shouldIncludeLegacySharedDirsInLookup(source: Source): Boolean {
+        return false
+    }
+
+    private fun buildSourceDirsCacheKey(downloadsDir: UniFile, source: Source): String {
+        return "${downloadsDir.uri}|${getSourceDirNames(source).joinToString(separator = "|")}"
+    }
+
+    private fun invalidateSourceDirCache() {
+        synchronized(sourceDirsCache) {
+            sourceDirsCache.clear()
+        }
+    }
+
+    private data class CacheEntry<T>(
+        val value: T,
+        val cachedAt: Long = System.currentTimeMillis(),
+    ) {
+        fun isExpired(): Boolean {
+            return System.currentTimeMillis() - cachedAt >= CACHE_TTL_MS
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -395,7 +395,8 @@ class DownloadProvider(
     }
 
     private fun shouldIncludeLegacySharedDirsInLookup(source: Source): Boolean {
-        return false
+        return source is KomgaSource &&
+            komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared
     }
 
     private fun buildSourceDirsCacheKey(downloadsDir: UniFile, source: Source): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -76,6 +76,7 @@ class Downloader(
     private val context: Context,
     private val provider: DownloadProvider,
     private val cache: DownloadCache,
+    private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager = Injekt.get(),
     private val sourceManager: SourceManager = Injekt.get(),
     private val chapterCache: ChapterCache = Injekt.get(),
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
@@ -542,6 +543,16 @@ class Downloader(
             }
             cache.addChapter(chapterDirname, mangaDir, download.manga)
 
+            val indexedFile = if (downloadPreferences.saveChaptersAsCBZ.get()) {
+                mangaDir.findFile("$chapterDirname.cbz")
+            } else {
+                mangaDir.findFile(chapterDirname)
+            }
+            val komgaSource = download.source as? KomgaSource
+            if (komgaSource != null && indexedFile != null) {
+                komgaSharedDownloadIndexManager.indexDownloadedChapter(download.chapter, komgaSource, indexedFile)
+            }
+
             DiskUtil.createNoMediaFile(tmpDir, context)
 
             download.status = Download.State.DOWNLOADED
@@ -684,6 +695,15 @@ class Downloader(
                     }
 
                     cache.addChapter(resolvedFinalFileName, mangaDir, download.manga)
+                    (download.source as? KomgaSource)?.let { komgaSource ->
+                        mangaDir.findFile(resolvedFinalFileName)?.let { finalizedFile ->
+                            komgaSharedDownloadIndexManager.indexDownloadedChapter(
+                                download.chapter,
+                                komgaSource,
+                                finalizedFile,
+                            )
+                        }
+                    }
                     DiskUtil.createNoMediaFile(mangaDir, context)
                     download.status = Download.State.DOWNLOADED
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
@@ -142,6 +142,22 @@ class KomgaSharedDownloadIndexManager(
         repository.deleteByServerId(serverId)
     }
 
+    suspend fun deleteMangaIndexedDownloads(mangaId: Long, sourceId: Long) {
+        val relativePaths = repository.getChapterSeedsByMangaId(mangaId, sourceId)
+            .mapNotNull { seed ->
+                val fingerprint = KomgaChapterMemo.readFingerprint(seed.memo) ?: return@mapNotNull null
+                repository.findByServerIdAndBookUrl(sourceId, fingerprint.bookUrl)
+            }
+            .map(KomgaSharedDownloadMatch::localRelativePath)
+            .distinct()
+
+        relativePaths.forEach { relativePath ->
+            deleteLocalRelativePath(relativePath)
+            repository.deleteByLocalRelativePath(relativePath)
+        }
+        invalidateLocalLookupCaches()
+    }
+
     suspend fun cleanupServerDownloads(
         serverId: Long,
         cleanupMode: koharia.source.komga.DownloadCleanupMode,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
@@ -183,31 +183,29 @@ class KomgaSharedDownloadIndexManager(
     private fun relativePathFromDocumentIds(root: UniFile, item: UniFile): String? {
         val rootDocumentId = root.documentIdOrNull() ?: return null
         val itemDocumentId = item.documentIdOrNull() ?: return null
-        if (!itemDocumentId.startsWith(rootDocumentId)) return null
-        return itemDocumentId.removePrefix(rootDocumentId)
-            .trimStart('/', '\\')
-            .replace('\\', '/')
-            .takeIf { it.isNotBlank() }
+        return relativePathAfterPrefix(rootDocumentId, itemDocumentId)
     }
 
     private fun relativePathFromUriPath(root: UniFile, item: UniFile): String? {
         val rootPath = root.uri.path?.trimEnd('/', '\\') ?: return null
         val itemPath = item.uri.path ?: return null
-        if (!itemPath.startsWith(rootPath)) return null
-        return itemPath.removePrefix(rootPath)
-            .trimStart('/', '\\')
-            .replace('\\', '/')
-            .takeIf { it.isNotBlank() }
+        return relativePathAfterPrefix(rootPath, itemPath)
     }
 
     private fun relativePathFromFilePath(root: UniFile, item: UniFile): String? {
         val rootPath = root.filePath?.trimEnd('/', '\\') ?: return null
         val itemPath = item.filePath ?: return null
+        return relativePathAfterPrefix(rootPath, itemPath)
+    }
+
+    private fun relativePathAfterPrefix(rootPath: String, itemPath: String): String? {
+        if (itemPath == rootPath) return null
         if (!itemPath.startsWith(rootPath)) return null
         return itemPath.removePrefix(rootPath)
-            .trimStart('/', '\\')
-            .replace('\\', '/')
-            .takeIf { it.isNotBlank() }
+            .takeIf { it.startsWith('/') || it.startsWith('\\') }
+            ?.trimStart('/', '\\')
+            ?.replace('\\', '/')
+            ?.takeIf { it.isNotBlank() }
     }
 
     private suspend fun findSharedChapterDir(
@@ -399,14 +397,7 @@ class KomgaSharedDownloadIndexManager(
         val localDownloadsByName = buildLocalDownloadsByName(mangaTitle)
 
         seeds.forEach { seed ->
-            val fingerprint = KomgaChapterMemo.readFingerprint(seed.memo)
-                ?: resolveFingerprintForIndexing(
-                    chapterUrl = seed.chapterUrl,
-                    source = source,
-                    chapterId = seed.chapterId,
-                    existingMemo = seed.memo,
-                )
-                ?: return@forEach
+            val fingerprint = KomgaChapterMemo.readFingerprint(seed.memo) ?: return@forEach
 
             if (repository.findByServerIdAndBookUrl(source.id, fingerprint.bookUrl) != null) {
                 return@forEach

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadIndexManager.kt
@@ -1,0 +1,603 @@
+package eu.kanade.tachiyomi.data.download
+
+import android.provider.DocumentsContract
+import com.hippo.unifile.UniFile
+import eu.kanade.tachiyomi.util.lang.Hash.md5
+import eu.kanade.tachiyomi.util.storage.DiskUtil
+import koharia.komga.download.KomgaBookFingerprint
+import koharia.komga.download.KomgaChapterMemo
+import koharia.source.komga.DownloadDirectoryMode
+import koharia.source.komga.KomgaServerPreferences
+import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonObject
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.Collections
+
+class KomgaSharedDownloadIndexManager(
+    private val repository: KomgaSharedDownloadRepository = Injekt.get(),
+    private val storageManager: StorageManager = Injekt.get(),
+    private val libraryPreferences: LibraryPreferences = Injekt.get(),
+    private val komgaServerPreferences: KomgaServerPreferences = Injekt.get(),
+) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val activeWarmups = Collections.synchronizedSet(mutableSetOf<String>())
+    private val recentWarmups = Collections.synchronizedMap(mutableMapOf<String, Long>())
+    private val sharedSourceDirsCache = Collections.synchronizedMap(mutableMapOf<String, CacheEntry<List<UniFile>>>())
+    private val mangaDownloadsCache =
+        Collections.synchronizedMap(mutableMapOf<String, CacheEntry<Map<String, UniFile>>>())
+
+    @Volatile
+    private var warmupJob: Job? = null
+
+    fun findSharedChapterDir(
+        chapterUrl: String,
+        mangaTitle: String,
+        source: KomgaSource,
+    ): UniFile? {
+        if (!shouldUseSharedMatching(source)) return null
+
+        return runBlocking(Dispatchers.IO) {
+            val fingerprint = resolveStoredFingerprint(
+                chapterUrl = chapterUrl,
+            )
+
+            if (fingerprint == null) {
+                scheduleWarmup(source, mangaTitle)
+                return@runBlocking null
+            }
+
+            findSharedChapterDir(source.id, fingerprint).also { file ->
+                if (file == null) {
+                    scheduleWarmup(source, mangaTitle)
+                }
+            }
+        }
+    }
+
+    suspend fun indexDownloadedChapter(
+        chapter: Chapter,
+        source: KomgaSource,
+        localFile: UniFile,
+    ) {
+        if (!shouldUseSharedMatching(source)) return
+
+        val fingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
+            ?: resolveFingerprintForIndexing(
+                chapterUrl = chapter.url,
+                source = source,
+                chapterId = chapter.id,
+                existingMemo = chapter.memo,
+            )
+            ?: return
+
+        val relativePath = relativePathOf(localFile) ?: return
+        upsertMatch(
+            serverId = source.id,
+            fingerprint = fingerprint,
+            relativePath = relativePath,
+            fileName = localFile.name.orEmpty(),
+            fileKind = if (localFile.isDirectory) FILE_KIND_DIRECTORY else FILE_KIND_FILE,
+        )
+        invalidateLocalLookupCaches()
+    }
+
+    suspend fun deleteIndexedPath(localItem: UniFile) {
+        val relativePath = relativePathOf(localItem) ?: return
+        if (localItem.isDirectory) {
+            deleteIndexedPathPrefix(relativePath)
+        } else {
+            repository.deleteByLocalRelativePath(relativePath)
+        }
+        invalidateLocalLookupCaches()
+    }
+
+    suspend fun deleteIndexedPathPrefix(relativePathPrefix: String) {
+        repository.findByLocalRelativePathPrefix(relativePathPrefix)
+            .map(KomgaSharedDownloadMatch::localRelativePath)
+            .distinct()
+            .forEach { repository.deleteByLocalRelativePath(it) }
+        invalidateLocalLookupCaches()
+    }
+
+    suspend fun updateIndexedPath(
+        oldRelativePath: String,
+        newLocalItem: UniFile,
+    ) {
+        val newRelativePath = relativePathOf(newLocalItem) ?: return
+        repository.updateLocalRelativePath(
+            oldLocalRelativePath = oldRelativePath,
+            newLocalRelativePath = newRelativePath,
+            newFileName = newLocalItem.name.orEmpty(),
+            lastVerifiedAt = now(),
+        )
+        invalidateLocalLookupCaches()
+    }
+
+    suspend fun updateIndexedPathPrefix(
+        oldRelativePathPrefix: String,
+        newRelativePathPrefix: String,
+    ) {
+        repository.updateLocalRelativePathPrefix(
+            oldPrefix = oldRelativePathPrefix,
+            newPrefix = newRelativePathPrefix,
+            lastVerifiedAt = now(),
+        )
+        invalidateLocalLookupCaches()
+    }
+
+    suspend fun removeServerIndexes(serverId: Long) {
+        repository.deleteByServerId(serverId)
+    }
+
+    suspend fun cleanupServerDownloads(
+        serverId: Long,
+        cleanupMode: koharia.source.komga.DownloadCleanupMode,
+    ) {
+        val matches = repository.findByServerId(serverId)
+        val relativePaths = matches.map(KomgaSharedDownloadMatch::localRelativePath).distinct()
+
+        when (cleanupMode) {
+            koharia.source.komga.DownloadCleanupMode.Preserve -> {
+                repository.deleteByServerId(serverId)
+            }
+            koharia.source.komga.DownloadCleanupMode.DeleteExclusiveMatches -> {
+                repository.deleteByServerId(serverId)
+                relativePaths.forEach { relativePath ->
+                    if (repository.countByLocalRelativePath(relativePath) == 0L) {
+                        deleteLocalRelativePath(relativePath)
+                        repository.deleteByLocalRelativePath(relativePath)
+                    }
+                }
+            }
+            koharia.source.komga.DownloadCleanupMode.DeleteAllMatchedFiles -> {
+                relativePaths.forEach { relativePath ->
+                    deleteLocalRelativePath(relativePath)
+                    repository.deleteByLocalRelativePath(relativePath)
+                }
+                repository.deleteByServerId(serverId)
+            }
+        }
+        invalidateLocalLookupCaches()
+    }
+
+    fun relativePathOf(localItem: UniFile): String? {
+        val downloadsDir = storageManager.getDownloadsDirectory() ?: return null
+        return relativePathFromDocumentIds(downloadsDir, localItem)
+            ?: relativePathFromUriPath(downloadsDir, localItem)
+            ?: relativePathFromFilePath(downloadsDir, localItem)
+    }
+
+    private fun relativePathFromDocumentIds(root: UniFile, item: UniFile): String? {
+        val rootDocumentId = root.documentIdOrNull() ?: return null
+        val itemDocumentId = item.documentIdOrNull() ?: return null
+        if (!itemDocumentId.startsWith(rootDocumentId)) return null
+        return itemDocumentId.removePrefix(rootDocumentId)
+            .trimStart('/', '\\')
+            .replace('\\', '/')
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun relativePathFromUriPath(root: UniFile, item: UniFile): String? {
+        val rootPath = root.uri.path?.trimEnd('/', '\\') ?: return null
+        val itemPath = item.uri.path ?: return null
+        if (!itemPath.startsWith(rootPath)) return null
+        return itemPath.removePrefix(rootPath)
+            .trimStart('/', '\\')
+            .replace('\\', '/')
+            .takeIf { it.isNotBlank() }
+    }
+
+    private fun relativePathFromFilePath(root: UniFile, item: UniFile): String? {
+        val rootPath = root.filePath?.trimEnd('/', '\\') ?: return null
+        val itemPath = item.filePath ?: return null
+        if (!itemPath.startsWith(rootPath)) return null
+        return itemPath.removePrefix(rootPath)
+            .trimStart('/', '\\')
+            .replace('\\', '/')
+            .takeIf { it.isNotBlank() }
+    }
+
+    private suspend fun findSharedChapterDir(
+        serverId: Long,
+        fingerprint: KomgaBookFingerprint,
+    ): UniFile? {
+        repository.findByServerIdAndBookUrl(serverId, fingerprint.bookUrl)?.let { directMatch ->
+            resolveVerifiedFile(directMatch)?.let { file ->
+                touchMatch(directMatch)
+                return file
+            }
+        }
+
+        findCandidateMatches(fingerprint).forEach { match ->
+            val file = resolveVerifiedFile(match) ?: return@forEach
+            touchMatch(match)
+            upsertMatch(
+                serverId = serverId,
+                fingerprint = fingerprint,
+                relativePath = match.localRelativePath,
+                fileName = match.fileName,
+                fileKind = match.fileKind,
+            )
+            return file
+        }
+
+        return null
+    }
+
+    private suspend fun resolveStoredFingerprint(
+        chapterUrl: String,
+    ): KomgaBookFingerprint? {
+        val seed = repository.getChapterSeedByUrl(chapterUrl)
+        return seed?.memo?.let(KomgaChapterMemo::readFingerprint)
+    }
+
+    private suspend fun resolveFingerprintForIndexing(
+        chapterUrl: String,
+        source: KomgaSource,
+        chapterId: Long = -1L,
+        existingMemo: JsonObject = JsonObject(emptyMap()),
+    ): KomgaBookFingerprint? {
+        val seed = repository.getChapterSeedByUrl(chapterUrl)
+        KomgaChapterMemo.readFingerprint(seed?.memo ?: existingMemo)?.let { return it }
+
+        val book = source.getBookDetails(chapterUrl) ?: return null
+        val fingerprint = KomgaChapterMemo.buildFingerprint(source.baseUrl, book)
+        val mergedMemo = KomgaChapterMemo.mergeInto(seed?.memo ?: existingMemo, fingerprint)
+        val targetChapterId = seed?.chapterId ?: chapterId
+        if (targetChapterId > 0L) {
+            repository.updateChapterMemo(targetChapterId, mergedMemo)
+        }
+        return fingerprint
+    }
+
+    private suspend fun findCandidateMatches(fingerprint: KomgaBookFingerprint): List<KomgaSharedDownloadMatch> {
+        val ordered = linkedMapOf<String, KomgaSharedDownloadMatch>()
+
+        if (fingerprint.fileHash.isNotBlank()) {
+            repository.findByFileHash(fingerprint.fileHash).forEach { ordered.putIfAbsent(it.localRelativePath, it) }
+        }
+        if (ordered.isNotEmpty()) return ordered.values.toList()
+
+        if (fingerprint.isbn.isNotBlank()) {
+            repository.findByIsbn(fingerprint.isbn).forEach { ordered.putIfAbsent(it.localRelativePath, it) }
+        }
+        if (ordered.isNotEmpty()) return ordered.values.toList()
+
+        if (fingerprint.seriesTitle.isNotBlank() && fingerprint.sizeBytes > 0L) {
+            repository.findBySeriesNumberSize(
+                seriesTitle = fingerprint.seriesTitle,
+                numberSort = fingerprint.numberSort,
+                sizeBytes = fingerprint.sizeBytes,
+            ).forEach { ordered.putIfAbsent(it.localRelativePath, it) }
+        }
+        if (ordered.isNotEmpty()) return ordered.values.toList()
+
+        if (fingerprint.bookTitle.isNotBlank() && fingerprint.sizeBytes > 0L) {
+            repository.findByBookTitleSize(
+                bookTitle = fingerprint.bookTitle,
+                sizeBytes = fingerprint.sizeBytes,
+            ).forEach { ordered.putIfAbsent(it.localRelativePath, it) }
+        }
+
+        return ordered.values.toList()
+    }
+
+    private suspend fun resolveVerifiedFile(match: KomgaSharedDownloadMatch): UniFile? {
+        val file = resolveLocalRelativePath(match.localRelativePath)
+        if (file == null || !file.exists()) {
+            repository.deleteByLocalRelativePath(match.localRelativePath)
+            return null
+        }
+        return file
+    }
+
+    private suspend fun touchMatch(match: KomgaSharedDownloadMatch) {
+        repository.upsert(match.copy(lastVerifiedAt = now()))
+    }
+
+    private suspend fun upsertMatch(
+        serverId: Long,
+        fingerprint: KomgaBookFingerprint,
+        relativePath: String,
+        fileName: String,
+        fileKind: String,
+    ) {
+        val existing = repository.findByServerIdAndBookUrl(serverId, fingerprint.bookUrl)
+        val timestamp = now()
+        repository.upsert(
+            KomgaSharedDownloadMatch(
+                serverId = serverId,
+                bookUrl = fingerprint.bookUrl,
+                seriesUrl = fingerprint.seriesUrl,
+                fileHash = fingerprint.fileHash,
+                sizeBytes = fingerprint.sizeBytes,
+                isbn = fingerprint.isbn,
+                seriesTitle = fingerprint.seriesTitle,
+                bookTitle = fingerprint.bookTitle,
+                numberSort = fingerprint.numberSort,
+                localRelativePath = relativePath,
+                fileName = fileName,
+                fileKind = fileKind,
+                createdAt = existing?.createdAt ?: timestamp,
+                lastVerifiedAt = timestamp,
+            ),
+        )
+    }
+
+    private fun resolveLocalRelativePath(relativePath: String): UniFile? {
+        val downloadsDir = storageManager.getDownloadsDirectory() ?: return null
+        return relativePath.split('/')
+            .filter { it.isNotBlank() }
+            .fold(downloadsDir as UniFile?) { current, segment ->
+                current?.findFile(segment)
+            }
+    }
+
+    private fun deleteLocalRelativePath(relativePath: String) {
+        val target = resolveLocalRelativePath(relativePath) ?: return
+        target.delete()
+        pruneEmptyParents(relativePath)
+    }
+
+    private fun pruneEmptyParents(relativePath: String) {
+        val downloadsDir = storageManager.getDownloadsDirectory() ?: return
+        val segments = relativePath.split('/').filter { it.isNotBlank() }
+        if (segments.size < 2) return
+
+        for (depth in segments.size - 1 downTo 1) {
+            val parent = segments.take(depth).fold(downloadsDir as UniFile?) { current, segment ->
+                current?.findFile(segment)
+            } ?: return
+            if (parent.listFiles().orEmpty().isEmpty()) {
+                parent.delete()
+            } else {
+                break
+            }
+        }
+    }
+
+    private fun scheduleWarmup(source: KomgaSource, mangaTitle: String) {
+        val warmupKey = "${source.id}::$mangaTitle"
+        val now = now()
+        val lastWarmupAt = recentWarmups[warmupKey]
+        if (lastWarmupAt != null && now - lastWarmupAt < WARMUP_COOLDOWN_MS) return
+        if (!activeWarmups.add(warmupKey)) return
+
+        warmupJob = scope.launch {
+            runCatching {
+                warmupMangaDownloads(source, mangaTitle)
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Komga shared download warmup failed for sourceId=${source.id} mangaTitle=$mangaTitle"
+                }
+            }.also {
+                recentWarmups[warmupKey] = now()
+                activeWarmups.remove(warmupKey)
+            }
+        }
+    }
+
+    private suspend fun warmupMangaDownloads(
+        source: KomgaSource,
+        mangaTitle: String,
+    ) {
+        val seeds = repository.getChapterSeedsBySourceId(source.id)
+            .filter { it.mangaTitle == mangaTitle }
+        val localDownloadsByName = buildLocalDownloadsByName(mangaTitle)
+
+        seeds.forEach { seed ->
+            val fingerprint = KomgaChapterMemo.readFingerprint(seed.memo)
+                ?: resolveFingerprintForIndexing(
+                    chapterUrl = seed.chapterUrl,
+                    source = source,
+                    chapterId = seed.chapterId,
+                    existingMemo = seed.memo,
+                )
+                ?: return@forEach
+
+            if (repository.findByServerIdAndBookUrl(source.id, fingerprint.bookUrl) != null) {
+                return@forEach
+            }
+
+            val localFile = findExistingLocalDownload(seed, localDownloadsByName) ?: return@forEach
+            val relativePath = relativePathOf(localFile) ?: return@forEach
+            upsertMatch(
+                serverId = source.id,
+                fingerprint = fingerprint,
+                relativePath = relativePath,
+                fileName = localFile.name.orEmpty(),
+                fileKind = if (localFile.isDirectory) FILE_KIND_DIRECTORY else FILE_KIND_FILE,
+            )
+        }
+    }
+
+    private fun buildLocalDownloadsByName(mangaTitle: String): Map<String, UniFile> {
+        val downloadsDir = storageManager.getDownloadsDirectory() ?: return emptyMap()
+        val mangaDirName = getMangaDirName(mangaTitle)
+        val cacheKey = "${downloadsDir.uri}|$mangaDirName"
+
+        mangaDownloadsCache[cacheKey]
+            ?.takeUnless { it.isExpired() }
+            ?.value
+            ?.let { return it }
+
+        return sharedSourceDirs()
+            .asSequence()
+            .mapNotNull { it.findFile(mangaDirName) }
+            .flatMap { mangaDir ->
+                mangaDir.listFiles()
+                    .orEmpty()
+                    .asSequence()
+                    .mapNotNull { file ->
+                        val name = file.name ?: return@mapNotNull null
+                        name to file
+                    }
+            }
+            .distinctBy { (name, _) -> name }
+            .associate { (name, file) -> name to file }
+            .also { files ->
+                mangaDownloadsCache[cacheKey] = CacheEntry(files)
+            }
+    }
+
+    private fun findExistingLocalDownload(
+        seed: KomgaChapterSeed,
+        localDownloadsByName: Map<String, UniFile>,
+    ): UniFile? {
+        return getValidChapterDirNames(seed.chapterName, seed.chapterScanlator, seed.chapterUrl)
+            .asSequence()
+            .mapNotNull(localDownloadsByName::get)
+            .firstOrNull()
+    }
+
+    private fun sharedSourceDirs(): List<UniFile> {
+        val downloadsDir = storageManager.getDownloadsDirectory() ?: return emptyList()
+        val sourceDirNames = buildList {
+            add(KomgaSource.SOURCE_NAME)
+            addAll(legacySharedSourceDirNames())
+        }
+            .distinct()
+        val cacheKey = "${downloadsDir.uri}|${sourceDirNames.joinToString(separator = "|")}"
+
+        sharedSourceDirsCache[cacheKey]
+            ?.takeUnless { it.isExpired() }
+            ?.value
+            ?.let { return it }
+
+        return sourceDirNames
+            .mapNotNull(downloadsDir::findFile)
+            .distinctBy { it.uri.toString() }
+            .also { dirs ->
+                sharedSourceDirsCache[cacheKey] = CacheEntry(dirs)
+            }
+    }
+
+    private fun legacySharedSourceDirNames(): List<String> {
+        return buildList {
+            add(legacySourceDirName(KomgaSource.SOURCE_NAME))
+            komgaServerPreferences.getProfiles().forEach { profile ->
+                add(legacySourceDirName(profile.name))
+            }
+        }.distinct()
+    }
+
+    private fun legacySourceDirName(sourceName: String): String {
+        return DiskUtil.buildValidFilename(
+            "$sourceName (${KomgaSource.SOURCE_LANG.uppercase()})",
+            disallowNonAscii = libraryPreferences.disallowNonAsciiFilenames.get(),
+        )
+    }
+
+    private fun getMangaDirName(mangaTitle: String): String {
+        return DiskUtil.buildValidFilename(
+            mangaTitle,
+            disallowNonAscii = libraryPreferences.disallowNonAsciiFilenames.get(),
+        )
+    }
+
+    private fun getChapterDirName(
+        chapterName: String,
+        chapterScanlator: String?,
+        chapterUrl: String,
+        disallowNonAscii: Boolean = libraryPreferences.disallowNonAsciiFilenames.get(),
+    ): String {
+        var dirName = chapterName.ifBlank { "Chapter" }
+        if (!chapterScanlator.isNullOrBlank()) {
+            dirName = chapterScanlator + "_" + dirName
+        }
+        dirName = DiskUtil.buildValidFilename(dirName, DiskUtil.MAX_FILE_NAME_BYTES - 11, disallowNonAscii)
+        dirName += "_" + md5(chapterUrl).take(6)
+        return dirName
+    }
+
+    private fun getLegacyChapterDirNames(
+        chapterName: String,
+        chapterScanlator: String?,
+        chapterUrl: String,
+    ): List<String> {
+        val sanitizedChapterName = chapterName.ifBlank { "Chapter" }
+        val legacyName = DiskUtil.buildValidFilename(
+            when {
+                !chapterScanlator.isNullOrBlank() -> "${chapterScanlator}_$sanitizedChapterName"
+                else -> sanitizedChapterName
+            },
+        )
+        val otherName = getChapterDirName(
+            chapterName = chapterName,
+            chapterScanlator = chapterScanlator,
+            chapterUrl = chapterUrl,
+            disallowNonAscii = !libraryPreferences.disallowNonAsciiFilenames.get(),
+        )
+        return listOf(legacyName, otherName)
+    }
+
+    private fun getValidChapterDirNames(
+        chapterName: String,
+        chapterScanlator: String?,
+        chapterUrl: String,
+    ): List<String> {
+        val chapterDirName = getChapterDirName(chapterName, chapterScanlator, chapterUrl)
+        val legacyChapterDirNames = getLegacyChapterDirNames(chapterName, chapterScanlator, chapterUrl)
+        return buildList {
+            add(chapterDirName)
+            DownloadProvider.SUPPORTED_CHAPTER_FILE_EXTENSIONS.forEach { extension ->
+                add("$chapterDirName.$extension")
+            }
+            legacyChapterDirNames.forEach { legacyName ->
+                add(legacyName)
+                DownloadProvider.SUPPORTED_CHAPTER_FILE_EXTENSIONS.forEach { extension ->
+                    add("$legacyName.$extension")
+                }
+            }
+        }
+    }
+
+    private fun shouldUseSharedMatching(source: KomgaSource): Boolean {
+        return komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared &&
+            source.hasValidBaseUrl()
+    }
+
+    private fun invalidateLocalLookupCaches() {
+        sharedSourceDirsCache.clear()
+        mangaDownloadsCache.clear()
+    }
+
+    private fun now(): Long = System.currentTimeMillis()
+
+    private data class CacheEntry<T>(
+        val value: T,
+        val cachedAt: Long = System.currentTimeMillis(),
+    ) {
+        fun isExpired(): Boolean {
+            return System.currentTimeMillis() - cachedAt >= LOCAL_LOOKUP_CACHE_TTL_MS
+        }
+    }
+
+    companion object {
+        private const val FILE_KIND_FILE = "file"
+        private const val FILE_KIND_DIRECTORY = "directory"
+        private const val WARMUP_COOLDOWN_MS = 30_000L
+        private const val LOCAL_LOOKUP_CACHE_TTL_MS = 10_000L
+    }
+}
+
+private fun UniFile.documentIdOrNull(): String? {
+    return runCatching {
+        DocumentsContract.getDocumentId(uri)
+    }.getOrElse {
+        runCatching { DocumentsContract.getTreeDocumentId(uri) }.getOrNull()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
@@ -1,0 +1,246 @@
+package eu.kanade.tachiyomi.data.download
+
+import app.cash.sqldelight.async.coroutines.awaitAsList
+import app.cash.sqldelight.async.coroutines.awaitAsOne
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import kotlinx.serialization.json.JsonObject
+import tachiyomi.data.Database
+
+data class KomgaSharedDownloadMatch(
+    val serverId: Long,
+    val bookUrl: String,
+    val seriesUrl: String,
+    val fileHash: String,
+    val sizeBytes: Long,
+    val isbn: String,
+    val seriesTitle: String,
+    val bookTitle: String,
+    val numberSort: Double,
+    val localRelativePath: String,
+    val fileName: String,
+    val fileKind: String,
+    val createdAt: Long,
+    val lastVerifiedAt: Long,
+)
+
+data class KomgaChapterSeed(
+    val chapterId: Long,
+    val chapterUrl: String,
+    val chapterName: String,
+    val chapterScanlator: String?,
+    val memo: JsonObject,
+    val mangaTitle: String,
+    val sourceId: Long,
+)
+
+class KomgaSharedDownloadRepository(
+    private val database: Database,
+) {
+
+    suspend fun findByServerIdAndBookUrl(serverId: Long, bookUrl: String): KomgaSharedDownloadMatch? {
+        return database.komga_shared_download_matchesQueries
+            .findByServerIdAndBookUrl(serverId, bookUrl, ::mapMatch)
+            .awaitAsOneOrNull()
+    }
+
+    suspend fun findByServerId(serverId: Long): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByServerId(serverId, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findByFileHash(fileHash: String): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByFileHash(fileHash, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findByIsbn(isbn: String): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByIsbn(isbn, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findBySeriesNumberSize(
+        seriesTitle: String,
+        numberSort: Double,
+        sizeBytes: Long,
+    ): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findBySeriesNumberSize(seriesTitle, numberSort, sizeBytes, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findByBookTitleSize(bookTitle: String, sizeBytes: Long): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByBookTitleSize(bookTitle, sizeBytes, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findByLocalRelativePath(localRelativePath: String): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByLocalRelativePath(localRelativePath, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun findByLocalRelativePathPrefix(localRelativePathPrefix: String): List<KomgaSharedDownloadMatch> {
+        return database.komga_shared_download_matchesQueries
+            .findByLocalRelativePathPrefix(localRelativePathPrefix, ::mapMatch)
+            .awaitAsList()
+    }
+
+    suspend fun countByLocalRelativePath(localRelativePath: String): Long {
+        return database.komga_shared_download_matchesQueries
+            .countByLocalRelativePath(localRelativePath)
+            .awaitAsOne()
+    }
+
+    suspend fun upsert(match: KomgaSharedDownloadMatch) {
+        database.komga_shared_download_matchesQueries.upsert(
+            serverId = match.serverId,
+            bookUrl = match.bookUrl,
+            seriesUrl = match.seriesUrl,
+            fileHash = match.fileHash,
+            sizeBytes = match.sizeBytes,
+            isbn = match.isbn,
+            seriesTitle = match.seriesTitle,
+            bookTitle = match.bookTitle,
+            numberSort = match.numberSort,
+            localRelativePath = match.localRelativePath,
+            fileName = match.fileName,
+            fileKind = match.fileKind,
+            createdAt = match.createdAt,
+            lastVerifiedAt = match.lastVerifiedAt,
+        )
+    }
+
+    suspend fun deleteByServerId(serverId: Long) {
+        database.komga_shared_download_matchesQueries.deleteByServerId(serverId)
+    }
+
+    suspend fun deleteByServerIdAndBookUrl(serverId: Long, bookUrl: String) {
+        database.komga_shared_download_matchesQueries.deleteByServerIdAndBookUrl(serverId, bookUrl)
+    }
+
+    suspend fun deleteByLocalRelativePath(localRelativePath: String) {
+        database.komga_shared_download_matchesQueries.deleteByLocalRelativePath(localRelativePath)
+    }
+
+    suspend fun updateLocalRelativePath(
+        oldLocalRelativePath: String,
+        newLocalRelativePath: String,
+        newFileName: String,
+        lastVerifiedAt: Long,
+    ) {
+        database.komga_shared_download_matchesQueries.updateLocalRelativePath(
+            oldLocalRelativePath = oldLocalRelativePath,
+            newLocalRelativePath = newLocalRelativePath,
+            newFileName = newFileName,
+            lastVerifiedAt = lastVerifiedAt,
+        )
+    }
+
+    suspend fun updateLocalRelativePathPrefix(
+        oldPrefix: String,
+        newPrefix: String,
+        lastVerifiedAt: Long,
+    ) {
+        database.komga_shared_download_matchesQueries.updateLocalRelativePathPrefix(
+            oldPrefix = oldPrefix,
+            newPrefix = newPrefix,
+            lastVerifiedAt = lastVerifiedAt,
+        )
+    }
+
+    suspend fun getChapterSeedByUrl(chapterUrl: String): KomgaChapterSeed? {
+        return database.komga_shared_download_matchesQueries
+            .getKomgaChapterSeedByUrl(chapterUrl, ::mapChapterSeed)
+            .awaitAsOneOrNull()
+    }
+
+    suspend fun getChapterSeedsBySourceId(sourceId: Long): List<KomgaChapterSeed> {
+        return database.komga_shared_download_matchesQueries
+            .getKomgaChapterSeedsBySourceId(sourceId, ::mapWarmupChapterSeed)
+            .awaitAsList()
+    }
+
+    suspend fun updateChapterMemo(chapterId: Long, memo: JsonObject) {
+        database.komga_shared_download_matchesQueries.updateChapterMemoOnly(
+            memo = memo,
+            chapterId = chapterId,
+        )
+    }
+
+    private fun mapMatch(
+        serverId: Long,
+        bookUrl: String,
+        seriesUrl: String,
+        fileHash: String,
+        sizeBytes: Long,
+        isbn: String,
+        seriesTitle: String,
+        bookTitle: String,
+        numberSort: Double,
+        localRelativePath: String,
+        fileName: String,
+        fileKind: String,
+        createdAt: Long,
+        lastVerifiedAt: Long,
+    ): KomgaSharedDownloadMatch {
+        return KomgaSharedDownloadMatch(
+            serverId = serverId,
+            bookUrl = bookUrl,
+            seriesUrl = seriesUrl,
+            fileHash = fileHash,
+            sizeBytes = sizeBytes,
+            isbn = isbn,
+            seriesTitle = seriesTitle,
+            bookTitle = bookTitle,
+            numberSort = numberSort,
+            localRelativePath = localRelativePath,
+            fileName = fileName,
+            fileKind = fileKind,
+            createdAt = createdAt,
+            lastVerifiedAt = lastVerifiedAt,
+        )
+    }
+
+    private fun mapChapterSeed(
+        chapterId: Long,
+        chapterUrl: String,
+        chapterName: String,
+        chapterScanlator: String?,
+        memo: JsonObject,
+        mangaTitle: String,
+        sourceId: Long,
+    ): KomgaChapterSeed {
+        return KomgaChapterSeed(
+            chapterId = chapterId,
+            chapterUrl = chapterUrl,
+            chapterName = chapterName,
+            chapterScanlator = chapterScanlator,
+            memo = memo,
+            mangaTitle = mangaTitle,
+            sourceId = sourceId,
+        )
+    }
+
+    private fun mapWarmupChapterSeed(
+        chapterId: Long,
+        chapterUrl: String,
+        chapterName: String,
+        chapterScanlator: String?,
+        memo: JsonObject,
+        mangaTitle: String,
+    ): KomgaChapterSeed {
+        return KomgaChapterSeed(
+            chapterId = chapterId,
+            chapterUrl = chapterUrl,
+            chapterName = chapterName,
+            chapterScanlator = chapterScanlator,
+            memo = memo,
+            mangaTitle = mangaTitle,
+            sourceId = -1L,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
@@ -147,6 +147,7 @@ class KomgaSharedDownloadRepository(
     ) {
         database.komga_shared_download_matchesQueries.updateLocalRelativePathPrefix(
             oldPrefix = oldPrefix,
+            oldPrefixLength = oldPrefix.length.toString(),
             newPrefix = newPrefix,
             lastVerifiedAt = lastVerifiedAt,
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/KomgaSharedDownloadRepository.kt
@@ -165,6 +165,12 @@ class KomgaSharedDownloadRepository(
             .awaitAsList()
     }
 
+    suspend fun getChapterSeedsByMangaId(mangaId: Long, sourceId: Long): List<KomgaChapterSeed> {
+        return database.komga_shared_download_matchesQueries
+            .getKomgaChapterSeedsByMangaId(mangaId, sourceId, ::mapChapterSeed)
+            .awaitAsList()
+    }
+
     suspend fun updateChapterMemo(chapterId: Long, memo: JsonObject) {
         database.komga_shared_download_matchesQueries.updateChapterMemoOnly(
             memo = memo,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/DeferredSharedPreferencesDataStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/DeferredSharedPreferencesDataStore.kt
@@ -9,92 +9,124 @@ class DeferredSharedPreferencesDataStore(
 ) : PreferenceDataStore() {
 
     private val cache = mutableMapOf<String, Any?>()
+    private val lock = Any()
 
+    @Volatile
     var hasUnsavedChanges = false
         private set
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
-        return cache[key] as? Boolean ?: prefs.getBoolean(key, defValue)
+        return synchronized(lock) {
+            cache[key] as? Boolean ?: prefs.getBoolean(key, defValue)
+        }
     }
 
     override fun putBoolean(key: String, value: Boolean) {
-        if (getBoolean(key, false) != value || !cache.containsKey(key)) {
-            cache[key] = value
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getBoolean(key, false) != value || !cache.containsKey(key)) {
+                cache[key] = value
+                hasUnsavedChanges = true
+            }
         }
     }
 
     override fun getInt(key: String, defValue: Int): Int {
-        return cache[key] as? Int ?: prefs.getInt(key, defValue)
+        return synchronized(lock) {
+            cache[key] as? Int ?: prefs.getInt(key, defValue)
+        }
     }
 
     override fun putInt(key: String, value: Int) {
-        if (getInt(key, 0) != value || !cache.containsKey(key)) {
-            cache[key] = value
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getInt(key, 0) != value || !cache.containsKey(key)) {
+                cache[key] = value
+                hasUnsavedChanges = true
+            }
         }
     }
 
     override fun getLong(key: String, defValue: Long): Long {
-        return cache[key] as? Long ?: prefs.getLong(key, defValue)
+        return synchronized(lock) {
+            cache[key] as? Long ?: prefs.getLong(key, defValue)
+        }
     }
 
     override fun putLong(key: String, value: Long) {
-        if (getLong(key, 0L) != value || !cache.containsKey(key)) {
-            cache[key] = value
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getLong(key, 0L) != value || !cache.containsKey(key)) {
+                cache[key] = value
+                hasUnsavedChanges = true
+            }
         }
     }
 
     override fun getFloat(key: String, defValue: Float): Float {
-        return cache[key] as? Float ?: prefs.getFloat(key, defValue)
+        return synchronized(lock) {
+            cache[key] as? Float ?: prefs.getFloat(key, defValue)
+        }
     }
 
     override fun putFloat(key: String, value: Float) {
-        if (getFloat(key, 0f) != value || !cache.containsKey(key)) {
-            cache[key] = value
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getFloat(key, 0f) != value || !cache.containsKey(key)) {
+                cache[key] = value
+                hasUnsavedChanges = true
+            }
         }
     }
 
     override fun getString(key: String, defValue: String?): String? {
-        return if (cache.containsKey(key)) {
-            cache[key] as? String
-        } else {
-            prefs.getString(key, defValue)
+        return synchronized(lock) {
+            if (cache.containsKey(key)) {
+                cache[key] as? String
+            } else {
+                prefs.getString(key, defValue)
+            }
         }
     }
 
     override fun putString(key: String, value: String?) {
-        if (getString(key, null) != value || !cache.containsKey(key)) {
-            cache[key] = value
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getString(key, null) != value || !cache.containsKey(key)) {
+                cache[key] = value
+                hasUnsavedChanges = true
+            }
         }
     }
 
     @Suppress("UNCHECKED_CAST")
     override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? {
-        return if (cache.containsKey(key)) {
-            cache[key] as? MutableSet<String>
-        } else {
-            prefs.getStringSet(key, defValues)
+        return synchronized(lock) {
+            if (cache.containsKey(key)) {
+                (cache[key] as? Set<String>)?.toMutableSet()
+            } else {
+                prefs.getStringSet(key, defValues)?.toMutableSet()
+            }
         }
     }
 
     override fun putStringSet(key: String, values: MutableSet<String>?) {
         // Deep copy the set to prevent external modifications bypassing the data store
         val copy = values?.toMutableSet()
-        if (getStringSet(key, null) != copy || !cache.containsKey(key)) {
-            cache[key] = copy
-            hasUnsavedChanges = true
+        synchronized(lock) {
+            if (getStringSet(key, null) != copy || !cache.containsKey(key)) {
+                cache[key] = copy
+                hasUnsavedChanges = true
+            }
         }
     }
 
     @Suppress("UNCHECKED_CAST")
     fun applyChanges() {
-        if (!hasUnsavedChanges) return
+        val changes = synchronized(lock) {
+            if (!hasUnsavedChanges) return
+            cache.toMap().also {
+                cache.clear()
+                hasUnsavedChanges = false
+            }
+        }
         prefs.edit {
-            cache.forEach { (k, v) ->
+            changes.forEach { (k, v) ->
                 when (v) {
                     is Boolean -> putBoolean(k, v)
                     is Int -> putInt(k, v)
@@ -105,7 +137,5 @@ class DeferredSharedPreferencesDataStore(
                 }
             }
         }
-        cache.clear()
-        hasUnsavedChanges = false
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/DeferredSharedPreferencesDataStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/DeferredSharedPreferencesDataStore.kt
@@ -1,0 +1,111 @@
+package eu.kanade.tachiyomi.data.preference
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import androidx.preference.PreferenceDataStore
+
+class DeferredSharedPreferencesDataStore(
+    private val prefs: SharedPreferences,
+) : PreferenceDataStore() {
+
+    private val cache = mutableMapOf<String, Any?>()
+
+    var hasUnsavedChanges = false
+        private set
+
+    override fun getBoolean(key: String, defValue: Boolean): Boolean {
+        return cache[key] as? Boolean ?: prefs.getBoolean(key, defValue)
+    }
+
+    override fun putBoolean(key: String, value: Boolean) {
+        if (getBoolean(key, false) != value || !cache.containsKey(key)) {
+            cache[key] = value
+            hasUnsavedChanges = true
+        }
+    }
+
+    override fun getInt(key: String, defValue: Int): Int {
+        return cache[key] as? Int ?: prefs.getInt(key, defValue)
+    }
+
+    override fun putInt(key: String, value: Int) {
+        if (getInt(key, 0) != value || !cache.containsKey(key)) {
+            cache[key] = value
+            hasUnsavedChanges = true
+        }
+    }
+
+    override fun getLong(key: String, defValue: Long): Long {
+        return cache[key] as? Long ?: prefs.getLong(key, defValue)
+    }
+
+    override fun putLong(key: String, value: Long) {
+        if (getLong(key, 0L) != value || !cache.containsKey(key)) {
+            cache[key] = value
+            hasUnsavedChanges = true
+        }
+    }
+
+    override fun getFloat(key: String, defValue: Float): Float {
+        return cache[key] as? Float ?: prefs.getFloat(key, defValue)
+    }
+
+    override fun putFloat(key: String, value: Float) {
+        if (getFloat(key, 0f) != value || !cache.containsKey(key)) {
+            cache[key] = value
+            hasUnsavedChanges = true
+        }
+    }
+
+    override fun getString(key: String, defValue: String?): String? {
+        return if (cache.containsKey(key)) {
+            cache[key] as? String
+        } else {
+            prefs.getString(key, defValue)
+        }
+    }
+
+    override fun putString(key: String, value: String?) {
+        if (getString(key, null) != value || !cache.containsKey(key)) {
+            cache[key] = value
+            hasUnsavedChanges = true
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? {
+        return if (cache.containsKey(key)) {
+            cache[key] as? MutableSet<String>
+        } else {
+            prefs.getStringSet(key, defValues)
+        }
+    }
+
+    override fun putStringSet(key: String, values: MutableSet<String>?) {
+        // Deep copy the set to prevent external modifications bypassing the data store
+        val copy = values?.toMutableSet()
+        if (getStringSet(key, null) != copy || !cache.containsKey(key)) {
+            cache[key] = copy
+            hasUnsavedChanges = true
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun applyChanges() {
+        if (!hasUnsavedChanges) return
+        prefs.edit {
+            cache.forEach { (k, v) ->
+                when (v) {
+                    is Boolean -> putBoolean(k, v)
+                    is Int -> putInt(k, v)
+                    is Float -> putFloat(k, v)
+                    is Long -> putLong(k, v)
+                    is String -> putString(k, v)
+                    is Set<*> -> putStringSet(k, v as Set<String>)
+                }
+            }
+        }
+        cache.clear()
+        hasUnsavedChanges = false
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -15,6 +15,8 @@ import eu.kanade.tachiyomi.data.cache.LocalCacheCleaner
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadIndexManager
+import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadRepository
 import eu.kanade.tachiyomi.data.saver.ImageSaver
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.network.JavaScriptEngine
@@ -128,6 +130,8 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { DownloadProvider(app) }
         addSingletonFactory { DownloadManager(app) }
         addSingletonFactory { DownloadCache(app) }
+        addSingletonFactory { KomgaSharedDownloadRepository(get()) }
+        addSingletonFactory { KomgaSharedDownloadIndexManager(get(), get(), get(), get()) }
 
         addSingletonFactory { TrackerManager() }
         addSingletonFactory { DelayedTrackingStore(app) }

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.system.isDebugBuildType
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaServerPreferences
+import koharia.source.komga.KomgaServerRemovalManager
 import tachiyomi.core.common.preference.AndroidPreferenceStore
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.ScopedPreferenceStore
@@ -46,6 +47,15 @@ class PreferenceModule(val app: Application) : InjektModule {
             ScopedPreferenceStore(
                 preferenceStore = get<PreferenceStore>(),
                 scopeProvider = get<KomgaLocalConfigManager>(),
+            )
+        }
+        addSingletonFactory {
+            KomgaServerRemovalManager(
+                serverPreferences = get<KomgaServerPreferences>(),
+                localConfigManager = get<KomgaLocalConfigManager>(),
+                downloadProvider = get(),
+                downloadCache = get(),
+                komgaSharedDownloadIndexManager = get(),
             )
         }
         addSingletonFactory {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourcePreferencesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourcePreferencesScreen.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -44,9 +45,15 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
+object DataStoreHolder {
+    var dataStore: androidx.preference.PreferenceDataStore? = null
+}
+
 class SourcePreferencesScreen(
     val sourceId: Long,
     private val titleOverride: String? = null,
+    private val actions: @Composable RowScope.() -> Unit = {},
+    private val navigateUpOverride: (() -> Unit)? = null,
 ) : Screen() {
 
     @Composable
@@ -63,8 +70,11 @@ class SourcePreferencesScreen(
             topBar = {
                 AppBar(
                     title = titleOverride ?: Injekt.get<SourceManager>().getOrStub(sourceId).toString(),
-                    navigateUp = navigator::pop,
+                    navigateUp = {
+                        if (navigateUpOverride != null) navigateUpOverride.invoke() else navigator.pop()
+                    },
                     scrollBehavior = it,
+                    actions = actions,
                 )
             },
         ) { contentPadding ->
@@ -139,7 +149,7 @@ class SourcePreferencesFragment : PreferenceFragmentCompat() {
         val sourceScreen = preferenceManager.createPreferenceScreen(requireContext())
 
         if (source is ConfigurableSource) {
-            val dataStore = SharedPreferencesDataStore(source.sourcePreferences())
+            val dataStore = DataStoreHolder.dataStore ?: SharedPreferencesDataStore(source.sourcePreferences())
             preferenceManager.preferenceDataStore = dataStore
 
             source.setupPreferenceScreen(sourceScreen)

--- a/app/src/main/java/koharia/komga/api/dto/Dto.kt
+++ b/app/src/main/java/koharia/komga/api/dto/Dto.kt
@@ -1,6 +1,7 @@
 package koharia.komga.api.dto
 
 import eu.kanade.tachiyomi.source.model.SManga
+import koharia.komga.download.KomgaChapterMemo
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -165,6 +166,7 @@ data class BookDto(
     val created: String? = null,
     val lastModified: String? = null,
     val fileLastModified: String,
+    val fileHash: String? = null,
     val sizeBytes: Long = 0,
     val size: String = "",
     val media: MediaDto = MediaDto(),
@@ -222,6 +224,8 @@ fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     author = metadata.authors.joinToString { it.name }
     artist = author
 }
+
+fun BookDto.toChapterMemo(baseUrl: String): JsonObject = KomgaChapterMemo.buildMemo(baseUrl, this)
 
 fun ReadListDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     title = name

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -15,6 +15,7 @@ import koharia.komga.api.dto.PageDto
 import koharia.komga.api.dto.ReadListDto
 import koharia.komga.api.dto.SeriesDto
 import koharia.komga.api.dto.formatChapterName
+import koharia.komga.api.dto.toChapterMemo
 import koharia.komga.api.dto.toSManga
 import koharia.source.komga.AuthorGroup
 import koharia.source.komga.CollectionSelect
@@ -168,6 +169,7 @@ class KomgaRepository(
             url = "$baseUrl/api/v1/books/$id"
             name = formatChapterName(chapterNameTemplate, isFromReadList)
             scanlator = metadata.authors.filter { it.role == "translator" }.joinToString { it.name }
+            memo = toChapterMemo(baseUrl)
             date_upload = when {
                 metadata.releaseDate != null -> parseDate(metadata.releaseDate)
                 created != null -> parseDateTime(created)

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -1,0 +1,113 @@
+package koharia.komga.download
+
+import koharia.komga.api.dto.BookDto
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+data class KomgaBookFingerprint(
+    val bookUrl: String,
+    val seriesUrl: String,
+    val fileHash: String,
+    val sizeBytes: Long,
+    val seriesTitle: String,
+    val bookTitle: String,
+    val numberSort: Double,
+    val isbn: String,
+)
+
+object KomgaChapterMemo {
+    const val BOOK_URL = "bookUrl"
+    const val SERIES_URL = "seriesUrl"
+    const val FILE_HASH = "fileHash"
+    const val SIZE_BYTES = "sizeBytes"
+    const val SERIES_TITLE = "seriesTitle"
+    const val BOOK_TITLE = "bookTitle"
+    const val NUMBER_SORT = "numberSort"
+    const val ISBN = "isbn"
+
+    fun buildFingerprint(baseUrl: String, book: BookDto): KomgaBookFingerprint {
+        return KomgaBookFingerprint(
+            bookUrl = "$baseUrl/api/v1/books/${book.id}",
+            seriesUrl = book.seriesId.takeIf { it.isNotBlank() }?.let { "$baseUrl/api/v1/series/$it" }.orEmpty(),
+            fileHash = book.fileHash.orEmpty(),
+            sizeBytes = book.sizeBytes,
+            seriesTitle = book.seriesTitle,
+            bookTitle = book.metadata.title,
+            numberSort = book.metadata.numberSort.toDouble(),
+            isbn = book.metadata.isbn,
+        )
+    }
+
+    fun buildMemo(baseUrl: String, book: BookDto): JsonObject {
+        return buildMemo(buildFingerprint(baseUrl, book))
+    }
+
+    fun buildMemo(fingerprint: KomgaBookFingerprint): JsonObject {
+        return buildJsonObject {
+            put(BOOK_URL, fingerprint.bookUrl)
+            if (fingerprint.seriesUrl.isNotBlank()) {
+                put(SERIES_URL, fingerprint.seriesUrl)
+            }
+            if (fingerprint.fileHash.isNotBlank()) {
+                put(FILE_HASH, fingerprint.fileHash)
+            }
+            if (fingerprint.sizeBytes > 0L) {
+                put(SIZE_BYTES, fingerprint.sizeBytes)
+            }
+            if (fingerprint.seriesTitle.isNotBlank()) {
+                put(SERIES_TITLE, fingerprint.seriesTitle)
+            }
+            if (fingerprint.bookTitle.isNotBlank()) {
+                put(BOOK_TITLE, fingerprint.bookTitle)
+            }
+            put(NUMBER_SORT, fingerprint.numberSort)
+            if (fingerprint.isbn.isNotBlank()) {
+                put(ISBN, fingerprint.isbn)
+            }
+        }
+    }
+
+    fun mergeInto(
+        existing: JsonObject,
+        fingerprint: KomgaBookFingerprint,
+    ): JsonObject {
+        val additions = buildMemo(fingerprint)
+        if (additions.isEmpty()) return existing
+        return buildJsonObject {
+            existing.forEach { (key, value) -> put(key, value) }
+            additions.forEach { (key, value) -> put(key, value) }
+        }
+    }
+
+    fun readFingerprint(memo: JsonObject): KomgaBookFingerprint? {
+        val bookUrl = memo.string(BOOK_URL).orEmpty()
+        if (bookUrl.isBlank()) return null
+
+        return KomgaBookFingerprint(
+            bookUrl = bookUrl,
+            seriesUrl = memo.string(SERIES_URL).orEmpty(),
+            fileHash = memo.string(FILE_HASH).orEmpty(),
+            sizeBytes = memo.long(SIZE_BYTES) ?: 0L,
+            seriesTitle = memo.string(SERIES_TITLE).orEmpty(),
+            bookTitle = memo.string(BOOK_TITLE).orEmpty(),
+            numberSort = memo.double(NUMBER_SORT) ?: 0.0,
+            isbn = memo.string(ISBN).orEmpty(),
+        )
+    }
+
+    private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull()
+
+    private fun JsonObject.long(key: String): Long? = this[key]?.jsonPrimitive?.longOrNull
+
+    private fun JsonObject.double(key: String): Double? = this[key]?.jsonPrimitive?.doubleOrNull
+
+    private fun kotlinx.serialization.json.JsonPrimitive.contentOrNull(): String? {
+        return content.takeIf { it.isNotBlank() }
+    }
+
+    private val kotlinx.serialization.json.JsonPrimitive.longOrNull: Long?
+        get() = content.toLongOrNull()
+}

--- a/app/src/main/java/koharia/source/komga/DownloadCleanupMode.kt
+++ b/app/src/main/java/koharia/source/komga/DownloadCleanupMode.kt
@@ -1,0 +1,7 @@
+package koharia.source.komga
+
+enum class DownloadCleanupMode {
+    Preserve,
+    DeleteExclusiveMatches,
+    DeleteAllMatchedFiles,
+}

--- a/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
@@ -119,6 +119,24 @@ class KomgaLocalConfigManager(
         )
     }
 
+    fun clearScopeForServer(serverId: Long) {
+        if (serverPreferences.localConfigMode.get() != LocalConfigMode.Separate) {
+            logcat(LogPriority.DEBUG) {
+                "Skipping scoped config cleanup for serverId=$serverId because local config mode is shared"
+            }
+            return
+        }
+
+        val targetPrefix = serverScopePrefix(serverId)
+        val keysToDelete = preferenceStore.getAll().keys.filter { it.startsWith(targetPrefix) }
+        if (keysToDelete.isEmpty()) return
+
+        logcat(LogPriority.DEBUG) {
+            "Clearing ${keysToDelete.size} scoped preference entries for serverId=$serverId in scope $targetPrefix"
+        }
+        keysToDelete.forEach { preferenceStore.getString(it).delete() }
+    }
+
     private fun cloneSharedScopeToProfiles(profiles: List<KomgaServerProfile>) {
         if (profiles.isEmpty()) return
 

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -62,6 +62,7 @@ class KomgaServerProfilesScreen : Screen() {
         val navigator = LocalNavigator.currentOrThrow
         val serverPreferences = remember { Injekt.get<KomgaServerPreferences>() }
         val localConfigManager = remember { Injekt.get<KomgaLocalConfigManager>() }
+        val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
         val profiles by serverPreferences.profilesChanges().collectAsState(initial = serverPreferences.getProfiles())
         val activeServerId by serverPreferences.activeServerId.collectAsState()
         val localConfigMode by serverPreferences.localConfigMode.collectAsState()
@@ -71,6 +72,8 @@ class KomgaServerProfilesScreen : Screen() {
         var showModeHelpDialog by rememberSaveable { mutableStateOf(false) }
         var pendingServerName by rememberSaveable { mutableStateOf<String?>(null) }
         var profileToDelete by remember { mutableStateOf<KomgaServerProfile?>(null) }
+        val addServerTitle = stringResource(MR.strings.komga_server_settings_add_title)
+        val editServerTitle = stringResource(MR.strings.komga_server_settings_edit_title)
 
         fun createServer(name: String) {
             val newProfile = KomgaServerProfile(
@@ -83,7 +86,8 @@ class KomgaServerProfilesScreen : Screen() {
             navigator.push(
                 KomgaServerSettingsScreen(
                     sourceId = newProfile.id,
-                    titleOverride = newProfile.name,
+                    titleOverride = addServerTitle,
+                    isNew = true,
                 ),
             )
         }
@@ -178,19 +182,11 @@ class KomgaServerProfilesScreen : Screen() {
                             profile = profile,
                             isActive = activeServerId == profile.id,
                             onSelect = { serverPreferences.activeServerId.set(profile.id) },
-                            onOpen = {
-                                navigator.push(
-                                    KomgaServerSettingsScreen(
-                                        sourceId = profile.id,
-                                        titleOverride = profile.name,
-                                    ),
-                                )
-                            },
                             onEdit = {
                                 navigator.push(
                                     KomgaServerSettingsScreen(
                                         sourceId = profile.id,
-                                        titleOverride = profile.name,
+                                        titleOverride = editServerTitle,
                                     ),
                                 )
                             },
@@ -241,14 +237,7 @@ class KomgaServerProfilesScreen : Screen() {
                 serverName = profile.name,
                 onDismissRequest = { profileToDelete = null },
                 onDelete = {
-                    val remainingProfiles = profiles.filterNot { it.id == profile.id }
-                    serverPreferences.setProfiles(remainingProfiles)
-                    when {
-                        remainingProfiles.isEmpty() ->
-                            serverPreferences.activeServerId.set(KomgaServerPreferences.NO_ACTIVE_SERVER)
-                        activeServerId == profile.id ->
-                            serverPreferences.activeServerId.set(remainingProfiles.first().id)
-                    }
+                    serverRemovalManager.removeServer(profile.id)
                     profileToDelete = null
                 },
             )
@@ -296,7 +285,6 @@ private fun ServerRow(
     profile: KomgaServerProfile,
     isActive: Boolean,
     onSelect: () -> Unit,
-    onOpen: () -> Unit,
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -321,7 +309,7 @@ private fun ServerRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onOpen)
+                .clickable(onClick = onSelect)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,6 +45,7 @@ import eu.kanade.presentation.more.settings.widget.PreferenceGroupHeader
 import eu.kanade.presentation.util.Screen
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import me.saket.swipe.SwipeAction
 import me.saket.swipe.SwipeableActionsBox
 import tachiyomi.i18n.MR
@@ -67,6 +69,7 @@ class KomgaServerProfilesScreen : Screen() {
         val activeServerId by serverPreferences.activeServerId.collectAsState()
         val localConfigMode by serverPreferences.localConfigMode.collectAsState()
         val downloadDirectoryMode by serverPreferences.downloadDirectoryMode.collectAsState()
+        val scope = rememberCoroutineScope()
 
         var showAddDialog by rememberSaveable { mutableStateOf(false) }
         var showModeHelpDialog by rememberSaveable { mutableStateOf(false) }
@@ -237,8 +240,10 @@ class KomgaServerProfilesScreen : Screen() {
                 serverName = profile.name,
                 onDismissRequest = { profileToDelete = null },
                 onDelete = {
-                    serverRemovalManager.removeServer(profile.id)
-                    profileToDelete = null
+                    scope.launch {
+                        serverRemovalManager.removeServer(profile.id)
+                        profileToDelete = null
+                    }
                 },
             )
         }

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -4,7 +4,8 @@ import androidx.core.content.edit
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadIndexManager
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 
@@ -16,18 +17,18 @@ class KomgaServerRemovalManager(
     private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager,
 ) {
 
-    fun removeServer(
+    suspend fun removeServer(
         serverId: Long,
         options: DownloadCleanupMode = DownloadCleanupMode.Preserve,
     ) {
         val currentProfiles = serverPreferences.getProfiles()
         val profile = currentProfiles.find { it.id == serverId } ?: return
 
-        clearServerSettingsIfNeeded(serverId)
-        runBlocking {
+        withContext(Dispatchers.IO) {
+            clearServerSettingsIfNeeded(serverId)
             cleanupDownloads(profile, options)
+            localConfigManager.clearScopeForServer(serverId)
         }
-        localConfigManager.clearScopeForServer(serverId)
         serverPreferences.setProfiles(currentProfiles - profile)
 
         logcat(LogPriority.DEBUG) {

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -1,0 +1,78 @@
+package koharia.source.komga
+
+import androidx.core.content.edit
+import eu.kanade.tachiyomi.data.download.DownloadCache
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadIndexManager
+import kotlinx.coroutines.runBlocking
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+
+class KomgaServerRemovalManager(
+    private val serverPreferences: KomgaServerPreferences,
+    private val localConfigManager: KomgaLocalConfigManager,
+    private val downloadProvider: DownloadProvider,
+    private val downloadCache: DownloadCache,
+    private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager,
+) {
+
+    fun removeServer(
+        serverId: Long,
+        options: DownloadCleanupMode = DownloadCleanupMode.Preserve,
+    ) {
+        val currentProfiles = serverPreferences.getProfiles()
+        val profile = currentProfiles.find { it.id == serverId } ?: return
+
+        clearServerSettingsIfNeeded(serverId)
+        runBlocking {
+            cleanupDownloads(profile, options)
+        }
+        localConfigManager.clearScopeForServer(serverId)
+        serverPreferences.setProfiles(currentProfiles - profile)
+
+        logcat(LogPriority.DEBUG) {
+            "Removed Komga server id=$serverId name=${profile.name} " +
+                "(localConfigMode=${serverPreferences.localConfigMode.get()}, " +
+                "downloadDirectoryMode=${serverPreferences.downloadDirectoryMode.get()}, " +
+                "cleanupMode=$options)"
+        }
+    }
+
+    private fun clearServerSettingsIfNeeded(serverId: Long) {
+        if (serverPreferences.localConfigMode.get() == LocalConfigMode.Shared) {
+            logcat(LogPriority.DEBUG) {
+                "Skipping persisted source settings cleanup for Komga server id=$serverId because local config mode is shared"
+            }
+            return
+        }
+
+        eu.kanade.tachiyomi.source.sourcePreferences("source_$serverId")
+            .edit { clear() }
+
+        logcat(LogPriority.DEBUG) {
+            "Cleared persisted source settings for Komga server id=$serverId (downloads preserved)"
+        }
+    }
+
+    private suspend fun cleanupDownloads(
+        profile: KomgaServerProfile,
+        mode: DownloadCleanupMode,
+    ) {
+        when (mode) {
+            DownloadCleanupMode.Preserve -> {
+                komgaSharedDownloadIndexManager.removeServerIndexes(profile.id)
+            }
+            else -> {
+                if (serverPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared) {
+                    komgaSharedDownloadIndexManager.cleanupServerDownloads(profile.id, mode)
+                } else {
+                    val source = KomgaSource(profile.id, profile.name)
+                    downloadProvider.findSourceDir(source)?.delete()
+                    downloadCache.removeSource(source)
+                    komgaSharedDownloadIndexManager.removeServerIndexes(profile.id)
+                }
+            }
+        }
+        downloadCache.invalidateCache()
+    }
+}

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -23,6 +24,7 @@ import eu.kanade.tachiyomi.data.preference.DeferredSharedPreferencesDataStore
 import eu.kanade.tachiyomi.source.sourcePreferences
 import eu.kanade.tachiyomi.ui.source.DataStoreHolder
 import eu.kanade.tachiyomi.ui.source.SourcePreferencesScreen
+import kotlinx.coroutines.launch
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
@@ -41,6 +43,7 @@ class KomgaServerSettingsScreen(
         var showUnsavedDialog by rememberSaveable { mutableStateOf(false) }
         val navigator = LocalNavigator.currentOrThrow
         val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
+        val scope = rememberCoroutineScope()
 
         val komgaSource = remember(sourceId) {
             Injekt.get<SourceManager>().getOrStub(sourceId) as? KomgaSource
@@ -58,14 +61,20 @@ class KomgaServerSettingsScreen(
             }
         }
 
-        fun onCancel() {
-            if (deferredDataStore?.hasUnsavedChanges == true) {
-                showUnsavedDialog = true
-            } else {
+        fun discardAndPop() {
+            scope.launch {
                 if (isNew) {
                     serverRemovalManager.removeServer(sourceId)
                 }
                 navigator.pop()
+            }
+        }
+
+        fun onCancel() {
+            if (deferredDataStore?.hasUnsavedChanges == true) {
+                showUnsavedDialog = true
+            } else {
+                discardAndPop()
             }
         }
 
@@ -104,10 +113,7 @@ class KomgaServerSettingsScreen(
                 confirmButton = {
                     TextButton(onClick = {
                         showUnsavedDialog = false
-                        if (isNew) {
-                            serverRemovalManager.removeServer(sourceId)
-                        }
-                        navigator.pop()
+                        discardAndPop()
                     }) {
                         Text(text = stringResource(MR.strings.komga_action_discard))
                     }

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -1,21 +1,136 @@
 package koharia.source.komga
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.data.preference.DeferredSharedPreferencesDataStore
+import eu.kanade.tachiyomi.source.sourcePreferences
+import eu.kanade.tachiyomi.ui.source.DataStoreHolder
 import eu.kanade.tachiyomi.ui.source.SourcePreferencesScreen
+import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class KomgaServerSettingsScreen(
     private val sourceId: Long,
     private val titleOverride: String? = null,
+    private val isNew: Boolean = false,
 ) : Screen() {
 
     @Composable
     override fun Content() {
+        var showHelpDialog by rememberSaveable { mutableStateOf(false) }
+        var showUnsavedDialog by rememberSaveable { mutableStateOf(false) }
+        val navigator = LocalNavigator.currentOrThrow
+        val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
+
+        val komgaSource = remember(sourceId) {
+            Injekt.get<SourceManager>().getOrStub(sourceId) as? KomgaSource
+        }
+
+        val deferredDataStore = remember(komgaSource) {
+            val prefs = komgaSource?.sourcePreferences() ?: return@remember null
+            DeferredSharedPreferencesDataStore(prefs)
+        }
+
+        DisposableEffect(deferredDataStore) {
+            DataStoreHolder.dataStore = deferredDataStore
+            onDispose {
+                DataStoreHolder.dataStore = null
+            }
+        }
+
+        fun onCancel() {
+            if (deferredDataStore?.hasUnsavedChanges == true) {
+                showUnsavedDialog = true
+            } else {
+                if (isNew) {
+                    serverRemovalManager.removeServer(sourceId)
+                }
+                navigator.pop()
+            }
+        }
+
+        BackHandler {
+            onCancel()
+        }
+
         SourcePreferencesScreen(
             sourceId = sourceId,
             titleOverride = titleOverride ?: stringResource(MR.strings.pref_komga_server),
+            navigateUpOverride = { onCancel() },
+            actions = {
+                IconButton(onClick = { showHelpDialog = true }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
+                        contentDescription = stringResource(MR.strings.komga_server_settings_help_title),
+                    )
+                }
+                IconButton(onClick = {
+                    deferredDataStore?.applyChanges()
+                    navigator.pop()
+                }) {
+                    Icon(
+                        imageVector = Icons.Default.Save,
+                        contentDescription = stringResource(MR.strings.action_save),
+                    )
+                }
+            },
         ).Content()
+
+        if (showUnsavedDialog) {
+            AlertDialog(
+                onDismissRequest = { showUnsavedDialog = false },
+                title = { Text(text = stringResource(MR.strings.komga_unsaved_changes_title)) },
+                text = { Text(text = stringResource(MR.strings.komga_unsaved_changes_message)) },
+                confirmButton = {
+                    TextButton(onClick = {
+                        showUnsavedDialog = false
+                        if (isNew) {
+                            serverRemovalManager.removeServer(sourceId)
+                        }
+                        navigator.pop()
+                    }) {
+                        Text(text = stringResource(MR.strings.komga_action_discard))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showUnsavedDialog = false }) {
+                        Text(text = stringResource(MR.strings.action_cancel))
+                    }
+                },
+            )
+        }
+
+        if (showHelpDialog) {
+            AlertDialog(
+                onDismissRequest = { showHelpDialog = false },
+                title = { Text(text = stringResource(MR.strings.komga_server_settings_help_title)) },
+                text = { Text(text = stringResource(MR.strings.komga_server_settings_help_content)) },
+                confirmButton = {
+                    TextButton(onClick = { showHelpDialog = false }) {
+                        Text(text = stringResource(MR.strings.action_ok))
+                    }
+                },
+            )
+        }
     }
 }

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -73,10 +73,11 @@ class KomgaSource(
         get() = preferences.getString(PREF_PASSWORD, "")!!
 
     private val authMode: String
-        get() = preferences.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)!!
+        get() = preferences.getString(PREF_AUTH_MODE, null) ?: defaultAuthMode()
 
     private val apiKey: String
-        get() = preferences.getString(PREF_API_KEY, "")!!
+        get() = preferences.getString(PREF_API_KEY, null)
+            ?: preferences.getString(PREF_API_KEY_WRONG_CASE, "")!!
 
     private val defaultLibraries: Set<String>
         get() = preferences.getStringSet(PREF_DEFAULT_LIBRARIES, emptySet()) ?: emptySet()
@@ -345,7 +346,7 @@ class KomgaSource(
                 screen.context.stringResource(MR.strings.komga_pref_auth_mode_api_key),
             )
             entryValues = arrayOf(AUTH_MODE_CREDENTIALS, AUTH_MODE_API_KEY)
-            setDefaultValue(AUTH_MODE_CREDENTIALS)
+            setDefaultValue(defaultAuthMode())
             summary = "%s"
         }.also(screen::addPreference)
 
@@ -391,9 +392,9 @@ class KomgaSource(
         }
 
         val initialAuthMode = screen.preferenceManager.preferenceDataStore
-            ?.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)
-            ?: preferences.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)
-            ?: AUTH_MODE_CREDENTIALS
+            ?.getString(PREF_AUTH_MODE, null)
+            ?: preferences.getString(PREF_AUTH_MODE, null)
+            ?: defaultAuthMode()
         updateAuthFieldsVisibility(initialAuthMode)
 
         androidx.preference.Preference(screen.context).apply {
@@ -411,14 +412,16 @@ class KomgaSource(
                 val dataStore = pref.preferenceManager.preferenceDataStore
                 val currentAddress = (dataStore?.getString(PREF_ADDRESS, "") ?: "").removeSuffix("/")
                 val currentAuthMode =
-                    dataStore?.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS) ?: AUTH_MODE_CREDENTIALS
+                    dataStore?.getString(PREF_AUTH_MODE, null) ?: defaultAuthMode()
                 val currentUsername = dataStore?.getString(PREF_USERNAME, "") ?: ""
                 val currentPassword = dataStore?.getString(PREF_PASSWORD, "") ?: ""
-                val currentApiKey = dataStore?.getString(PREF_API_KEY, "") ?: ""
+                val currentApiKey = dataStore?.getString(PREF_API_KEY, null)
+                    ?: dataStore?.getString(PREF_API_KEY_WRONG_CASE, null)
+                    ?: ""
 
                 val currentSelection = dataStore?.getStringSet(PREF_DEFAULT_LIBRARIES, emptySet()) ?: emptySet()
 
-                CoroutineScope(Dispatchers.Main).launch {
+                scope.launch(Dispatchers.Main) {
                     val fetchedLibraries = kotlinx.coroutines.withContext(Dispatchers.IO) {
                         try {
                             if (currentAddress.isBlank()) return@withContext emptyList<LibraryDto>()
@@ -630,6 +633,8 @@ class KomgaSource(
             PREF_USERNAME,
             PREF_PASSWORD,
             PREF_API_KEY,
+            PREF_API_KEY_WRONG_CASE,
+            PREF_AUTH_MODE,
             PREF_DEFAULT_LIBRARIES,
             PREF_CHAPTER_NAME_TEMPLATE,
         )
@@ -639,6 +644,10 @@ class KomgaSource(
             val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
             (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
         }
+    }
+
+    private fun defaultAuthMode(): String {
+        return if (apiKey.isNotBlank()) AUTH_MODE_API_KEY else AUTH_MODE_CREDENTIALS
     }
 }
 
@@ -743,7 +752,8 @@ private fun Filter.CheckBox.persistentOptionKey(): String {
 private const val PREF_ADDRESS = "Address"
 private const val PREF_USERNAME = "Username"
 private const val PREF_PASSWORD = "Password"
-private const val PREF_API_KEY = "Api key"
+private const val PREF_API_KEY = "API key"
+private const val PREF_API_KEY_WRONG_CASE = "Api key"
 
 private const val PREF_AUTH_MODE = "AuthMode"
 private const val AUTH_MODE_CREDENTIALS = "Credentials"

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -20,6 +20,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.sourcePreferences
 import koharia.komga.api.KomgaApiClient
+import koharia.komga.api.dto.BookDto
 import koharia.komga.api.dto.LibraryDto
 import koharia.komga.domain.repository.KomgaRepository
 import kotlinx.coroutines.CoroutineScope
@@ -71,6 +72,9 @@ class KomgaSource(
     private val password: String
         get() = preferences.getString(PREF_PASSWORD, "")!!
 
+    private val authMode: String
+        get() = preferences.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)!!
+
     private val apiKey: String
         get() = preferences.getString(PREF_API_KEY, "")!!
 
@@ -97,21 +101,22 @@ class KomgaSource(
             }
         }
 
-    override val client: OkHttpClient
-        get() = network.client.newBuilder()
-            .addInterceptor(KomgaOfflineInterceptor(application))
-            .addNetworkInterceptor(KomgaCacheControlInterceptor(application))
-            .authenticator { _, response ->
-                if (apiKey.isNotBlank() || response.request.header("Authorization") != null) {
-                    null
-                } else {
-                    response.request.newBuilder()
-                        .addHeader("Authorization", Credentials.basic(username, password))
-                        .build()
-                }
+    override val client = super.client.newBuilder()
+        .addInterceptor(KomgaOfflineInterceptor(application))
+        .addNetworkInterceptor(KomgaCacheControlInterceptor(application))
+        .addInterceptor { chain ->
+            val original = chain.request()
+            val newBuilder = original.newBuilder()
+
+            if (authMode == AUTH_MODE_API_KEY && apiKey.isNotBlank()) {
+                newBuilder.addHeader("X-Komga-Api-Key", apiKey)
+            } else if (authMode == AUTH_MODE_CREDENTIALS && username.isNotBlank() && password.isNotBlank()) {
+                newBuilder.addHeader("Authorization", Credentials.basic(username, password))
             }
-            .dns(Dns.SYSTEM)
-            .build()
+            chain.proceed(newBuilder.build())
+        }
+        .dns(Dns.SYSTEM)
+        .build()
 
     override fun popularMangaRequest(page: Int): Request =
         repository.popularMangaRequest(page, defaultLibraries, consumeBrowseCachePolicy())
@@ -164,6 +169,17 @@ class KomgaSource(
                 .awaitSuccess()
                 .let { apiClient.parse<koharia.komga.api.dto.UserDto>(it) }
         } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun getBookDetails(bookUrl: String): BookDto? {
+        if (!hasValidBaseUrl()) return null
+        return try {
+            client.newCall(apiClient.detailsRequest(bookUrl, KomgaCachePolicy.NetworkFirst))
+                .awaitSuccess()
+                .let { apiClient.parse<BookDto>(it) }
+        } catch (_: Exception) {
             null
         }
     }
@@ -321,7 +337,36 @@ class KomgaSource(
             validationMessage = screen.context.stringResource(MR.strings.komga_pref_address_validation),
             key = PREF_ADDRESS,
         )
-        screen.addEditTextPreference(
+        val authModePref = androidx.preference.ListPreference(screen.context).apply {
+            key = PREF_AUTH_MODE
+            title = screen.context.stringResource(MR.strings.komga_pref_auth_mode_title)
+            entries = arrayOf(
+                screen.context.stringResource(MR.strings.komga_pref_auth_mode_credentials),
+                screen.context.stringResource(MR.strings.komga_pref_auth_mode_api_key),
+            )
+            entryValues = arrayOf(AUTH_MODE_CREDENTIALS, AUTH_MODE_API_KEY)
+            setDefaultValue(AUTH_MODE_CREDENTIALS)
+            summary = "%s"
+        }.also(screen::addPreference)
+
+        val usernamePref = screen.addEditTextPreference(
+            title = screen.context.stringResource(MR.strings.komga_pref_username_title),
+            default = "",
+            summary = username.ifBlank { screen.context.stringResource(MR.strings.komga_pref_username_summary) },
+            key = PREF_USERNAME,
+        )
+        val passwordPref = screen.addEditTextPreference(
+            title = screen.context.stringResource(MR.strings.komga_pref_password_title),
+            default = "",
+            summary = if (password.isBlank()) {
+                screen.context.stringResource(MR.strings.komga_pref_password_summary)
+            } else {
+                "*".repeat(password.length)
+            },
+            inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
+            key = PREF_PASSWORD,
+        )
+        val apiKeyPref = screen.addEditTextPreference(
             title = screen.context.stringResource(MR.strings.komga_pref_api_key_title),
             default = "",
             summary = if (apiKey.isBlank()) {
@@ -332,39 +377,99 @@ class KomgaSource(
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
             key = PREF_API_KEY,
         )
-        if (apiKey.isBlank()) {
-            screen.addEditTextPreference(
-                title = screen.context.stringResource(MR.strings.komga_pref_username_title),
-                default = "",
-                summary = username.ifBlank { screen.context.stringResource(MR.strings.komga_pref_username_summary) },
-                key = PREF_USERNAME,
-            )
-            screen.addEditTextPreference(
-                title = screen.context.stringResource(MR.strings.komga_pref_password_title),
-                default = "",
-                summary = if (password.isBlank()) {
-                    screen.context.stringResource(MR.strings.komga_pref_password_summary)
-                } else {
-                    "*".repeat(password.length)
-                },
-                inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_PASSWORD,
-                key = PREF_PASSWORD,
-            )
+
+        fun updateAuthFieldsVisibility(mode: String) {
+            val isCredentials = mode == AUTH_MODE_CREDENTIALS
+            usernamePref.isVisible = isCredentials
+            passwordPref.isVisible = isCredentials
+            apiKeyPref.isVisible = !isCredentials
         }
 
-        MultiSelectListPreference(screen.context).apply {
+        authModePref.setOnPreferenceChangeListener { _, newValue ->
+            updateAuthFieldsVisibility(newValue as String)
+            true
+        }
+
+        val initialAuthMode = screen.preferenceManager.preferenceDataStore
+            ?.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)
+            ?: preferences.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS)
+            ?: AUTH_MODE_CREDENTIALS
+        updateAuthFieldsVisibility(initialAuthMode)
+
+        androidx.preference.Preference(screen.context).apply {
             key = PREF_DEFAULT_LIBRARIES
             title = screen.context.stringResource(MR.strings.komga_pref_default_libraries_title)
-            summary = buildString {
-                append(screen.context.stringResource(MR.strings.komga_pref_default_libraries_summary))
-                if (libraries.isEmpty()) {
-                    append(' ')
-                    append(screen.context.stringResource(MR.strings.komga_pref_default_libraries_reload_hint))
-                }
-            }
-            entries = libraries.map { it.name }.toTypedArray()
-            entryValues = libraries.map { it.id }.toTypedArray()
+            summary = screen.context.stringResource(MR.strings.komga_pref_default_libraries_summary)
             setDefaultValue(emptySet<String>())
+
+            var isFetching = false
+
+            setOnPreferenceClickListener { pref ->
+                if (isFetching) return@setOnPreferenceClickListener true
+                isFetching = true
+
+                val dataStore = pref.preferenceManager.preferenceDataStore
+                val currentAddress = (dataStore?.getString(PREF_ADDRESS, "") ?: "").removeSuffix("/")
+                val currentAuthMode =
+                    dataStore?.getString(PREF_AUTH_MODE, AUTH_MODE_CREDENTIALS) ?: AUTH_MODE_CREDENTIALS
+                val currentUsername = dataStore?.getString(PREF_USERNAME, "") ?: ""
+                val currentPassword = dataStore?.getString(PREF_PASSWORD, "") ?: ""
+                val currentApiKey = dataStore?.getString(PREF_API_KEY, "") ?: ""
+
+                val currentSelection = dataStore?.getStringSet(PREF_DEFAULT_LIBRARIES, emptySet()) ?: emptySet()
+
+                CoroutineScope(Dispatchers.Main).launch {
+                    val fetchedLibraries = kotlinx.coroutines.withContext(Dispatchers.IO) {
+                        try {
+                            if (currentAddress.isBlank()) return@withContext emptyList<LibraryDto>()
+
+                            val tempHeaders = Headers.Builder().apply {
+                                if (currentAuthMode == AUTH_MODE_API_KEY && currentApiKey.isNotBlank()) {
+                                    add("X-Komga-Api-Key", currentApiKey)
+                                } else if (currentAuthMode == AUTH_MODE_CREDENTIALS && currentUsername.isNotBlank() &&
+                                    currentPassword.isNotBlank()
+                                ) {
+                                    add("Authorization", Credentials.basic(currentUsername, currentPassword))
+                                }
+                            }.build()
+
+                            val cleanClient = Injekt.get<eu.kanade.tachiyomi.network.NetworkHelper>().client
+                            val tempApiClient = KomgaApiClient(currentAddress, tempHeaders, cleanClient, json)
+                            val tempRepo = KomgaRepository(currentAddress, tempApiClient)
+                            tempRepo.fetchFilterOptions(forceRefresh = true).libraries
+                        } catch (e: Exception) {
+                            emptyList<LibraryDto>()
+                        }
+                    }
+
+                    if (fetchedLibraries.isEmpty()) {
+                        isFetching = false
+                        return@launch
+                    }
+
+                    val names = fetchedLibraries.map { it.name }.toTypedArray<CharSequence>()
+                    val checkedItems = fetchedLibraries.map { it.id in currentSelection }.toBooleanArray()
+                    val newSelection = currentSelection.toMutableSet()
+
+                    com.google.android.material.dialog.MaterialAlertDialogBuilder(screen.context)
+                        .setTitle(screen.context.stringResource(MR.strings.komga_pref_default_libraries_title))
+                        .setMultiChoiceItems(names, checkedItems) { _, which, isChecked ->
+                            val id = fetchedLibraries[which].id
+                            if (isChecked) newSelection.add(id) else newSelection.remove(id)
+                        }
+                        .setPositiveButton(android.R.string.ok) { _, _ ->
+                            if (newSelection != currentSelection) {
+                                if (callChangeListener(newSelection)) {
+                                    dataStore?.putStringSet(PREF_DEFAULT_LIBRARIES, newSelection)
+                                }
+                            }
+                        }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .setOnDismissListener { isFetching = false }
+                        .show()
+                }
+                true
+            }
         }.also(screen::addPreference)
 
         screen.addEditTextPreference(
@@ -638,7 +743,11 @@ private fun Filter.CheckBox.persistentOptionKey(): String {
 private const val PREF_ADDRESS = "Address"
 private const val PREF_USERNAME = "Username"
 private const val PREF_PASSWORD = "Password"
-private const val PREF_API_KEY = "API key"
+private const val PREF_API_KEY = "Api key"
+
+private const val PREF_AUTH_MODE = "AuthMode"
+private const val AUTH_MODE_CREDENTIALS = "Credentials"
+private const val AUTH_MODE_API_KEY = "ApiKey"
 private const val PREF_DEFAULT_LIBRARIES = "Default libraries"
 private const val PREF_CHAPTER_NAME_TEMPLATE = "Chapter name template"
 private const val PREF_CHAPTER_NAME_TEMPLATE_DEFAULT = "{number} - {title} ({size})"
@@ -654,8 +763,8 @@ private fun PreferenceScreen.addEditTextPreference(
     validate: ((String) -> Boolean)? = null,
     validationMessage: String? = null,
     key: String = title,
-) {
-    EditTextPreference(context).apply {
+): EditTextPreference {
+    return EditTextPreference(context).apply {
         this.key = key
         this.title = title
         this.summary = summary

--- a/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
@@ -1,0 +1,197 @@
+import kotlinx.serialization.json.JsonObject;
+
+CREATE TABLE komga_shared_download_matches(
+    server_id INTEGER NOT NULL,
+    book_url TEXT NOT NULL,
+    series_url TEXT NOT NULL DEFAULT '',
+    file_hash TEXT NOT NULL DEFAULT '',
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    isbn TEXT NOT NULL DEFAULT '',
+    series_title TEXT NOT NULL DEFAULT '',
+    book_title TEXT NOT NULL DEFAULT '',
+    number_sort REAL NOT NULL DEFAULT 0,
+    local_relative_path TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    file_kind TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_verified_at INTEGER NOT NULL,
+    PRIMARY KEY(server_id, book_url)
+);
+
+CREATE INDEX idx_komga_shared_download_matches_book_url
+ON komga_shared_download_matches(book_url);
+
+CREATE INDEX idx_komga_shared_download_matches_file_hash
+ON komga_shared_download_matches(file_hash);
+
+CREATE INDEX idx_komga_shared_download_matches_local_relative_path
+ON komga_shared_download_matches(local_relative_path);
+
+findByServerIdAndBookUrl:
+SELECT *
+FROM komga_shared_download_matches
+WHERE server_id = :serverId
+AND book_url = :bookUrl;
+
+findByServerId:
+SELECT *
+FROM komga_shared_download_matches
+WHERE server_id = :serverId;
+
+findByFileHash:
+SELECT *
+FROM komga_shared_download_matches
+WHERE file_hash = :fileHash
+AND file_hash != ''
+ORDER BY last_verified_at DESC, created_at DESC;
+
+findByIsbn:
+SELECT *
+FROM komga_shared_download_matches
+WHERE lower(isbn) = lower(:isbn)
+AND isbn != ''
+ORDER BY last_verified_at DESC, created_at DESC;
+
+findBySeriesNumberSize:
+SELECT *
+FROM komga_shared_download_matches
+WHERE lower(series_title) = lower(:seriesTitle)
+AND number_sort = :numberSort
+AND size_bytes = :sizeBytes
+AND series_title != ''
+ORDER BY last_verified_at DESC, created_at DESC;
+
+findByBookTitleSize:
+SELECT *
+FROM komga_shared_download_matches
+WHERE lower(book_title) = lower(:bookTitle)
+AND size_bytes = :sizeBytes
+AND book_title != ''
+ORDER BY last_verified_at DESC, created_at DESC;
+
+findByLocalRelativePath:
+SELECT *
+FROM komga_shared_download_matches
+WHERE local_relative_path = :localRelativePath;
+
+findByLocalRelativePathPrefix:
+SELECT *
+FROM komga_shared_download_matches
+WHERE local_relative_path = :localRelativePathPrefix
+OR local_relative_path LIKE :localRelativePathPrefix || '/%';
+
+countByLocalRelativePath:
+SELECT count(*)
+FROM komga_shared_download_matches
+WHERE local_relative_path = :localRelativePath;
+
+upsert:
+INSERT INTO komga_shared_download_matches(
+    server_id,
+    book_url,
+    series_url,
+    file_hash,
+    size_bytes,
+    isbn,
+    series_title,
+    book_title,
+    number_sort,
+    local_relative_path,
+    file_name,
+    file_kind,
+    created_at,
+    last_verified_at
+)
+VALUES (
+    :serverId,
+    :bookUrl,
+    :seriesUrl,
+    :fileHash,
+    :sizeBytes,
+    :isbn,
+    :seriesTitle,
+    :bookTitle,
+    :numberSort,
+    :localRelativePath,
+    :fileName,
+    :fileKind,
+    :createdAt,
+    :lastVerifiedAt
+)
+ON CONFLICT(server_id, book_url)
+DO UPDATE
+SET
+    series_url = :seriesUrl,
+    file_hash = :fileHash,
+    size_bytes = :sizeBytes,
+    isbn = :isbn,
+    series_title = :seriesTitle,
+    book_title = :bookTitle,
+    number_sort = :numberSort,
+    local_relative_path = :localRelativePath,
+    file_name = :fileName,
+    file_kind = :fileKind,
+    last_verified_at = :lastVerifiedAt;
+
+deleteByServerId:
+DELETE FROM komga_shared_download_matches
+WHERE server_id = :serverId;
+
+deleteByServerIdAndBookUrl:
+DELETE FROM komga_shared_download_matches
+WHERE server_id = :serverId
+AND book_url = :bookUrl;
+
+deleteByLocalRelativePath:
+DELETE FROM komga_shared_download_matches
+WHERE local_relative_path = :localRelativePath;
+
+updateLocalRelativePath:
+UPDATE komga_shared_download_matches
+SET
+    local_relative_path = :newLocalRelativePath,
+    file_name = :newFileName,
+    last_verified_at = :lastVerifiedAt
+WHERE local_relative_path = :oldLocalRelativePath;
+
+updateLocalRelativePathPrefix:
+UPDATE komga_shared_download_matches
+SET
+    local_relative_path = replace(local_relative_path, :oldPrefix, :newPrefix),
+    last_verified_at = :lastVerifiedAt
+WHERE local_relative_path = :oldPrefix
+OR local_relative_path LIKE :oldPrefix || '/%';
+
+getKomgaChapterSeedByUrl:
+SELECT
+    C._id,
+    C.url,
+    C.name,
+    C.scanlator,
+    C.memo,
+    M.title,
+    M.source
+FROM chapters C
+INNER JOIN mangas M
+ON M._id = C.manga_id
+WHERE C.url = :chapterUrl
+LIMIT 1;
+
+getKomgaChapterSeedsBySourceId:
+SELECT
+    C._id,
+    C.url,
+    C.name,
+    C.scanlator,
+    C.memo,
+    M.title
+FROM chapters C
+INNER JOIN mangas M
+ON M._id = C.manga_id
+WHERE M.source = :sourceId
+ORDER BY C._id ASC;
+
+updateChapterMemoOnly:
+UPDATE chapters
+SET memo = :memo
+WHERE _id = :chapterId;

--- a/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
@@ -157,7 +157,7 @@ WHERE local_relative_path = :oldLocalRelativePath;
 updateLocalRelativePathPrefix:
 UPDATE komga_shared_download_matches
 SET
-    local_relative_path = replace(local_relative_path, :oldPrefix, :newPrefix),
+    local_relative_path = :newPrefix || substr(local_relative_path, :oldPrefixLength + 1),
     last_verified_at = :lastVerifiedAt
 WHERE local_relative_path = :oldPrefix
 OR local_relative_path LIKE :oldPrefix || '/%';

--- a/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/komga_shared_download_matches.sq
@@ -191,6 +191,22 @@ ON M._id = C.manga_id
 WHERE M.source = :sourceId
 ORDER BY C._id ASC;
 
+getKomgaChapterSeedsByMangaId:
+SELECT
+    C._id,
+    C.url,
+    C.name,
+    C.scanlator,
+    C.memo,
+    M.title,
+    M.source
+FROM chapters C
+INNER JOIN mangas M
+ON M._id = C.manga_id
+WHERE C.manga_id = :mangaId
+AND M.source = :sourceId
+ORDER BY C._id ASC;
+
 updateChapterMemoOnly:
 UPDATE chapters
 SET memo = :memo

--- a/data/src/main/sqldelight/tachiyomi/migrations/12.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/12.sqm
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS komga_shared_download_matches(
+    server_id INTEGER NOT NULL,
+    book_url TEXT NOT NULL,
+    series_url TEXT NOT NULL DEFAULT '',
+    file_hash TEXT NOT NULL DEFAULT '',
+    size_bytes INTEGER NOT NULL DEFAULT 0,
+    isbn TEXT NOT NULL DEFAULT '',
+    series_title TEXT NOT NULL DEFAULT '',
+    book_title TEXT NOT NULL DEFAULT '',
+    number_sort REAL NOT NULL DEFAULT 0,
+    local_relative_path TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    file_kind TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_verified_at INTEGER NOT NULL,
+    PRIMARY KEY(server_id, book_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_komga_shared_download_matches_book_url
+ON komga_shared_download_matches(book_url);
+
+CREATE INDEX IF NOT EXISTS idx_komga_shared_download_matches_file_hash
+ON komga_shared_download_matches(file_hash);
+
+CREATE INDEX IF NOT EXISTS idx_komga_shared_download_matches_local_relative_path
+ON komga_shared_download_matches(local_relative_path);

--- a/domain/src/main/java/tachiyomi/domain/chapter/interactor/ShouldUpdateDbChapter.kt
+++ b/domain/src/main/java/tachiyomi/domain/chapter/interactor/ShouldUpdateDbChapter.kt
@@ -9,6 +9,7 @@ class ShouldUpdateDbChapter {
             dbChapter.name != sourceChapter.name ||
             dbChapter.dateUpload != sourceChapter.dateUpload ||
             dbChapter.chapterNumber != sourceChapter.chapterNumber ||
-            dbChapter.sourceOrder != sourceChapter.sourceOrder
+            dbChapter.sourceOrder != sourceChapter.sourceOrder ||
+            dbChapter.memo != sourceChapter.memo
     }
 }

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1209,4 +1209,14 @@
     <string name="donationCampaign.paragraph3">Regardless, Koharia will continue to be maintained by me and the volunteers, and it will stay open source.</string>
     <string name="donationCampaign.contactPlatform">Discord</string>
     <string name="donationCampaign.dismiss">Dismiss</string>
+    <string name="komga_unsaved_changes_title">Unsaved changes</string>
+    <string name="komga_unsaved_changes_message">You have unsaved changes. Are you sure you want to discard them?</string>
+    <string name="komga_action_discard">Discard</string>
+    <string name="komga_server_settings_add_title">Add Server</string>
+    <string name="komga_server_settings_edit_title">Edit Server</string>
+    <string name="komga_pref_auth_mode_title">Authentication Mode</string>
+    <string name="komga_pref_auth_mode_api_key">API Key</string>
+    <string name="komga_pref_auth_mode_credentials">Username and Password</string>
+    <string name="komga_server_settings_help_title">Server Configuration Guide</string>
+    <string name="komga_server_settings_help_content">Configure your server address and authentication method here. Use the API Key mode for a streamlined setup, or Username/Password if preferred.</string>
 </resources>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -1069,4 +1069,14 @@
     <string name="komga_download_directory_mode_per_server_explanation">按服务器分开：每台服务器都会把下载内容保存到自己的源目录中。</string>
     <string name="komga_download_directory_mode_shared_explanation">共用目录：多个 Komga 服务器会共用同一个下载源目录。</string>
     <string name="komga_server_management_delete_hint">删除服务器的方法：在服务器列表中将对应服务器向左滑动，出现删除按钮后，再确认删除。</string>
+    <string name="komga_unsaved_changes_title">未保存的更改</string>
+    <string name="komga_unsaved_changes_message">您有未保存的更改。确定要放弃它们吗？</string>
+    <string name="komga_action_discard">放弃</string>
+    <string name="komga_server_settings_add_title">添加服务器</string>
+    <string name="komga_server_settings_edit_title">修改服务器</string>
+    <string name="komga_pref_auth_mode_title">验证模式</string>
+    <string name="komga_pref_auth_mode_api_key">API Key</string>
+    <string name="komga_pref_auth_mode_credentials">用户名和密码</string>
+    <string name="komga_server_settings_help_title">服务器配置说明</string>
+    <string name="komga_server_settings_help_content">配置服务器地址及验证模式。切换API Key或者用户名密码登录。</string>
 </resources>


### PR DESCRIPTION
## 概述

在已有多服务器支持的基础上，为 Komga 的共用下载目录模式补齐跨服务器下载复用能力。现在同一份文件在不同服务器上能通过共享索引和书籍指纹进行匹配复用，减少重复下载，并为后续“删除服务器时按策略清理下载文件”预留了完整链路。

## 主要改动

- 新增 Komga 共享下载索引与 repository，用于记录远端书籍和本地下载文件之间的映射关系
- 在 `DownloadDirectoryMode.Shared` 下增加跨服务器查找逻辑，优先保留原有文件名直查，再补共享索引匹配
- 引入基于 `fileHash` 的主匹配流程，并在必要时使用书籍元数据做兜底匹配
- 下载成功后即时回填共享索引，并在访问时按需进行懒索引与脏记录清理
- 调整下载、重命名、删除流程，保证文件系统状态与共享索引保持一致
- 补齐 Komga 章节 memo / 书籍信息持久化字段，为跨服务器匹配提供稳定指纹来源
- 预埋服务器删除时的下载清理策略接口，当前默认仍保持“保留下载文件”
- 优化服务器设置页相关交互与本地配置清理行为，使后续删除链路更安全
- 增加 SQLDelight 表与 `12.sqm` 迁移，持久化共享下载匹配数据

## 为什么需要这次改动

在多服务器场景下，用户切换到共用下载目录模式后，如果两个服务器上存在同一部漫画，现有逻辑仍会把它们当作两份独立下载处理。这会带来重复下载、切换后重新扫描、进入作品页额外加载等问题。

这次改动的目标是仅在共用目录模式下建立稳定的“远端书籍 -> 本地文件”复用机制，同时不破坏按服务器分目录模式的既有行为，并确保未来如果要实现“删除服务器时一并删除对应下载文件”，可以在现有链路上平滑扩展。

## 影响

- 共用目录模式下，同一份 Komga 文件可在不同服务器之间复用
- 按服务器分目录模式维持现有行为，不启用跨服务器匹配
- 删除服务器的底层能力已支持扩展清理策略，但当前默认仍然保留下载文件，避免误删高价值数据
- 下载目录、索引记录、章节 memo 之间的一致性会更强，后续继续优化性能与删除策略的成本更低

## 验证

- 已完成对应实现与分支提交
- 本分支基于已合入的多服务器支持继续推进
