### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         applicationId = "app.koharia"
 
         versionCode = 2
-        versionName = "0.1.7"
+        versionName = "0.1.8"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")


### PR DESCRIPTION
## Summary

- Bump the app version to 0.1.8.
- Land the existing version-only commit independently from the EPUB feature stack.

## Context

The three EPUB branches were created on top of this local version commit. Merging it separately keeps the upcoming EPUB foundation PR focused only on EPUB changes.

## Scope

- Only app/build.gradle.kts is changed.
- No EPUB implementation changes are included.

## Validation

- Confirmed this commit is the direct child of the current GitHub main.
- Confirmed the diff contains one insertion and one deletion in app/build.gradle.kts.
- Gradle was not run because the repository is currently in rapid-development mode.