### PR TITLE
feat(epub): add native reader foundation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -239,6 +239,9 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.bundles.kotlinx.coroutines)
+    implementation(libs.readium.shared)
+    implementation(libs.readium.streamer)
+    implementation(libs.readium.navigator)
 
     implementation(libs.sqldelight.async)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -251,6 +251,7 @@ dependencies {
     implementation(libs.androidx.biometric)
     implementation(libs.androidx.constraintLayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.fragment.compose)
     implementation(libs.androidx.coreSplashScreen)
     implementation(libs.androidx.recyclerView)
     implementation(libs.androidx.viewPager)
@@ -295,7 +296,6 @@ dependencies {
     // UI libraries
     implementation(libs.material)
     implementation(libs.flexibleAdapter)
-    implementation(libs.photoView)
     implementation(libs.directionalViewPager) {
         exclude(group = "androidx.viewpager", module = "viewpager")
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,10 @@
         </activity>
 
         <activity
+            android:name="koharia.epub.EpubReaderActivity"
+            android:exported="false" />
+
+        <activity
             android:name=".ui.security.UnlockActivity"
             android:exported="false"
             android:theme="@style/Theme.Tachiyomi" />

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -20,7 +20,11 @@ import eu.kanade.domain.track.interactor.RefreshTracks
 import eu.kanade.domain.track.interactor.SyncChapterProgressWithTrack
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
+import koharia.data.epub.EpubProgressRepositoryImpl
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
+import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.domain.epub.interactor.UpsertEpubProgress
+import koharia.domain.epub.repository.EpubProgressRepository
 import koharia.domain.upcoming.interactor.GetUpcomingManga
 import tachiyomi.data.category.CategoryRepositoryImpl
 import tachiyomi.data.chapter.ChapterRepositoryImpl
@@ -153,6 +157,9 @@ class DomainModule : InjektModule {
         addFactory { UpsertHistory(get()) }
         addFactory { RemoveHistory(get()) }
         addFactory { GetTotalReadDuration(get()) }
+        addSingletonFactory<EpubProgressRepository> { EpubProgressRepositoryImpl(get()) }
+        addFactory { GetEpubProgress(get()) }
+        addFactory { UpsertEpubProgress(get()) }
 
         addFactory { DeleteDownload(get(), get()) }
 

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -433,11 +433,6 @@ object SettingsReaderScreen : SearchableSettings {
             title = stringResource(MR.strings.pref_category_epub_reader),
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = epubReaderPreferences.enableNativeReader,
-                    title = stringResource(MR.strings.pref_enable_native_epub_reader),
-                    subtitle = stringResource(MR.strings.pref_enable_native_epub_reader_summary),
-                ),
-                Preference.PreferenceItem.SwitchPreference(
                     preference = epubReaderPreferences.preferLocalFile,
                     title = stringResource(MR.strings.pref_prefer_local_epub_file),
                     subtitle = stringResource(MR.strings.pref_prefer_local_epub_file_summary),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
+import koharia.epub.settings.EpubReaderPreferences
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -30,6 +31,7 @@ object SettingsReaderScreen : SearchableSettings {
     @Composable
     override fun getPreferences(): List<Preference> {
         val readerPref = remember { Injekt.get<ReaderPreferences>() }
+        val epubReaderPref = remember { Injekt.get<EpubReaderPreferences>() }
 
         return listOf(
             Preference.PreferenceItem.ListPreference(
@@ -69,6 +71,7 @@ object SettingsReaderScreen : SearchableSettings {
             getWebtoonGroup(readerPreferences = readerPref),
             getNavigationGroup(readerPreferences = readerPref),
             getActionsGroup(readerPreferences = readerPref),
+            getEpubGroup(epubReaderPreferences = epubReaderPref),
         )
     }
 
@@ -419,6 +422,30 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = readerPreferences.folderPerManga,
                     title = stringResource(MR.strings.pref_create_folder_per_manga),
                     subtitle = stringResource(MR.strings.pref_create_folder_per_manga_summary),
+                ),
+            ),
+        )
+    }
+
+    @Composable
+    private fun getEpubGroup(epubReaderPreferences: EpubReaderPreferences): Preference.PreferenceGroup {
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_category_epub_reader),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = epubReaderPreferences.enableNativeReader,
+                    title = stringResource(MR.strings.pref_enable_native_epub_reader),
+                    subtitle = stringResource(MR.strings.pref_enable_native_epub_reader_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = epubReaderPreferences.preferLocalFile,
+                    title = stringResource(MR.strings.pref_prefer_local_epub_file),
+                    subtitle = stringResource(MR.strings.pref_prefer_local_epub_file_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = epubReaderPreferences.syncProgressionToKomga,
+                    title = stringResource(MR.strings.pref_sync_epub_progression_komga),
+                    subtitle = stringResource(MR.strings.pref_sync_epub_progression_komga_summary),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/presentation/reader/DisplayRefreshHost.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/DisplayRefreshHost.kt
@@ -19,10 +19,11 @@ import uy.kohesive.injekt.api.get
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-class DisplayRefreshHost {
+class DisplayRefreshHost(
+    readerPreferences: ReaderPreferences = Injekt.get(),
+) {
 
     internal var currentDisplayRefresh by mutableStateOf(false)
-    private val readerPreferences = Injekt.get<ReaderPreferences>()
 
     internal val flashMillis = readerPreferences.flashDurationMillis
     internal val flashMode = readerPreferences.flashColor

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -11,12 +11,12 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
 import eu.kanade.tachiyomi.ui.main.MainActivity
-import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.getParcelableExtraCompat
 import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
+import koharia.epub.EpubReaderLauncher
 import kotlinx.coroutines.runBlocking
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
@@ -151,7 +151,9 @@ class NotificationReceiver : BroadcastReceiver() {
         val manga = runBlocking { getManga.await(mangaId) }
         val chapter = runBlocking { getChapter.await(chapterId) }
         if (manga != null && chapter != null) {
-            val intent = ReaderActivity.newIntent(context, manga.id, chapter.id).apply {
+            val intent = runBlocking {
+                EpubReaderLauncher().resolveIntent(context, manga.id, chapter.id)
+            }.apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
             context.startActivity(intent)
@@ -402,8 +404,12 @@ class NotificationReceiver : BroadcastReceiver() {
          * @param chapter chapter that needs to be opened
          */
         internal fun openChapterPendingActivity(context: Context, manga: Manga, chapter: Chapter): PendingIntent {
-            val newIntent = ReaderActivity.newIntent(context, manga.id, chapter.id)
-            return PendingIntent.getActivity(
+            val newIntent = Intent(context, NotificationReceiver::class.java).apply {
+                action = ACTION_OPEN_CHAPTER
+                putExtra(EXTRA_MANGA_ID, manga.id)
+                putExtra(EXTRA_CHAPTER_ID, chapter.id)
+            }
+            return PendingIntent.getBroadcast(
                 context,
                 manga.id.hashCode(),
                 newIntent,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -17,9 +17,11 @@ import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import koharia.epub.EpubReaderLauncher
-import kotlinx.coroutines.runBlocking
+import logcat.LogPriority
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.util.lang.launchIO
+import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.Chapter
@@ -78,11 +80,21 @@ class NotificationReceiver : BroadcastReceiver() {
             ACTION_CANCEL_APP_UPDATE_DOWNLOAD -> cancelDownloadAppUpdate(context)
             // Open reader activity
             ACTION_OPEN_CHAPTER -> {
-                openChapter(
-                    context,
-                    intent.getLongExtra(EXTRA_MANGA_ID, -1),
-                    intent.getLongExtra(EXTRA_CHAPTER_ID, -1),
-                )
+                val pendingResult = goAsync()
+                launchIO {
+                    try {
+                        openChapter(
+                            context,
+                            intent.getLongExtra(EXTRA_MANGA_ID, -1),
+                            intent.getLongExtra(EXTRA_CHAPTER_ID, -1),
+                        )
+                    } catch (error: Exception) {
+                        logcat(LogPriority.ERROR, error) { "Failed to open EPUB chapter from notification" }
+                        withUIContext { context.toast(MR.strings.chapter_error) }
+                    } finally {
+                        pendingResult.finish()
+                    }
+                }
             }
             // Mark updated manga chapters as read
             ACTION_MARK_AS_READ -> {
@@ -147,18 +159,16 @@ class NotificationReceiver : BroadcastReceiver() {
      * @param mangaId id of manga
      * @param chapterId id of chapter
      */
-    private fun openChapter(context: Context, mangaId: Long, chapterId: Long) {
-        val manga = runBlocking { getManga.await(mangaId) }
-        val chapter = runBlocking { getChapter.await(chapterId) }
+    private suspend fun openChapter(context: Context, mangaId: Long, chapterId: Long) {
+        val manga = getManga.await(mangaId)
+        val chapter = getChapter.await(chapterId)
         if (manga != null && chapter != null) {
-            val intent = runBlocking {
-                EpubReaderLauncher().resolveIntent(context, manga.id, chapter.id)
-            }.apply {
+            val intent = EpubReaderLauncher().resolveIntent(context, manga.id, chapter.id).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
             }
-            context.startActivity(intent)
+            withUIContext { context.startActivity(intent) }
         } else {
-            context.toast(MR.strings.chapter_error)
+            withUIContext { context.toast(MR.strings.chapter_error) }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -22,6 +22,12 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.network.JavaScriptEngine
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.AndroidSourceManager
+import koharia.epub.progress.KomgaEpubProgressSyncService
+import koharia.epub.service.EpubPublicationResolver
+import koharia.epub.service.KomgaEpubPublicationService
+import koharia.epub.service.KomgaReadiumHttpClient
+import koharia.epub.service.LocalEpubPublicationService
+import koharia.epub.session.EpubReaderSessionRepository
 import koharia.komga.api.KomgaActiveServerSseManager
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaServerPreferences
@@ -35,6 +41,7 @@ import tachiyomi.core.common.storage.AndroidStorageFolderProvider
 import tachiyomi.data.Chapters
 import tachiyomi.data.Database
 import tachiyomi.data.DateColumnAdapter
+import tachiyomi.data.Epub_progress
 import tachiyomi.data.History
 import tachiyomi.data.Mangas
 import tachiyomi.data.MemoColumnAdapter
@@ -78,6 +85,10 @@ class AppModule(val app: Application) : InjektModule {
                 driver = get(),
                 historyAdapter = History.Adapter(
                     last_readAdapter = DateColumnAdapter,
+                ),
+                epub_progressAdapter = Epub_progress.Adapter(
+                    updated_atAdapter = DateColumnAdapter,
+                    last_synced_atAdapter = DateColumnAdapter,
                 ),
                 mangasAdapter = Mangas.Adapter(
                     genreAdapter = StringListColumnAdapter,
@@ -140,6 +151,12 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingletonFactory { AndroidStorageFolderProvider(app) }
         addSingletonFactory { StorageManager(app, get()) }
+        addSingletonFactory { EpubReaderSessionRepository() }
+        addSingletonFactory { KomgaReadiumHttpClient() }
+        addSingletonFactory { LocalEpubPublicationService() }
+        addSingletonFactory { KomgaEpubPublicationService() }
+        addSingletonFactory { EpubPublicationResolver() }
+        addSingletonFactory { KomgaEpubProgressSyncService(get(), get()) }
 
         // Asynchronously init expensive components for a faster cold start
         ContextCompat.getMainExecutor(app).execute {

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.AndroidSourceManager
 import koharia.epub.progress.KomgaEpubProgressSyncService
 import koharia.epub.service.EpubPublicationResolver
+import koharia.epub.service.EpubReaderSupportResolver
 import koharia.epub.service.KomgaEpubPublicationService
 import koharia.epub.service.KomgaReadiumHttpClient
 import koharia.epub.service.LocalEpubPublicationService
@@ -156,6 +157,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { LocalEpubPublicationService() }
         addSingletonFactory { KomgaEpubPublicationService() }
         addSingletonFactory { EpubPublicationResolver() }
+        addSingletonFactory { EpubReaderSupportResolver() }
         addSingletonFactory { KomgaEpubProgressSyncService(get(), get()) }
 
         // Asynchronously init expensive components for a faster cold start

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -10,8 +10,10 @@ import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.system.isDebugBuildType
+import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.source.komga.KomgaLocalConfigManager
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaServerRemovalManager
 import tachiyomi.core.common.preference.AndroidPreferenceStore
@@ -51,6 +53,13 @@ class PreferenceModule(val app: Application) : InjektModule {
             )
         }
         addSingletonFactory {
+            KomgaScopedPreferenceStoreFactory(
+                app = app,
+                preferenceStore = get<PreferenceStore>(),
+                serverPreferences = get<KomgaServerPreferences>(),
+            )
+        }
+        addSingletonFactory {
             KomgaServerRemovalManager(
                 serverPreferences = get<KomgaServerPreferences>(),
                 localConfigManager = get<KomgaLocalConfigManager>(),
@@ -85,6 +94,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             EpubReaderPreferences(get<ScopedPreferenceStore>())
+        }
+        addSingletonFactory {
+            EpubLayoutPreferences(get<ScopedPreferenceStore>())
         }
         addSingletonFactory {
             TrackPreferences(get<ScopedPreferenceStore>())

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.system.isDebugBuildType
+import koharia.epub.settings.EpubReaderPreferences
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaServerRemovalManager
@@ -81,6 +82,9 @@ class PreferenceModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             ReaderPreferences(get<ScopedPreferenceStore>())
+        }
+        addSingletonFactory {
+            EpubReaderPreferences(get<ScopedPreferenceStore>())
         }
         addSingletonFactory {
             TrackPreferences(get<ScopedPreferenceStore>())

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
@@ -2,10 +2,10 @@ package eu.kanade.tachiyomi.ui.deeplink
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
@@ -16,7 +16,6 @@ import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import koharia.epub.EpubReaderLauncher
-import kotlinx.coroutines.launch
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
@@ -30,7 +29,6 @@ class DeepLinkScreen(
     override fun Content() {
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
-        val scope = rememberCoroutineScope()
         val epubReaderLauncher = remember { EpubReaderLauncher() }
 
         val screenModel = rememberScreenModel {
@@ -51,21 +49,31 @@ class DeepLinkScreen(
                     LoadingScreen(Modifier.padding(contentPadding))
                 }
                 is DeepLinkScreenModel.State.NoResults -> {
-                    navigator.pop()
-                    scope.launch { HomeScreen.search(query) }
+                    LaunchedEffect(query) {
+                        HomeScreen.search(query)
+                        navigator.pop()
+                    }
                 }
                 is DeepLinkScreenModel.State.Result -> {
                     val resultState = state as DeepLinkScreenModel.State.Result
-                    if (resultState.chapterId == null) {
-                        navigator.replace(
-                            MangaScreen(
+                    val chapterId = resultState.chapterId
+                    LaunchedEffect(resultState.manga.id, chapterId) {
+                        if (chapterId == null) {
+                            navigator.replace(
+                                MangaScreen(
+                                    resultState.manga.id,
+                                    true,
+                                ),
+                            )
+                        } else {
+                            val intent = epubReaderLauncher.resolveIntent(
+                                context,
                                 resultState.manga.id,
-                                true,
-                            ),
-                        )
-                    } else {
-                        navigator.pop()
-                        epubReaderLauncher.launch(scope, context, resultState.manga.id, resultState.chapterId)
+                                chapterId,
+                            )
+                            context.startActivity(intent)
+                            navigator.pop()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -14,7 +15,7 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import eu.kanade.tachiyomi.ui.reader.ReaderActivity
+import koharia.epub.EpubReaderLauncher
 import kotlinx.coroutines.launch
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -30,6 +31,7 @@ class DeepLinkScreen(
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
         val scope = rememberCoroutineScope()
+        val epubReaderLauncher = remember { EpubReaderLauncher() }
 
         val screenModel = rememberScreenModel {
             DeepLinkScreenModel(query = query)
@@ -63,11 +65,7 @@ class DeepLinkScreen(
                         )
                     } else {
                         navigator.pop()
-                        ReaderActivity.newIntent(
-                            context,
-                            resultState.manga.id,
-                            resultState.chapterId,
-                        ).also(context::startActivity)
+                        epubReaderLauncher.launch(scope, context, resultState.manga.id, resultState.chapterId)
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryTab.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -26,7 +28,8 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import eu.kanade.tachiyomi.ui.reader.ReaderActivity
+import koharia.epub.EpubReaderLauncher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -61,6 +64,8 @@ data object HistoryTab : Tab {
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+        val epubReaderLauncher = remember { EpubReaderLauncher() }
         val screenModel = rememberScreenModel { HistoryScreenModel() }
         val state by screenModel.state.collectAsState()
 
@@ -129,22 +134,31 @@ data object HistoryTab : Tab {
                         snackbarHostState.showSnackbar(context.stringResource(MR.strings.internal_error))
                     HistoryScreenModel.Event.HistoryCleared ->
                         snackbarHostState.showSnackbar(context.stringResource(MR.strings.clear_history_completed))
-                    is HistoryScreenModel.Event.OpenChapter -> openChapter(context, e.chapter)
+                    is HistoryScreenModel.Event.OpenChapter -> openChapter(
+                        context,
+                        scope,
+                        epubReaderLauncher,
+                        e.chapter,
+                    )
                 }
             }
         }
 
         LaunchedEffect(Unit) {
             resumeLastChapterReadEvent.receiveAsFlow().collectLatest {
-                openChapter(context, screenModel.getNextChapter())
+                openChapter(context, scope, epubReaderLauncher, screenModel.getNextChapter())
             }
         }
     }
 
-    private suspend fun openChapter(context: Context, chapter: Chapter?) {
+    private suspend fun openChapter(
+        context: Context,
+        scope: CoroutineScope,
+        launcher: EpubReaderLauncher,
+        chapter: Chapter?,
+    ) {
         if (chapter != null) {
-            val intent = ReaderActivity.newIntent(context, chapter.mangaId, chapter.id)
-            context.startActivity(intent)
+            launcher.launch(scope, context, chapter.mangaId, chapter.id)
         } else {
             snackbarHostState.showSnackbar(context.stringResource(MR.strings.no_next_chapter))
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -47,11 +47,12 @@ import eu.kanade.tachiyomi.ui.category.CategoryScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.manga.notes.MangaNotesScreen
 import eu.kanade.tachiyomi.ui.manga.track.TrackInfoDialogHomeScreen
-import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
+import koharia.epub.EpubReaderLauncher
 import koharia.komga.ui.library.KomgaLibraryScreen
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withIOContext
@@ -78,6 +79,7 @@ class MangaScreen(
         val context = LocalContext.current
         val haptic = LocalHapticFeedback.current
         val scope = rememberCoroutineScope()
+        val epubReaderLauncher = remember { EpubReaderLauncher() }
         val lifecycleOwner = LocalLifecycleOwner.current
         val screenModel = rememberScreenModel {
             MangaScreenModel(context, lifecycleOwner.lifecycle, mangaId, fromSource)
@@ -102,7 +104,7 @@ class MangaScreen(
             chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
             navigateUp = navigator::pop,
-            onChapterClicked = { openChapter(context, it) },
+            onChapterClicked = { openChapter(context, scope, epubReaderLauncher, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
             onAddToLibraryClicked = {
                 screenModel.toggleFavorite()
@@ -113,7 +115,9 @@ class MangaScreen(
             onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
             onFilterButtonClicked = screenModel::showSettingsDialog,
             onRefresh = screenModel::fetchAllFromSource,
-            onContinueReading = { continueReading(context, screenModel.getNextUnreadChapter()) },
+            onContinueReading = {
+                continueReading(context, scope, epubReaderLauncher, screenModel.getNextUnreadChapter())
+            },
             onSearch = { query, global -> scope.launch { performSearch(navigator, query, global) } },
             onCoverClicked = screenModel::showCoverDialog,
             onShareClicked = { shareManga(context, screenModel.manga, screenModel.source) }.takeIf { isHttpSource },
@@ -250,12 +254,22 @@ class MangaScreen(
         }
     }
 
-    private fun continueReading(context: Context, unreadChapter: Chapter?) {
-        if (unreadChapter != null) openChapter(context, unreadChapter)
+    private fun continueReading(
+        context: Context,
+        scope: CoroutineScope,
+        launcher: EpubReaderLauncher,
+        unreadChapter: Chapter?,
+    ) {
+        if (unreadChapter != null) openChapter(context, scope, launcher, unreadChapter)
     }
 
-    private fun openChapter(context: Context, chapter: Chapter) {
-        context.startActivity(ReaderActivity.newIntent(context, chapter.mangaId, chapter.id))
+    private fun openChapter(
+        context: Context,
+        scope: CoroutineScope,
+        launcher: EpubReaderLauncher,
+        chapter: Chapter,
+    ) {
+        launcher.launch(scope, context, chapter.mangaId, chapter.id)
     }
 
     private fun getMangaUrl(manga_: Manga?, source_: Source?): String? {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -84,6 +84,7 @@ import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.setComposeContent
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
@@ -109,17 +110,33 @@ import java.io.ByteArrayOutputStream
 class ReaderActivity : BaseActivity() {
 
     companion object {
-        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?): Intent {
+        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, sourceId: Long? = null): Intent {
             return Intent(context, ReaderActivity::class.java).apply {
                 putExtra("manga", mangaId)
                 putExtra("chapter", chapterId)
+                sourceId?.let { putExtra("source", it) }
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
         }
     }
 
-    private val readerPreferences = Injekt.get<ReaderPreferences>()
-    private val preferences = Injekt.get<BasePreferences>()
+    private val scopedPreferenceStoreFactory = Injekt.get<KomgaScopedPreferenceStoreFactory>()
+    val readerPreferences: ReaderPreferences by lazy {
+        val sourceId = intent.extras?.getLong("source", -1L) ?: -1L
+        if (sourceId > 0L) {
+            scopedPreferenceStoreFactory.readerPreferences(sourceId)
+        } else {
+            Injekt.get<ReaderPreferences>()
+        }
+    }
+    val basePreferences: BasePreferences by lazy {
+        val sourceId = intent.extras?.getLong("source", -1L) ?: -1L
+        if (sourceId > 0L) {
+            scopedPreferenceStoreFactory.basePreferences(sourceId)
+        } else {
+            Injekt.get<BasePreferences>()
+        }
+    }
 
     lateinit var binding: ReaderActivityBinding
 
@@ -133,7 +150,7 @@ class ReaderActivity : BaseActivity() {
 
     private var menuToggleToast: Toast? = null
     private var readingModeToast: Toast? = null
-    private val displayRefreshHost = DisplayRefreshHost()
+    private val displayRefreshHost by lazy { DisplayRefreshHost(readerPreferences) }
 
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
 
@@ -194,7 +211,7 @@ class ReaderActivity : BaseActivity() {
         setMenuVisibility(viewModel.state.value.menuVisible)
 
         // Finish when incognito mode is disabled
-        preferences.incognitoMode.changes()
+        basePreferences.incognitoMode.changes()
             .drop(1)
             .onEach { if (!it) finish() }
             .launchIn(lifecycleScope)
@@ -256,6 +273,7 @@ class ReaderActivity : BaseActivity() {
                 readerState = viewModel.state,
                 onChangeReadingMode = viewModel::setMangaReadingMode,
                 onChangeOrientation = viewModel::setMangaOrientationType,
+                preferences = readerPreferences,
             )
         }
 
@@ -869,7 +887,7 @@ class ReaderActivity : BaseActivity() {
                 }
                 .launchIn(lifecycleScope)
 
-            preferences.displayProfile.changes()
+            basePreferences.displayProfile.changes()
                 .onEach { setDisplayProfile(it) }
                 .launchIn(lifecycleScope)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -12,7 +12,6 @@ import eu.kanade.domain.chapter.model.toDbChapter
 import eu.kanade.domain.manga.interactor.SetMangaViewerFlags
 import eu.kanade.domain.manga.model.readerOrientation
 import eu.kanade.domain.manga.model.readingMode
-import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.domain.track.service.TrackPreferences
 import eu.kanade.tachiyomi.data.database.models.toDomainChapter
@@ -41,6 +40,7 @@ import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -88,10 +88,10 @@ class ReaderViewModel @JvmOverloads constructor(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val downloadProvider: DownloadProvider = Injekt.get(),
     private val imageSaver: ImageSaver = Injekt.get(),
-    val readerPreferences: ReaderPreferences = Injekt.get(),
-    private val basePreferences: BasePreferences = Injekt.get(),
-    private val downloadPreferences: DownloadPreferences = Injekt.get(),
-    private val trackPreferences: TrackPreferences = Injekt.get(),
+    globalReaderPreferences: ReaderPreferences = Injekt.get(),
+    globalBasePreferences: BasePreferences = Injekt.get(),
+    globalDownloadPreferences: DownloadPreferences = Injekt.get(),
+    globalTrackPreferences: TrackPreferences = Injekt.get(),
     private val trackChapter: TrackChapter = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
@@ -99,10 +99,21 @@ class ReaderViewModel @JvmOverloads constructor(
     private val upsertHistory: UpsertHistory = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
-    private val getIncognitoState: GetIncognitoState = Injekt.get(),
-    private val libraryPreferences: LibraryPreferences = Injekt.get(),
+    globalLibraryPreferences: LibraryPreferences = Injekt.get(),
     private val komgaProgressSyncService: KomgaProgressSyncService = Injekt.get(),
+    scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) : ViewModel() {
+
+    val readerPreferences: ReaderPreferences =
+        scopedPreferenceStoreFactory.readerPreferencesForSavedSource(savedState) ?: globalReaderPreferences
+    private val basePreferences: BasePreferences =
+        scopedPreferenceStoreFactory.basePreferencesForSavedSource(savedState) ?: globalBasePreferences
+    private val downloadPreferences: DownloadPreferences =
+        scopedPreferenceStoreFactory.downloadPreferencesForSavedSource(savedState) ?: globalDownloadPreferences
+    private val trackPreferences: TrackPreferences =
+        scopedPreferenceStoreFactory.trackPreferencesForSavedSource(savedState) ?: globalTrackPreferences
+    private val libraryPreferences: LibraryPreferences =
+        scopedPreferenceStoreFactory.libraryPreferencesForSavedSource(savedState) ?: globalLibraryPreferences
 
     private val mutableState = MutableStateFlow(State())
     val state = mutableState.asStateFlow()
@@ -227,7 +238,7 @@ class ReaderViewModel @JvmOverloads constructor(
             .map(::ReaderChapter)
     }
 
-    private val incognitoMode: Boolean by lazy { getIncognitoState.await(manga?.source) }
+    private val incognitoMode: Boolean by lazy { basePreferences.incognitoMode.get() }
     private val downloadAheadAmount = downloadPreferences.autoDownloadWhileReading.get()
     private val cacheCurrentChapterWhileReading = downloadPreferences.cacheCurrentChapterWhileReading.get()
 
@@ -284,6 +295,7 @@ class ReaderViewModel @JvmOverloads constructor(
             try {
                 val manga = getManga.await(mangaId)
                 if (manga != null) {
+                    savedState["source_id"] = manga.source
                     komgaProgressSyncService.syncFromServer(manga)
                     sourceManager.isInitialized.first { it }
                     mutableState.update { it.copy(manga = manga) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -58,10 +58,11 @@ open class ReaderPageImageView @JvmOverloads constructor(
     @AttrRes defStyleAttrs: Int = 0,
     @StyleRes defStyleRes: Int = 0,
     private val isWebtoon: Boolean = false,
+    private val basePreferences: BasePreferences = Injekt.get(),
 ) : FrameLayout(context, attrs, defStyleAttrs, defStyleRes) {
 
     private val alwaysDecodeLongStripWithSSIV by lazy {
-        Injekt.get<BasePreferences>().alwaysDecodeLongStripWithSSIV.get()
+        basePreferences.alwaysDecodeLongStripWithSSIV.get()
     }
 
     private var pageView: View? = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -37,7 +37,11 @@ class PagerPageHolder(
     readerThemedContext: Context,
     val viewer: PagerViewer,
     val page: ReaderPage,
-) : ReaderPageImageView(readerThemedContext), ViewPagerAdapter.PositionableView {
+) : ReaderPageImageView(
+    context = readerThemedContext,
+    basePreferences = viewer.activity.basePreferences,
+),
+    ViewPagerAdapter.PositionableView {
 
     /**
      * Item that identifies this view. Needed by the adapter to not recreate views.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -44,7 +44,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
     /**
      * Configuration used by the pager, like allow taps, scale mode on images, page transitions...
      */
-    val config = PagerConfig(this, scope)
+    val config = PagerConfig(this, scope, activity.readerPreferences)
 
     /**
      * Adapter of the pager.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonAdapter.kt
@@ -102,7 +102,11 @@ class WebtoonAdapter(val viewer: WebtoonViewer) : RecyclerView.Adapter<RecyclerV
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return when (viewType) {
             PAGE_VIEW -> {
-                val view = ReaderPageImageView(readerThemedContext, isWebtoon = true)
+                val view = ReaderPageImageView(
+                    context = readerThemedContext,
+                    isWebtoon = true,
+                    basePreferences = viewer.activity.basePreferences,
+                )
                 WebtoonPageHolder(view, viewer)
             }
             TRANSITION_VIEW -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -13,15 +13,12 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
-
 /**
  * Configuration used by webtoon viewers.
  */
 class WebtoonConfig(
     scope: CoroutineScope,
-    readerPreferences: ReaderPreferences = Injekt.get(),
+    readerPreferences: ReaderPreferences,
 ) : ViewerConfig(readerPreferences, scope) {
 
     var themeChangedListener: (() -> Unit)? = null

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -16,14 +16,11 @@ import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.reader.model.ChapterTransition
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import eu.kanade.tachiyomi.ui.reader.model.ViewerChapters
-import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.viewer.Viewer
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation.NavigationRegion
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import tachiyomi.core.common.util.system.logcat
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import kotlin.math.max
 import kotlin.math.min
@@ -60,7 +57,7 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
     /**
      * Configuration used by this viewer, like allow taps, or crop image borders.
      */
-    val config = WebtoonConfig(scope)
+    val config = WebtoonConfig(scope, activity.readerPreferences)
 
     /**
      * Adapter of the recycler view.
@@ -72,11 +69,7 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
      */
     private var currentPage: Any? = null
 
-    private val threshold: Int =
-        Injekt.get<ReaderPreferences>()
-            .readerHideThreshold
-            .get()
-            .threshold
+    private val threshold: Int = activity.readerPreferences.readerHideThreshold.get().threshold
 
     init {
         recycler.setItemViewCacheSize(RECYCLER_VIEW_CACHE_SIZE)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesTab.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -24,8 +26,8 @@ import eu.kanade.tachiyomi.ui.download.DownloadQueueScreen
 import eu.kanade.tachiyomi.ui.home.HomeScreen
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
-import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import eu.kanade.tachiyomi.ui.updates.UpdatesScreenModel.Event
+import koharia.epub.EpubReaderLauncher
 import koharia.feature.upcoming.UpcomingScreen
 import kotlinx.coroutines.flow.collectLatest
 import tachiyomi.core.common.i18n.stringResource
@@ -54,6 +56,8 @@ data object UpdatesTab : Tab {
     override fun Content() {
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
+        val scope = rememberCoroutineScope()
+        val epubReaderLauncher = remember { EpubReaderLauncher() }
         val screenModel = rememberScreenModel { UpdatesScreenModel() }
         val settingsScreenModel = rememberScreenModel { UpdatesSettingsScreenModel() }
         val state by screenModel.state.collectAsState()
@@ -72,8 +76,7 @@ data object UpdatesTab : Tab {
             onMultiDeleteClicked = screenModel::showConfirmDeleteChapters,
             onUpdateSelected = screenModel::toggleSelection,
             onOpenChapter = {
-                val intent = ReaderActivity.newIntent(context, it.update.mangaId, it.update.chapterId)
-                context.startActivity(intent)
+                epubReaderLauncher.launch(scope, context, it.update.mangaId, it.update.chapterId)
             },
             onCalendarClicked = { navigator.push(UpcomingScreen()) },
             onFilterClicked = screenModel::showFilterDialog,

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -1,0 +1,45 @@
+package koharia.epub
+
+internal const val EPUB_PARAGRAPH_INDENT_STYLE_ID = "koharia-paragraph-indent"
+internal const val EPUB_PARAGRAPH_INDENT_CSS =
+    "p { text-indent: var(--USER__paraIndent, 2rem) !important; }"
+
+internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
+    """(function() {
+        var style = document.getElementById('$EPUB_PARAGRAPH_INDENT_STYLE_ID');
+        if (!style) {
+            style = document.createElementNS('http://www.w3.org/1999/xhtml', 'style');
+            style.id = '$EPUB_PARAGRAPH_INDENT_STYLE_ID';
+            style.setAttribute('type', 'text/css');
+            (document.head || document.documentElement).appendChild(style);
+        }
+        style.textContent = '$EPUB_PARAGRAPH_INDENT_CSS';
+        return true;
+    })()"""
+
+internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
+    """(function() {
+        var style = document.getElementById('$EPUB_PARAGRAPH_INDENT_STYLE_ID');
+        if (style) style.remove();
+        return true;
+    })()"""
+
+internal fun String.injectEpubParagraphIndentStyle(): String {
+    if (contains("id=\"$EPUB_PARAGRAPH_INDENT_STYLE_ID\"", ignoreCase = true)) return this
+
+    val style =
+        "<style id=\"$EPUB_PARAGRAPH_INDENT_STYLE_ID\" type=\"text/css\">" +
+            EPUB_PARAGRAPH_INDENT_CSS +
+            "</style>"
+    val closingHead = Regex("</head\\s*>", RegexOption.IGNORE_CASE).find(this)
+    if (closingHead != null) {
+        return replaceRange(closingHead.range.first, closingHead.range.first, style)
+    }
+
+    val openingBody = Regex("<body\\b", RegexOption.IGNORE_CASE).find(this)
+    return if (openingBody != null) {
+        replaceRange(openingBody.range.first, openingBody.range.first, style)
+    } else {
+        style + this
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -36,17 +36,21 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.commitNow
 import androidx.fragment.compose.AndroidFragment
 import androidx.lifecycle.lifecycleScope
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.view.setComposeContent
 import koharia.epub.model.EpubTocEntry
+import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -80,7 +84,14 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     private val viewModel by viewModels<EpubReaderViewModel>()
     private val scopedPreferenceStoreFactory = Injekt.get<KomgaScopedPreferenceStoreFactory>()
+    private val sessionRepository = Injekt.get<EpubReaderSessionRepository>()
     private val sourceId by lazy { intent.extras?.getLong("source", -1L) ?: -1L }
+    private val basePreferences by lazy {
+        sourceId
+            .takeIf { it > 0L }
+            ?.let(scopedPreferenceStoreFactory::basePreferences)
+            ?: Injekt.get<BasePreferences>()
+    }
     private val epubReaderPreferences by lazy {
         sourceId
             .takeIf { it > 0L }
@@ -105,6 +116,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         windowInsetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 
         super.onCreate(savedInstanceState)
+        removeRestoredReaderWithoutSession(savedInstanceState)
 
         setComposeContent {
             val state by viewModel.state.collectAsState()
@@ -207,6 +219,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             .onEach { updateSystemBars(viewModel.state.value.menuVisible) }
             .launchIn(lifecycleScope)
 
+        basePreferences.incognitoMode.changes()
+            .drop(1)
+            .onEach { if (!it) finish() }
+            .launchIn(lifecycleScope)
+
         viewModel.state
             .map { it.menuVisible }
             .distinctUntilChanged()
@@ -275,6 +292,20 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         } else {
             window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
+    }
+
+    private fun removeRestoredReaderWithoutSession(savedInstanceState: Bundle?) {
+        if (savedInstanceState == null) return
+        val chapterId = intent.extras?.getLong("chapter", -1L) ?: -1L
+        if (chapterId <= 0L || sessionRepository.get(chapterId) != null) return
+
+        supportFragmentManager.fragments
+            .filterIsInstance<EpubReaderFragment>()
+            .forEach { fragment ->
+                supportFragmentManager.commitNow {
+                    remove(fragment)
+                }
+            }
     }
 
     @Composable

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -70,10 +70,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     companion object {
         private const val READER_FRAGMENT_TAG = "epub_reader_fragment"
 
-        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?): Intent {
+        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, sourceId: Long? = null): Intent {
             return Intent(context, EpubReaderActivity::class.java).apply {
                 putExtra("manga", mangaId)
                 putExtra("chapter", chapterId)
+                sourceId?.let { putExtra("source", it) }
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
         }

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -1,0 +1,363 @@
+package koharia.epub
+
+import android.app.assist.AssistContent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.List
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
+import eu.kanade.presentation.components.AppBar
+import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import eu.kanade.tachiyomi.util.system.openInBrowser
+import eu.kanade.tachiyomi.util.view.setComposeContent
+import koharia.epub.model.EpubTocEntry
+import koharia.epub.settings.EpubReaderPreferences
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.toUri
+import tachiyomi.core.common.util.lang.launchNonCancellable
+import tachiyomi.core.common.util.lang.withUIContext
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.material.Scaffold
+import tachiyomi.presentation.core.i18n.stringResource
+import tachiyomi.presentation.core.screens.LoadingScreen
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+@OptIn(ExperimentalReadiumApi::class)
+class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
+
+    companion object {
+        private const val READER_FRAGMENT_TAG = "epub_reader_fragment"
+
+        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?): Intent {
+            return Intent(context, EpubReaderActivity::class.java).apply {
+                putExtra("manga", mangaId)
+                putExtra("chapter", chapterId)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            }
+        }
+    }
+
+    private val viewModel by viewModels<EpubReaderViewModel>()
+    private val epubReaderPreferences = Injekt.get<EpubReaderPreferences>()
+    private val readerPreferences = Injekt.get<ReaderPreferences>()
+    private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        registerSecureActivity(this)
+        enableEdgeToEdge()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
+        }
+        windowInsetsController.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+
+        super.onCreate(savedInstanceState)
+
+        setComposeContent {
+            val state by viewModel.state.collectAsState()
+            val tocEntries = remember(state.chapterId, state.isReady) { viewModel.tableOfContents() }
+            var showToc by rememberSaveable { mutableStateOf(false) }
+            val subtitle = remember(state.chapterTitle, state.currentSectionTitle, state.progressionPercent) {
+                listOfNotNull(
+                    state.chapterTitle,
+                    state.currentSectionTitle,
+                    state.progressionPercent?.let { "$it%" },
+                ).joinToString(" / ").takeIf { it.isNotBlank() }
+            }
+
+            Scaffold(
+                topBar = {
+                    if (state.menuVisible) {
+                        AppBar(
+                            title = state.mangaTitle,
+                            subtitle = subtitle,
+                            navigateUp = ::finish,
+                            actions = {
+                                if (tocEntries.isNotEmpty()) {
+                                    IconButton(onClick = { showToc = true }) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.List,
+                                            contentDescription = stringResource(MR.strings.epub_reader_toc),
+                                        )
+                                    }
+                                }
+                            },
+                        )
+                    }
+                },
+            ) { contentPadding ->
+                Box(modifier = Modifier.fillMaxSize()) {
+                    if (state.isReady && state.chapterId > 0) {
+                        ReaderFragmentContainer(
+                            fragmentManager = supportFragmentManager,
+                            chapterId = state.chapterId,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(if (state.menuVisible) contentPadding else PaddingValues(0.dp)),
+                        )
+                    }
+
+                    when {
+                        state.isLoading -> {
+                            LoadingScreen(Modifier.fillMaxSize())
+                        }
+                        state.errorMessage != null -> {
+                            ErrorContent(
+                                message = state.errorMessage.orEmpty(),
+                                onRetry = {
+                                    viewModel.retry()?.let { (mangaId, chapterId) ->
+                                        lifecycleScope.launch {
+                                            viewModel.init(mangaId, chapterId)
+                                        }
+                                    }
+                                },
+                            )
+                        }
+                    }
+                }
+
+                if (showToc) {
+                    TocDialog(
+                        entries = tocEntries,
+                        onDismissRequest = { showToc = false },
+                        onSelect = { entry ->
+                            (supportFragmentManager.findFragmentByTag(READER_FRAGMENT_TAG) as? EpubReaderFragment)
+                                ?.goTo(entry.link)
+                            showToc = false
+                        },
+                    )
+                }
+            }
+        }
+
+        if (viewModel.needsInit()) {
+            val mangaId = intent.extras?.getLong("manga", -1L) ?: -1L
+            val chapterId = intent.extras?.getLong("chapter", -1L) ?: -1L
+            if (mangaId <= 0 || chapterId <= 0) {
+                finish()
+                return
+            }
+
+            lifecycleScope.launchNonCancellable {
+                val initResult = viewModel.init(mangaId, chapterId)
+                if (initResult.isFailure) {
+                    withUIContext { updateSystemBars(viewModel.state.value.menuVisible) }
+                }
+            }
+        }
+
+        epubReaderPreferences.enableNativeReader.changes()
+            .onEach {
+                if (!it) finish()
+            }
+            .launchIn(lifecycleScope)
+
+        setKeepScreenOn(readerPreferences.keepScreenOn.get())
+        readerPreferences.keepScreenOn.changes()
+            .onEach(::setKeepScreenOn)
+            .launchIn(lifecycleScope)
+
+        readerPreferences.fullscreen.changes()
+            .onEach { updateSystemBars(viewModel.state.value.menuVisible) }
+            .launchIn(lifecycleScope)
+
+        viewModel.state
+            .map { it.menuVisible }
+            .distinctUntilChanged()
+            .onEach(::updateSystemBars)
+            .launchIn(lifecycleScope)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        updateSystemBars(viewModel.state.value.menuVisible)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            updateSystemBars(viewModel.state.value.menuVisible)
+        }
+    }
+
+    override fun onDestroy() {
+        if (isFinishing) {
+            viewModel.releaseSession()
+        }
+        super.onDestroy()
+    }
+
+    override fun finish() {
+        super.finish()
+    }
+
+    override fun onProvideAssistContent(outContent: AssistContent) {
+        super.onProvideAssistContent(outContent)
+    }
+
+    override fun onCenterTap() {
+        viewModel.showMenus(!viewModel.state.value.menuVisible)
+    }
+
+    override fun onLocatorChanged(locator: Locator) {
+        viewModel.updateLocator(locator)
+    }
+
+    override fun onExternalLinkActivated(url: AbsoluteUrl) {
+        openInBrowser(url.toUri(), forceDefaultBrowser = false)
+    }
+
+    private fun updateSystemBars(visible: Boolean) {
+        if (visible || !readerPreferences.fullscreen.get()) {
+            windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
+        } else {
+            windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        }
+    }
+
+    private fun setKeepScreenOn(enabled: Boolean) {
+        if (enabled) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
+    @Composable
+    private fun ReaderFragmentContainer(
+        fragmentManager: FragmentManager,
+        chapterId: Long,
+        modifier: Modifier = Modifier,
+    ) {
+        val initialized = remember(chapterId) { mutableStateOf(false) }
+        androidx.compose.ui.viewinterop.AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                FragmentContainerView(context).apply {
+                    id = android.view.View.generateViewId()
+                }
+            },
+            update = { view ->
+                if (!initialized.value) {
+                    fragmentManager.commit {
+                        setReorderingAllowed(true)
+                        replace(view.id, EpubReaderFragment.newInstance(chapterId), READER_FRAGMENT_TAG)
+                    }
+                    initialized.value = true
+                } else {
+                    fragmentManager.onContainerAvailable(view)
+                }
+                applyInsets(view, viewModel.state.value.menuVisible)
+            },
+        )
+    }
+
+    @Composable
+    private fun ErrorContent(
+        message: String,
+        onRetry: () -> Unit,
+    ) {
+        androidx.compose.foundation.layout.Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        ) {
+            Text(text = message)
+            Text(
+                text = stringResource(MR.strings.action_retry),
+                modifier = Modifier
+                    .padding(top = 16.dp)
+                    .clickable(onClick = onRetry),
+            )
+        }
+    }
+
+    @Composable
+    private fun TocDialog(
+        entries: List<EpubTocEntry>,
+        onDismissRequest: () -> Unit,
+        onSelect: (EpubTocEntry) -> Unit,
+    ) {
+        AlertDialog(
+            onDismissRequest = onDismissRequest,
+            confirmButton = {},
+            dismissButton = {},
+            title = { Text(text = stringResource(MR.strings.epub_reader_toc)) },
+            text = {
+                LazyColumn {
+                    items(entries) { entry ->
+                        Text(
+                            text = entry.title,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onSelect(entry) }
+                                .padding(start = (entry.depth * 16).dp, top = 8.dp, bottom = 8.dp),
+                        )
+                    }
+                }
+            },
+        )
+    }
+
+    private fun FragmentManager.onContainerAvailable(view: FragmentContainerView) {
+        val method = FragmentManager::class.java.getDeclaredMethod(
+            "onContainerAvailable",
+            FragmentContainerView::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(this, view)
+    }
+
+    private fun applyInsets(
+        view: android.view.View,
+        menuVisible: Boolean,
+    ) {
+        val insets = if (menuVisible || !readerPreferences.fullscreen.get()) {
+            ViewCompat.getRootWindowInsets(view)?.getInsets(WindowInsetsCompat.Type.systemBars()) ?: Insets.NONE
+        } else {
+            Insets.NONE
+        }
+        view.setPadding(insets.left, insets.top, insets.right, insets.bottom)
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -11,9 +11,12 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -31,13 +34,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.Insets
-import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.fragment.app.FragmentContainerView
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.commit
+import androidx.fragment.compose.AndroidFragment
 import androidx.lifecycle.lifecycleScope
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
@@ -46,6 +45,7 @@ import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.view.setComposeContent
 import koharia.epub.model.EpubTocEntry
 import koharia.epub.settings.EpubReaderPreferences
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -68,8 +68,6 @@ import uy.kohesive.injekt.api.get
 class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     companion object {
-        private const val READER_FRAGMENT_TAG = "epub_reader_fragment"
-
         fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, sourceId: Long? = null): Intent {
             return Intent(context, EpubReaderActivity::class.java).apply {
                 putExtra("manga", mangaId)
@@ -81,8 +79,21 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     private val viewModel by viewModels<EpubReaderViewModel>()
-    private val epubReaderPreferences = Injekt.get<EpubReaderPreferences>()
-    private val readerPreferences = Injekt.get<ReaderPreferences>()
+    private val scopedPreferenceStoreFactory = Injekt.get<KomgaScopedPreferenceStoreFactory>()
+    private val sourceId by lazy { intent.extras?.getLong("source", -1L) ?: -1L }
+    private val epubReaderPreferences by lazy {
+        sourceId
+            .takeIf { it > 0L }
+            ?.let(scopedPreferenceStoreFactory::epubReaderPreferences)
+            ?: Injekt.get<EpubReaderPreferences>()
+    }
+    private val readerPreferences by lazy {
+        sourceId
+            .takeIf { it > 0L }
+            ?.let(scopedPreferenceStoreFactory::readerPreferences)
+            ?: Injekt.get<ReaderPreferences>()
+    }
+    private var readerFragment: EpubReaderFragment? = null
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -131,8 +142,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 Box(modifier = Modifier.fillMaxSize()) {
                     if (state.isReady && state.chapterId > 0) {
                         ReaderFragmentContainer(
-                            fragmentManager = supportFragmentManager,
                             chapterId = state.chapterId,
+                            menuVisible = state.menuVisible,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .padding(if (state.menuVisible) contentPadding else PaddingValues(0.dp)),
@@ -163,8 +174,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                         entries = tocEntries,
                         onDismissRequest = { showToc = false },
                         onSelect = { entry ->
-                            (supportFragmentManager.findFragmentByTag(READER_FRAGMENT_TAG) as? EpubReaderFragment)
-                                ?.goTo(entry.link)
+                            readerFragment?.goTo(entry.link)
                             showToc = false
                         },
                     )
@@ -188,12 +198,6 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             }
         }
 
-        epubReaderPreferences.enableNativeReader.changes()
-            .onEach {
-                if (!it) finish()
-            }
-            .launchIn(lifecycleScope)
-
         setKeepScreenOn(readerPreferences.keepScreenOn.get())
         readerPreferences.keepScreenOn.changes()
             .onEach(::setKeepScreenOn)
@@ -210,8 +214,16 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             .launchIn(lifecycleScope)
     }
 
+    override fun onPause() {
+        lifecycleScope.launchNonCancellable {
+            viewModel.updateHistory()
+        }
+        super.onPause()
+    }
+
     override fun onResume() {
         super.onResume()
+        viewModel.restartReadTimer()
         updateSystemBars(viewModel.state.value.menuVisible)
     }
 
@@ -267,30 +279,22 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     @Composable
     private fun ReaderFragmentContainer(
-        fragmentManager: FragmentManager,
         chapterId: Long,
+        menuVisible: Boolean,
         modifier: Modifier = Modifier,
     ) {
-        val initialized = remember(chapterId) { mutableStateOf(false) }
-        androidx.compose.ui.viewinterop.AndroidView(
-            modifier = modifier,
-            factory = { context ->
-                FragmentContainerView(context).apply {
-                    id = android.view.View.generateViewId()
-                }
-            },
-            update = { view ->
-                if (!initialized.value) {
-                    fragmentManager.commit {
-                        setReorderingAllowed(true)
-                        replace(view.id, EpubReaderFragment.newInstance(chapterId), READER_FRAGMENT_TAG)
-                    }
-                    initialized.value = true
-                } else {
-                    fragmentManager.onContainerAvailable(view)
-                }
-                applyInsets(view, viewModel.state.value.menuVisible)
-            },
+        val fullscreen by remember(readerPreferences) { readerPreferences.fullscreen.changes() }
+            .collectAsState(initial = readerPreferences.fullscreen.get())
+        val arguments = remember(chapterId) { EpubReaderFragment.createArguments(chapterId) }
+        val containerModifier = if (!menuVisible && !fullscreen) {
+            modifier.windowInsetsPadding(WindowInsets.systemBars)
+        } else {
+            modifier
+        }
+        AndroidFragment<EpubReaderFragment>(
+            modifier = containerModifier,
+            arguments = arguments,
+            onUpdate = { readerFragment = it },
         )
     }
 
@@ -339,26 +343,5 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 }
             },
         )
-    }
-
-    private fun FragmentManager.onContainerAvailable(view: FragmentContainerView) {
-        val method = FragmentManager::class.java.getDeclaredMethod(
-            "onContainerAvailable",
-            FragmentContainerView::class.java,
-        )
-        method.isAccessible = true
-        method.invoke(this, view)
-    }
-
-    private fun applyInsets(
-        view: android.view.View,
-        menuVisible: Boolean,
-    ) {
-        val insets = if (menuVisible || !readerPreferences.fullscreen.get()) {
-            ViewCompat.getRootWindowInsets(view)?.getInsets(WindowInsetsCompat.Type.systemBars()) ?: Insets.NONE
-        } else {
-            Insets.NONE
-        }
-        view.setPadding(insets.left, insets.top, insets.right, insets.bottom)
     }
 }

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -1,0 +1,168 @@
+package koharia.epub
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.commitNow
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import koharia.epub.session.EpubReaderSessionRepository
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import org.readium.r2.navigator.HyperlinkNavigator
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.navigator.input.InputListener
+import org.readium.r2.navigator.input.TapEvent
+import org.readium.r2.navigator.util.DirectionalNavigationAdapter
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+@OptIn(ExperimentalReadiumApi::class)
+class EpubReaderFragment : Fragment() {
+
+    interface Host {
+        fun onCenterTap()
+
+        fun onLocatorChanged(locator: Locator)
+
+        fun onExternalLinkActivated(url: AbsoluteUrl)
+    }
+
+    private val sessionRepository: EpubReaderSessionRepository = Injekt.get()
+    private val chapterId: Long
+        get() = requireArguments().getLong(ARG_CHAPTER_ID)
+
+    private var host: Host? = null
+    private var containerId: Int = View.NO_ID
+
+    private val navigatorListener = object : EpubNavigatorFragment.Listener {
+        override fun onExternalLinkActivated(url: AbsoluteUrl) {
+            host?.onExternalLinkActivated(url)
+        }
+
+        override fun shouldFollowInternalLink(
+            link: Link,
+            context: HyperlinkNavigator.LinkContext?,
+        ): Boolean {
+            return true
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        host = context as? Host
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val session = sessionRepository.get(chapterId)
+        logcat(LogPriority.DEBUG) {
+            "EPUB fragment onCreate chapterId=$chapterId hasSession=${session != null}"
+        }
+        childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
+            initialLocator = session.initialLocator,
+            readingOrder = session.publication.readingOrder,
+            listener = navigatorListener,
+            configuration = EpubNavigatorFragment.Configuration(
+                shouldApplyInsetsPadding = false,
+            ),
+        ) ?: EpubNavigatorFragment.createDummyFactory()
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: android.view.LayoutInflater,
+        container: android.view.ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return FragmentContainerView(requireContext()).apply {
+            id = View.generateViewId()
+            containerId = id
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) == null && sessionRepository.get(chapterId) != null) {
+            logcat(LogPriority.DEBUG) {
+                "EPUB fragment create navigator chapterId=$chapterId containerId=$containerId"
+            }
+            val navigatorFragment = childFragmentManager.fragmentFactory.instantiate(
+                requireContext().classLoader,
+                EpubNavigatorFragment::class.java.name,
+            )
+            childFragmentManager.commitNow {
+                setReorderingAllowed(true)
+                replace(containerId, navigatorFragment, NAVIGATOR_TAG)
+            }
+        }
+        observeNavigator()
+    }
+
+    override fun onDetach() {
+        host = null
+        super.onDetach()
+    }
+
+    fun goTo(link: Link): Boolean {
+        val navigator = navigatorFragment() ?: return false
+        return navigator.go(link)
+    }
+
+    private fun observeNavigator() {
+        val navigator = navigatorFragment() ?: return
+        logcat(LogPriority.DEBUG) {
+            "EPUB fragment observe navigator chapterId=$chapterId"
+        }
+        navigator.addInputListener(
+            DirectionalNavigationAdapter(
+                navigator = navigator,
+                handleTapsWhileScrolling = true,
+            ),
+        )
+        navigator.addInputListener(
+            object : InputListener {
+                override fun onTap(event: TapEvent): Boolean {
+                    val width = navigator.publicationView.width.toFloat()
+                    val edgeSize = width * 0.3f
+                    if (event.point.x > edgeSize && event.point.x < width - edgeSize) {
+                        host?.onCenterTap()
+                        return true
+                    }
+                    return false
+                }
+            },
+        )
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                navigator.currentLocator.collect { locator ->
+                    host?.onLocatorChanged(locator)
+                }
+            }
+        }
+    }
+
+    private fun navigatorFragment(): EpubNavigatorFragment? =
+        childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
+
+    companion object {
+        private const val ARG_CHAPTER_ID = "chapter_id"
+        private const val NAVIGATOR_TAG = "epub_navigator"
+
+        fun newInstance(chapterId: Long): EpubReaderFragment {
+            return EpubReaderFragment().apply {
+                arguments = Bundle().apply {
+                    putLong(ARG_CHAPTER_ID, chapterId)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -156,13 +156,12 @@ class EpubReaderFragment : Fragment() {
     companion object {
         private const val ARG_CHAPTER_ID = "chapter_id"
         private const val NAVIGATOR_TAG = "epub_navigator"
+        fun createArguments(chapterId: Long): Bundle {
+            return Bundle().apply { putLong(ARG_CHAPTER_ID, chapterId) }
+        }
 
         fun newInstance(chapterId: Long): EpubReaderFragment {
-            return EpubReaderFragment().apply {
-                arguments = Bundle().apply {
-                    putLong(ARG_CHAPTER_ID, chapterId)
-                }
-            }
+            return EpubReaderFragment().apply { arguments = createArguments(chapterId) }
         }
     }
 }

--- a/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
@@ -1,0 +1,87 @@
+package koharia.epub
+
+import android.content.Context
+import android.content.Intent
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.ui.reader.ReaderActivity
+import koharia.epub.settings.EpubReaderPreferences
+import koharia.komga.api.dto.isEpub
+import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class EpubReaderLauncher @JvmOverloads constructor(
+    private val getManga: GetManga = Injekt.get(),
+    private val getChapter: GetChapter = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val epubReaderPreferences: EpubReaderPreferences = Injekt.get(),
+) {
+
+    fun launch(
+        scope: CoroutineScope,
+        context: Context,
+        mangaId: Long,
+        chapterId: Long,
+    ) {
+        scope.launch {
+            context.startActivity(resolveIntent(context, mangaId, chapterId))
+        }
+    }
+
+    suspend fun resolveIntent(
+        context: Context,
+        mangaId: Long,
+        chapterId: Long,
+    ): Intent {
+        if (!epubReaderPreferences.enableNativeReader.get()) {
+            return ReaderActivity.newIntent(context, mangaId, chapterId)
+        }
+
+        return withIOContext {
+            val manga = getManga.await(mangaId)
+            val chapter = getChapter.await(chapterId)
+            val source = manga?.let { sourceManager.get(it.source) }
+
+            if (manga == null || chapter == null || source !is KomgaSource) {
+                return@withIOContext ReaderActivity.newIntent(context, mangaId, chapterId)
+            }
+
+            val localFile = downloadProvider.findChapterDir(
+                chapterName = chapter.name,
+                chapterScanlator = chapter.scanlator,
+                chapterUrl = chapter.url,
+                mangaTitle = manga.title,
+                source = source,
+            )
+
+            val shouldOpenLocalEpub = localFile?.extension.equals("epub", ignoreCase = true)
+            if (shouldOpenLocalEpub) {
+                return@withIOContext EpubReaderActivity.newIntent(context, mangaId, chapterId)
+            }
+
+            try {
+                val book = source.getBookDetails(chapter.url)
+                if (book?.isEpub == true) {
+                    EpubReaderActivity.newIntent(context, mangaId, chapterId)
+                } else {
+                    ReaderActivity.newIntent(context, mangaId, chapterId)
+                }
+            } catch (e: Exception) {
+                logcat(LogPriority.WARN, e) {
+                    "EpubReaderLauncher failed to resolve reader type for chapterId=$chapterId"
+                }
+                ReaderActivity.newIntent(context, mangaId, chapterId)
+            }
+        }
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
@@ -2,29 +2,24 @@ package koharia.epub
 
 import android.content.Context
 import android.content.Intent
-import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
+import koharia.epub.service.EpubReaderSupportResolver
 import koharia.epub.settings.EpubReaderPreferences
-import koharia.komga.api.dto.isEpub
-import koharia.source.komga.KomgaSource
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
-import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
-import tachiyomi.domain.chapter.interactor.GetChapter
 import tachiyomi.domain.manga.interactor.GetManga
-import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 class EpubReaderLauncher @JvmOverloads constructor(
-    private val getManga: GetManga = Injekt.get(),
-    private val getChapter: GetChapter = Injekt.get(),
-    private val sourceManager: SourceManager = Injekt.get(),
-    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val supportResolver: EpubReaderSupportResolver = Injekt.get(),
     private val epubReaderPreferences: EpubReaderPreferences = Injekt.get(),
+    private val getManga: GetManga = Injekt.get(),
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) {
 
     fun launch(
@@ -38,49 +33,50 @@ class EpubReaderLauncher @JvmOverloads constructor(
         }
     }
 
+    fun launchAsPages(
+        scope: CoroutineScope,
+        context: Context,
+        mangaId: Long,
+        chapterId: Long,
+    ) {
+        scope.launch {
+            context.startActivity(resolveIntent(context, mangaId, chapterId, forcePages = true))
+        }
+    }
+
     suspend fun resolveIntent(
         context: Context,
         mangaId: Long,
         chapterId: Long,
+        forcePages: Boolean = false,
     ): Intent {
-        if (!epubReaderPreferences.enableNativeReader.get()) {
-            return ReaderActivity.newIntent(context, mangaId, chapterId)
+        val sourceId = withIOContext { getManga.await(mangaId)?.source }
+        val scopedPreferences = sourceId
+            ?.takeIf { it > 0L }
+            ?.let(scopedPreferenceStoreFactory::epubReaderPreferences)
+            ?: epubReaderPreferences
+
+        if (forcePages) {
+            return ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
         }
 
         return withIOContext {
-            val manga = getManga.await(mangaId)
-            val chapter = getChapter.await(chapterId)
-            val source = manga?.let { sourceManager.get(it.source) }
-
-            if (manga == null || chapter == null || source !is KomgaSource) {
-                return@withIOContext ReaderActivity.newIntent(context, mangaId, chapterId)
-            }
-
-            val localFile = downloadProvider.findChapterDir(
-                chapterName = chapter.name,
-                chapterScanlator = chapter.scanlator,
-                chapterUrl = chapter.url,
-                mangaTitle = manga.title,
-                source = source,
-            )
-
-            val shouldOpenLocalEpub = localFile?.extension.equals("epub", ignoreCase = true)
-            if (shouldOpenLocalEpub) {
-                return@withIOContext EpubReaderActivity.newIntent(context, mangaId, chapterId)
-            }
-
-            try {
-                val book = source.getBookDetails(chapter.url)
-                if (book?.isEpub == true) {
-                    EpubReaderActivity.newIntent(context, mangaId, chapterId)
+            runCatching {
+                if (supportResolver.resolve(
+                        mangaId = mangaId,
+                        chapterId = chapterId,
+                        preferLocalFile = scopedPreferences.preferLocalFile.get(),
+                    ).isNativeSupported
+                ) {
+                    EpubReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
                 } else {
-                    ReaderActivity.newIntent(context, mangaId, chapterId)
+                    ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
                 }
-            } catch (e: Exception) {
-                logcat(LogPriority.WARN, e) {
+            }.getOrElse { error ->
+                logcat(LogPriority.WARN, error) {
                     "EpubReaderLauncher failed to resolve reader type for chapterId=$chapterId"
                 }
-                ReaderActivity.newIntent(context, mangaId, chapterId)
+                ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
             }
         }
     }

--- a/app/src/main/java/koharia/epub/EpubReaderUiState.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderUiState.kt
@@ -1,0 +1,17 @@
+package koharia.epub
+
+import androidx.compose.runtime.Immutable
+
+@Immutable
+data class EpubReaderUiState(
+    val mangaId: Long = -1L,
+    val chapterId: Long = -1L,
+    val mangaTitle: String? = null,
+    val chapterTitle: String? = null,
+    val currentSectionTitle: String? = null,
+    val progressionPercent: Int? = null,
+    val isLoading: Boolean = false,
+    val isReady: Boolean = false,
+    val menuVisible: Boolean = true,
+    val errorMessage: String? = null,
+)

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -113,6 +113,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var currentChapterRead = false
     private var historyReadStartTime: Long? = null
     private var completionMarkedThisSession = false
+    private var incognitoSession = basePreferences.incognitoMode.get()
     private val locatorPersistenceJob = viewModelScope.launch {
         locatorUpdates
             .debounce(750L)
@@ -147,6 +148,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 savedState["source_id"] = source.id
                 epubReaderPreferences = scopedPreferenceStoreFactory.epubReaderPreferences(source.id)
                 basePreferences = scopedPreferenceStoreFactory.basePreferences(source.id)
+                incognitoSession = basePreferences.incognitoMode.get()
                 currentChapterRead = chapter.read
                 completionMarkedThisSession = chapter.read
                 historyReadStartTime = if (isIncognito()) null else System.currentTimeMillis()
@@ -317,7 +319,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         return flattenLinks(session.publication.tableOfContents)
     }
 
-    fun isIncognito(): Boolean = basePreferences.incognitoMode.get()
+    fun isIncognito(): Boolean = incognitoSession
 
     fun restartReadTimer() {
         historyReadStartTime = if (isIncognito()) null else System.currentTimeMillis()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -16,15 +16,21 @@ import koharia.epub.service.EpubPublicationResolver
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.komga.api.dto.isEpub
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
 import org.json.JSONObject
 import org.readium.r2.shared.publication.Link
@@ -34,6 +40,10 @@ import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.ChapterUpdate
+import tachiyomi.domain.history.interactor.UpsertHistory
+import tachiyomi.domain.history.model.HistoryUpdate
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
@@ -53,9 +63,21 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private val getEpubProgress: GetEpubProgress = Injekt.get(),
     private val upsertEpubProgress: UpsertEpubProgress = Injekt.get(),
     private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
-    private val epubReaderPreferences: EpubReaderPreferences = Injekt.get(),
-    private val basePreferences: BasePreferences = Injekt.get(),
+    private val updateChapter: UpdateChapter = Injekt.get(),
+    private val upsertHistory: UpsertHistory = Injekt.get(),
+    globalEpubReaderPreferences: EpubReaderPreferences = Injekt.get(),
+    globalBasePreferences: BasePreferences = Injekt.get(),
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) : ViewModel() {
+
+    private var epubReaderPreferences =
+        scopedPreferenceStoreFactory.epubReaderPreferencesForSavedSource(savedState) ?: globalEpubReaderPreferences
+    private var basePreferences =
+        scopedPreferenceStoreFactory.basePreferencesForSavedSource(savedState) ?: globalBasePreferences
+
+    private companion object {
+        val sessionReleaseScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
 
     private val mutableState = MutableStateFlow(EpubReaderUiState())
     val state = mutableState.asStateFlow()
@@ -64,6 +86,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
 
+    private val progressPersistenceMutex = Mutex()
     private var mangaId = savedState.get<Long>("manga_id") ?: -1L
         set(value) {
             savedState["manga_id"] = value
@@ -87,12 +110,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var currentProgress: EpubProgress? = null
     private var latestLocator: Locator? = null
 
-    init {
-        viewModelScope.launch {
-            locatorUpdates
-                .debounce(750L)
-                .collectLatest(::persistLocator)
-        }
+    private var currentChapterRead = false
+    private var historyReadStartTime: Long? = null
+    private var completionMarkedThisSession = false
+    private val locatorPersistenceJob = viewModelScope.launch {
+        locatorUpdates
+            .debounce(750L)
+            .collect(::persistLocator)
     }
 
     fun needsInit(): Boolean = !state.value.isLoading && !state.value.isReady
@@ -120,6 +144,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 val source = sourceManager.get(manga.source) as? KomgaSource
                     ?: error(application.stringResource(MR.strings.source_unsupported))
                 currentSourceId = source.id
+                savedState["source_id"] = source.id
+                epubReaderPreferences = scopedPreferenceStoreFactory.epubReaderPreferences(source.id)
+                basePreferences = scopedPreferenceStoreFactory.basePreferences(source.id)
+                currentChapterRead = chapter.read
+                completionMarkedThisSession = chapter.read
+                historyReadStartTime = if (isIncognito()) null else System.currentTimeMillis()
 
                 val localFile = downloadProvider.findChapterDir(
                     chapterName = chapter.name,
@@ -289,15 +319,43 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun isIncognito(): Boolean = basePreferences.incognitoMode.get()
 
+    fun restartReadTimer() {
+        historyReadStartTime = if (isIncognito()) null else System.currentTimeMillis()
+    }
+
+    suspend fun updateHistory() {
+        if (isIncognito()) return
+
+        val chapterId = chapterId.takeIf { it > 0 } ?: return
+        val endTime = Date()
+        val sessionReadDuration = historyReadStartTime
+            ?.let { startTime -> (endTime.time - startTime).coerceAtLeast(0L) }
+            ?: 0L
+        upsertHistory.await(
+            HistoryUpdate(
+                chapterId = chapterId,
+                readAt = endTime,
+                sessionReadDuration = sessionReadDuration,
+            ),
+        )
+        historyReadStartTime = null
+    }
+
     fun releaseSession() {
-        latestLocator?.let { locator ->
-            if (!isIncognito()) {
-                viewModelScope.launch {
-                    persistLocator(locator)
-                }
+        locatorPersistenceJob.cancel()
+        sessionRepository.remove(chapterId)?.close()
+
+        val locator = latestLocator
+        if (locator != null && !isIncognito()) {
+            sessionReleaseScope.launch {
+                runCatching { persistLocator(locator) }
+                    .onFailure { error ->
+                        logcat(LogPriority.ERROR, error) {
+                            "Failed to persist final EPUB locator for chapterId=$chapterId"
+                        }
+                    }
             }
         }
-        sessionRepository.remove(chapterId)?.close()
     }
 
     private fun restoreLocator(): Locator? =
@@ -323,9 +381,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
         }
     }
 
-    private suspend fun persistLocator(locator: Locator) {
-        val chapterId = chapterId.takeIf { it > 0 } ?: return
-        val mangaId = mangaId.takeIf { it > 0 } ?: return
+    private suspend fun persistLocator(locator: Locator) = progressPersistenceMutex.withLock {
+        val chapterId = chapterId.takeIf { it > 0 } ?: return@withLock
+        mangaId.takeIf { it > 0 } ?: return@withLock
         val now = Date()
         val progress = buildProgress(
             locator = locator,
@@ -334,6 +392,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
         )
         upsertEpubProgress.await(progress)
         currentProgress = progress
+
+        markChapterCompletedIfNeeded(locator)
 
         val bookUrl = progress.bookUrl
         val sourceId = currentSourceId.takeIf { it > 0 }
@@ -349,6 +409,24 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    private suspend fun markChapterCompletedIfNeeded(locator: Locator) {
+        if (completionMarkedThisSession || currentChapterRead) return
+
+        val totalProgression = (locator.locations.totalProgression as? Number)?.toDouble() ?: return
+        val threshold = epubReaderPreferences.completionThresholdPercent.get().coerceIn(0, 100) / 100.0
+        if (totalProgression < threshold) return
+
+        updateChapter.await(
+            ChapterUpdate(
+                id = chapterId,
+                read = true,
+                lastPageRead = 0,
+            ),
+        )
+        currentChapterRead = true
+        completionMarkedThisSession = true
     }
 
     private fun buildProgress(

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -1,0 +1,421 @@
+package koharia.epub
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import eu.kanade.domain.base.BasePreferences
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.domain.epub.interactor.UpsertEpubProgress
+import koharia.domain.epub.model.EpubProgress
+import koharia.epub.model.EpubOpenRequest
+import koharia.epub.model.EpubTocEntry
+import koharia.epub.progress.KomgaEpubProgressSyncService
+import koharia.epub.service.EpubPublicationResolver
+import koharia.epub.session.EpubReaderSessionRepository
+import koharia.epub.settings.EpubReaderPreferences
+import koharia.komga.api.dto.isEpub
+import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.Date
+
+class EpubReaderViewModel @JvmOverloads constructor(
+    private val savedState: SavedStateHandle,
+    private val application: Application = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val getManga: GetManga = Injekt.get(),
+    private val getChapter: GetChapter = Injekt.get(),
+    private val publicationResolver: EpubPublicationResolver = Injekt.get(),
+    private val sessionRepository: EpubReaderSessionRepository = Injekt.get(),
+    private val getEpubProgress: GetEpubProgress = Injekt.get(),
+    private val upsertEpubProgress: UpsertEpubProgress = Injekt.get(),
+    private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
+    private val epubReaderPreferences: EpubReaderPreferences = Injekt.get(),
+    private val basePreferences: BasePreferences = Injekt.get(),
+) : ViewModel() {
+
+    private val mutableState = MutableStateFlow(EpubReaderUiState())
+    val state = mutableState.asStateFlow()
+    private val locatorUpdates = MutableSharedFlow<Locator>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private var mangaId = savedState.get<Long>("manga_id") ?: -1L
+        set(value) {
+            savedState["manga_id"] = value
+            field = value
+        }
+
+    private var chapterId = savedState.get<Long>("chapter_id") ?: -1L
+        set(value) {
+            savedState["chapter_id"] = value
+            field = value
+        }
+
+    private var locatorJson = savedState.get<String>("locator_json")
+        set(value) {
+            savedState["locator_json"] = value
+            field = value
+        }
+
+    private var currentBookUrl: String? = null
+    private var currentSourceId: Long = -1L
+    private var currentProgress: EpubProgress? = null
+    private var latestLocator: Locator? = null
+
+    init {
+        viewModelScope.launch {
+            locatorUpdates
+                .debounce(750L)
+                .collectLatest(::persistLocator)
+        }
+    }
+
+    fun needsInit(): Boolean = !state.value.isLoading && !state.value.isReady
+
+    suspend fun init(
+        mangaId: Long,
+        chapterId: Long,
+    ): Result<Unit> {
+        this.mangaId = mangaId
+        this.chapterId = chapterId
+        mutableState.update {
+            it.copy(
+                mangaId = mangaId,
+                chapterId = chapterId,
+                isLoading = true,
+                isReady = false,
+                errorMessage = null,
+            )
+        }
+
+        return withIOContext {
+            runCatching {
+                val manga = checkNotNull(getManga.await(mangaId)) { "Manga not found" }
+                val chapter = checkNotNull(getChapter.await(chapterId)) { "Chapter not found" }
+                val source = sourceManager.get(manga.source) as? KomgaSource
+                    ?: error(application.stringResource(MR.strings.source_unsupported))
+                currentSourceId = source.id
+
+                val localFile = downloadProvider.findChapterDir(
+                    chapterName = chapter.name,
+                    chapterScanlator = chapter.scanlator,
+                    chapterUrl = chapter.url,
+                    mangaTitle = manga.title,
+                    source = source,
+                )
+                val localUri = localFile
+                    ?.takeIf { it.extension.equals("epub", ignoreCase = true) }
+                    ?.uri
+                    ?.toString()
+
+                val remoteBookUrl = runCatching { source.getBookDetails(chapter.url) }
+                    .getOrNull()
+                    ?.takeIf { it.isEpub }
+                    ?.let { chapter.url.substringBefore('#').removeSuffix("/") }
+
+                check(localUri != null || remoteBookUrl != null) {
+                    application.stringResource(MR.strings.epub_reader_unsupported_book)
+                }
+
+                val primarySource = when {
+                    epubReaderPreferences.preferLocalFile.get() && localUri != null ->
+                        EpubOpenRequest.OpenSource.LOCAL
+                    remoteBookUrl != null ->
+                        EpubOpenRequest.OpenSource.REMOTE
+                    else ->
+                        EpubOpenRequest.OpenSource.LOCAL
+                }
+                logcat(LogPriority.DEBUG) {
+                    "EPUB init chapterId=${chapter.id} localUri=$localUri remoteBookUrl=$remoteBookUrl primarySource=$primarySource incognito=${isIncognito()}"
+                }
+
+                currentBookUrl = remoteBookUrl
+
+                val incognito = isIncognito()
+                val localProgress = if (incognito) {
+                    null
+                } else {
+                    getEpubProgress.await(chapter.id)
+                }
+                val remoteProgress = if (incognito || remoteBookUrl == null ||
+                    !epubReaderPreferences.syncProgressionToKomga.get()
+                ) {
+                    null
+                } else {
+                    runCatching { komgaEpubProgressSyncService.pullProgression(source.id, remoteBookUrl) }
+                        .onFailure { error ->
+                            logcat(LogPriority.WARN, error) {
+                                "Failed to pull Komga EPUB progression for chapterId=${chapter.id}"
+                            }
+                        }
+                        .getOrNull()
+                }
+                val persistedLocator = localProgress?.toLocatorOrNull()
+                val initialLocator = restoreLocator()
+                    ?: chooseMoreRecentLocator(localProgress, remoteProgress)
+
+                if (initialLocator != null) {
+                    latestLocator = initialLocator
+                    locatorJson = initialLocator.toJSON().toString()
+                }
+
+                val session = publicationResolver.open(
+                    request = EpubOpenRequest(
+                        mangaId = manga.id,
+                        chapterId = chapter.id,
+                        sourceId = source.id,
+                        title = chapter.name,
+                        bookUrl = remoteBookUrl,
+                        localUri = localUri,
+                        openSource = primarySource,
+                    ),
+                    initialLocator = initialLocator,
+                )
+                sessionRepository.put(session)
+                logcat(LogPriority.DEBUG) {
+                    "EPUB session ready chapterId=${chapter.id} readingOrder=${session.publication.readingOrder.size} toc=${session.publication.tableOfContents.size}"
+                }
+                latestLocator = initialLocator
+                currentProgress = localProgress
+
+                mutableState.update {
+                    it.copy(
+                        mangaId = manga.id,
+                        chapterId = chapter.id,
+                        mangaTitle = manga.title,
+                        chapterTitle = chapter.name,
+                        currentSectionTitle = initialLocator?.title,
+                        progressionPercent = initialLocator?.progressionPercent(),
+                        isLoading = false,
+                        isReady = true,
+                        menuVisible = true,
+                        errorMessage = null,
+                    )
+                }
+
+                if (!incognito) {
+                    val selectedRemote = remoteProgress?.takeIf {
+                        localProgress == null || it.modifiedAt.time > localProgress.updatedAt.time
+                    }
+                    if (selectedRemote != null) {
+                        val syncedProgress = buildProgress(
+                            locator = selectedRemote.locator,
+                            updatedAt = selectedRemote.modifiedAt,
+                            lastSyncedAt = selectedRemote.modifiedAt,
+                        )
+                        currentProgress = syncedProgress
+                        upsertEpubProgress.await(syncedProgress)
+                    } else if (remoteBookUrl != null && localProgress != null && persistedLocator != null &&
+                        epubReaderPreferences.syncProgressionToKomga.get() &&
+                        (remoteProgress == null || localProgress.updatedAt.time > remoteProgress.modifiedAt.time)
+                    ) {
+                        syncPersistedProgress(localProgress, persistedLocator)
+                    }
+                }
+            }
+                .onFailure { error ->
+                    logcat(LogPriority.ERROR, error) {
+                        "EPUB init failed chapterId=$chapterId mangaId=$mangaId"
+                    }
+                    mutableState.update {
+                        it.copy(
+                            isLoading = false,
+                            isReady = false,
+                            errorMessage =
+                            error.message ?: application.stringResource(MR.strings.epub_reader_open_failed),
+                        )
+                    }
+                }
+        }
+    }
+
+    fun retry(): Pair<Long, Long>? {
+        val mangaId = mangaId.takeIf { it > 0 } ?: return null
+        val chapterId = chapterId.takeIf { it > 0 } ?: return null
+        return mangaId to chapterId
+    }
+
+    fun showMenus(visible: Boolean) {
+        mutableState.update { it.copy(menuVisible = visible) }
+    }
+
+    fun updateLocator(locator: Locator) {
+        latestLocator = locator
+        val newLocatorJson = locator.toJSON().toString()
+        locatorJson = newLocatorJson
+        logcat(LogPriority.DEBUG) {
+            "EPUB locator update chapterId=$chapterId href=${locator.href} progression=${locator.totalProgressionValue()} position=${locator.positionIndex()}"
+        }
+        mutableState.update {
+            it.copy(
+                currentSectionTitle = locator.title ?: it.currentSectionTitle,
+                progressionPercent = locator.progressionPercent(),
+            )
+        }
+        if (!isIncognito()) {
+            locatorUpdates.tryEmit(locator)
+        }
+    }
+
+    fun tableOfContents(): List<EpubTocEntry> {
+        val session = sessionRepository.get(chapterId) ?: return emptyList()
+        return flattenLinks(session.publication.tableOfContents)
+    }
+
+    fun isIncognito(): Boolean = basePreferences.incognitoMode.get()
+
+    fun releaseSession() {
+        latestLocator?.let { locator ->
+            if (!isIncognito()) {
+                viewModelScope.launch {
+                    persistLocator(locator)
+                }
+            }
+        }
+        sessionRepository.remove(chapterId)?.close()
+    }
+
+    private fun restoreLocator(): Locator? =
+        locatorJson?.let {
+            runCatching { Locator.fromJSON(JSONObject(it)) }.getOrNull()
+        }
+
+    private suspend fun syncPersistedProgress(
+        localProgress: EpubProgress,
+        locator: Locator,
+    ) {
+        val bookUrl = localProgress.bookUrl ?: currentBookUrl ?: return
+        val sourceId = currentSourceId.takeIf { it > 0 } ?: return
+        runCatching {
+            komgaEpubProgressSyncService.pushProgression(sourceId, bookUrl, locator, localProgress.updatedAt)
+            val syncedProgress = localProgress.copy(lastSyncedAt = localProgress.updatedAt)
+            currentProgress = syncedProgress
+            upsertEpubProgress.await(syncedProgress)
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) {
+                "Failed to sync existing Komga EPUB progression for chapterId=${localProgress.chapterId}"
+            }
+        }
+    }
+
+    private suspend fun persistLocator(locator: Locator) {
+        val chapterId = chapterId.takeIf { it > 0 } ?: return
+        val mangaId = mangaId.takeIf { it > 0 } ?: return
+        val now = Date()
+        val progress = buildProgress(
+            locator = locator,
+            updatedAt = now,
+            lastSyncedAt = currentProgress?.lastSyncedAt,
+        )
+        upsertEpubProgress.await(progress)
+        currentProgress = progress
+
+        val bookUrl = progress.bookUrl
+        val sourceId = currentSourceId.takeIf { it > 0 }
+        if (bookUrl != null && sourceId != null && epubReaderPreferences.syncProgressionToKomga.get()) {
+            runCatching {
+                komgaEpubProgressSyncService.pushProgression(sourceId, bookUrl, locator, now)
+                val syncedProgress = progress.copy(lastSyncedAt = now)
+                upsertEpubProgress.await(syncedProgress)
+                currentProgress = syncedProgress
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to push Komga EPUB progression for chapterId=$chapterId"
+                }
+            }
+        }
+    }
+
+    private fun buildProgress(
+        locator: Locator,
+        updatedAt: Date,
+        lastSyncedAt: Date?,
+    ): EpubProgress {
+        return EpubProgress(
+            chapterId = chapterId,
+            mangaId = mangaId,
+            bookUrl = currentBookUrl ?: currentProgress?.bookUrl,
+            locatorJson = locator.toJSON().toString(),
+            progression = locator.totalProgressionValue(),
+            positionIndex = locator.positionIndex(),
+            updatedAt = updatedAt,
+            lastSyncedAt = lastSyncedAt,
+        )
+    }
+
+    private fun chooseMoreRecentLocator(
+        localProgress: EpubProgress?,
+        remoteProgress: KomgaEpubProgressSyncService.RemoteProgression?,
+    ): Locator? {
+        val localLocator = localProgress?.toLocatorOrNull()
+        return when {
+            remoteProgress != null &&
+                (localProgress == null || remoteProgress.modifiedAt.time > localProgress.updatedAt.time) ->
+                remoteProgress.locator
+            localLocator != null ->
+                localLocator
+            else ->
+                remoteProgress?.locator
+        }
+    }
+
+    private fun flattenLinks(
+        links: List<Link>,
+        depth: Int = 0,
+    ): List<EpubTocEntry> {
+        return links.flatMap { link ->
+            buildList {
+                add(
+                    EpubTocEntry(
+                        title = link.title?.takeIf(String::isNotBlank) ?: link.href.toString(),
+                        link = link,
+                        depth = depth,
+                    ),
+                )
+                addAll(flattenLinks(link.children, depth + 1))
+            }
+        }
+    }
+
+    private fun EpubProgress.toLocatorOrNull(): Locator? {
+        return runCatching { Locator.fromJSON(JSONObject(locatorJson)) }.getOrNull()
+    }
+
+    private fun Locator.progressionPercent(): Int? {
+        return totalProgressionValue()?.times(100)?.toInt()
+    }
+
+    private fun Locator.totalProgressionValue(): Double? {
+        return (locations.totalProgression as? Number)?.toDouble()
+            ?: (locations.progression as? Number)?.toDouble()
+    }
+
+    private fun Locator.positionIndex(): Long? {
+        return (locations.position as? Number)?.toLong()
+    }
+}

--- a/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
+++ b/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
@@ -8,6 +8,7 @@ data class EpubOpenRequest(
     val bookUrl: String?,
     val localUri: String?,
     val openSource: OpenSource,
+    val publisherStylesOverride: Boolean? = null,
 ) {
     enum class OpenSource {
         LOCAL,

--- a/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
+++ b/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
@@ -1,0 +1,16 @@
+package koharia.epub.model
+
+data class EpubOpenRequest(
+    val mangaId: Long,
+    val chapterId: Long,
+    val sourceId: Long,
+    val title: String,
+    val bookUrl: String?,
+    val localUri: String?,
+    val openSource: OpenSource,
+) {
+    enum class OpenSource {
+        LOCAL,
+        REMOTE,
+    }
+}

--- a/app/src/main/java/koharia/epub/model/EpubTocEntry.kt
+++ b/app/src/main/java/koharia/epub/model/EpubTocEntry.kt
@@ -1,0 +1,9 @@
+package koharia.epub.model
+
+import org.readium.r2.shared.publication.Link
+
+data class EpubTocEntry(
+    val title: String,
+    val link: Link,
+    val depth: Int,
+)

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -1,0 +1,99 @@
+package koharia.epub.progress
+
+import android.os.Build
+import eu.kanade.domain.base.BasePreferences
+import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.awaitSuccess
+import koharia.source.komga.KomgaSource
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
+import org.readium.r2.shared.publication.Locator
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.source.service.SourceManager
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.util.Date
+
+class KomgaEpubProgressSyncService(
+    private val basePreferences: BasePreferences,
+    private val sourceManager: SourceManager,
+) {
+
+    suspend fun pullProgression(
+        sourceId: Long,
+        bookUrl: String,
+    ): RemoteProgression? = withIOContext {
+        val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext null
+        val normalizedBookUrl = normalizeBookUrl(bookUrl)
+        source.client.newCall(GET("$normalizedBookUrl/progression", source.currentReadiumHeaders()))
+            .awaitSuccess()
+            .use { response ->
+                val body = response.body.string().trim()
+                if (body.isBlank() || body == "\"\"") {
+                    return@withIOContext null
+                }
+
+                val json = JSONObject(body)
+                val locator = json.optJSONObject("locator")?.let(Locator::fromJSON) ?: return@withIOContext null
+                val modifiedAt = json.optString("modified")
+                    .takeIf(String::isNotBlank)
+                    ?.let(::parseDate)
+                    ?: return@withIOContext null
+
+                RemoteProgression(
+                    locator = locator,
+                    modifiedAt = modifiedAt,
+                )
+            }
+    }
+
+    suspend fun pushProgression(
+        sourceId: Long,
+        bookUrl: String,
+        locator: Locator,
+        modifiedAt: Date,
+    ) = withIOContext {
+        val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext
+        val normalizedBookUrl = normalizeBookUrl(bookUrl)
+        val payload = JSONObject().apply {
+            put(
+                "device",
+                JSONObject().apply {
+                    put("id", basePreferences.installationId.get().ifBlank { "koharia-${Build.DEVICE}" })
+                    put("name", buildDeviceName())
+                },
+            )
+            put("locator", locator.toJSON())
+            put("modified", modifiedAt.toInstant().toString())
+        }
+        val request = Request.Builder()
+            .url("$normalizedBookUrl/progression")
+            .headers(source.currentReadiumHeaders())
+            .put(payload.toString().toRequestBody("application/json".toMediaType()))
+            .build()
+
+        source.client.newCall(request).awaitSuccess().close()
+    }
+
+    private fun normalizeBookUrl(bookUrl: String): String = bookUrl.substringBefore('#').removeSuffix("/")
+
+    private fun parseDate(value: String): Date? {
+        return runCatching { Date.from(Instant.parse(value)) }
+            .recoverCatching { Date.from(OffsetDateTime.parse(value).toInstant()) }
+            .getOrNull()
+    }
+
+    private fun buildDeviceName(): String {
+        return listOfNotNull(
+            Build.MANUFACTURER?.trim().takeIf { !it.isNullOrBlank() },
+            Build.MODEL?.trim().takeIf { !it.isNullOrBlank() },
+        ).joinToString(" ").ifBlank { "Android" }
+    }
+
+    data class RemoteProgression(
+        val locator: Locator,
+        val modifiedAt: Date,
+    )
+}

--- a/app/src/main/java/koharia/epub/service/EpubPublicationResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubPublicationResolver.kt
@@ -1,0 +1,46 @@
+package koharia.epub.service
+
+import koharia.epub.model.EpubOpenRequest
+import koharia.epub.model.EpubOpenRequest.OpenSource
+import koharia.epub.session.EpubReaderSession
+import org.readium.r2.shared.publication.Locator
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class EpubPublicationResolver(
+    private val localService: LocalEpubPublicationService = Injekt.get(),
+    private val komgaService: KomgaEpubPublicationService = Injekt.get(),
+) {
+
+    suspend fun open(
+        request: EpubOpenRequest,
+        initialLocator: Locator?,
+    ): EpubReaderSession {
+        val attempts = buildList {
+            when (request.openSource) {
+                OpenSource.LOCAL -> {
+                    if (request.localUri != null) add(OpenSource.LOCAL)
+                    if (request.bookUrl != null) add(OpenSource.REMOTE)
+                }
+                OpenSource.REMOTE -> {
+                    if (request.bookUrl != null) add(OpenSource.REMOTE)
+                    if (request.localUri != null) add(OpenSource.LOCAL)
+                }
+            }
+        }.distinct()
+
+        var lastError: Throwable? = null
+        attempts.forEach { source ->
+            runCatching {
+                when (source) {
+                    OpenSource.LOCAL -> localService.open(request, initialLocator)
+                    OpenSource.REMOTE -> komgaService.open(request, initialLocator)
+                }
+            }
+                .onSuccess { return it }
+                .onFailure { lastError = it }
+        }
+
+        throw lastError ?: IllegalStateException("No EPUB open strategy available")
+    }
+}

--- a/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
@@ -1,0 +1,158 @@
+package koharia.epub.service
+
+import android.app.Application
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.util.system.isOnline
+import koharia.epub.model.EpubOpenRequest
+import koharia.komga.api.dto.isDivinaCompatibleEpub
+import koharia.komga.api.dto.isEpub
+import koharia.source.komga.KomgaSource
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.storage.extension
+import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.manga.interactor.GetManga
+import tachiyomi.domain.source.service.SourceManager
+import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class EpubReaderSupportResolver @JvmOverloads constructor(
+    private val application: Application = Injekt.get(),
+    private val sourceManager: SourceManager = Injekt.get(),
+    private val downloadProvider: DownloadProvider = Injekt.get(),
+    private val getManga: GetManga = Injekt.get(),
+    private val getChapter: GetChapter = Injekt.get(),
+) {
+
+    suspend fun resolve(
+        mangaId: Long,
+        chapterId: Long,
+        preferLocalFile: Boolean,
+    ): EpubReaderSupportResolution = withIOContext {
+        val manga = getManga.await(mangaId) ?: return@withIOContext EpubReaderSupportResolution(
+            mangaId = mangaId,
+            chapterId = chapterId,
+            unsupportedReason = EpubReaderSupportResolution.UnsupportedReason.MANGA_NOT_FOUND,
+        )
+        val chapter = getChapter.await(chapterId) ?: return@withIOContext EpubReaderSupportResolution(
+            mangaId = mangaId,
+            chapterId = chapterId,
+            mangaTitle = manga.title,
+            unsupportedReason = EpubReaderSupportResolution.UnsupportedReason.CHAPTER_NOT_FOUND,
+        )
+        val source = sourceManager.get(manga.source) as? KomgaSource
+            ?: return@withIOContext EpubReaderSupportResolution(
+                mangaId = manga.id,
+                chapterId = chapter.id,
+                mangaTitle = manga.title,
+                chapterTitle = chapter.name,
+                chapterRead = chapter.read,
+                unsupportedReason = EpubReaderSupportResolution.UnsupportedReason.SOURCE_UNSUPPORTED,
+            )
+
+        val localUri = downloadProvider.findChapterDir(
+            chapterName = chapter.name,
+            chapterScanlator = chapter.scanlator,
+            chapterUrl = chapter.url,
+            mangaTitle = manga.title,
+            source = source,
+        )
+            ?.takeIf { it.extension.equals("epub", ignoreCase = true) }
+            ?.uri
+            ?.toString()
+
+        val remoteLookup = if (localUri != null && !application.isOnline()) {
+            Result.success(null)
+        } else {
+            runCatching { source.getBookDetails(chapter.url) }
+        }
+        val remoteBook = remoteLookup.getOrNull()
+        val remoteBookUrl = remoteBook
+            ?.takeIf { it.isEpub }
+            ?.let { chapter.url.substringBefore('#').removeSuffix("/") }
+
+        val isDivinaCompatible = remoteBook?.media?.isDivinaCompatibleEpub == true
+
+        val preferredOpenSource = when {
+            preferLocalFile && localUri != null -> EpubOpenRequest.OpenSource.LOCAL
+            remoteBookUrl != null -> EpubOpenRequest.OpenSource.REMOTE
+            localUri != null -> EpubOpenRequest.OpenSource.LOCAL
+            else -> null
+        }
+
+        val unsupportedReason = when {
+            preferredOpenSource != null -> null
+            remoteLookup.isSuccess -> EpubReaderSupportResolution.UnsupportedReason.NOT_EPUB
+            else -> EpubReaderSupportResolution.UnsupportedReason.REMOTE_METADATA_UNAVAILABLE
+        }
+
+        EpubReaderSupportResolution(
+            mangaId = manga.id,
+            chapterId = chapter.id,
+            sourceId = source.id,
+            mangaTitle = manga.title,
+            chapterTitle = chapter.name,
+            chapterRead = chapter.read,
+            localUri = localUri,
+            remoteBookUrl = remoteBookUrl,
+            isDivinaCompatible = isDivinaCompatible,
+            preferredOpenSource = preferredOpenSource,
+            unsupportedReason = unsupportedReason,
+            metadataError = remoteLookup.exceptionOrNull(),
+        )
+    }
+}
+
+data class EpubReaderSupportResolution(
+    val mangaId: Long,
+    val chapterId: Long,
+    val sourceId: Long = 0L,
+    val mangaTitle: String? = null,
+    val chapterTitle: String? = null,
+    val chapterRead: Boolean = false,
+    val localUri: String? = null,
+    val remoteBookUrl: String? = null,
+    val isDivinaCompatible: Boolean = false,
+    val preferredOpenSource: EpubOpenRequest.OpenSource? = null,
+    val unsupportedReason: UnsupportedReason? = null,
+    val metadataError: Throwable? = null,
+) {
+
+    val isNativeSupported: Boolean
+        get() = preferredOpenSource != null
+
+    fun toOpenRequest(): EpubOpenRequest? {
+        val openSource = preferredOpenSource ?: return null
+        return EpubOpenRequest(
+            mangaId = mangaId,
+            chapterId = chapterId,
+            sourceId = sourceId,
+            title = chapterTitle.orEmpty(),
+            bookUrl = remoteBookUrl,
+            localUri = localUri,
+            openSource = openSource,
+        )
+    }
+
+    fun unsupportedMessage(application: Application): String {
+        return when (unsupportedReason) {
+            UnsupportedReason.MANGA_NOT_FOUND -> application.stringResource(MR.strings.epub_reader_manga_not_found)
+            UnsupportedReason.CHAPTER_NOT_FOUND -> application.stringResource(MR.strings.chapter_not_found)
+            UnsupportedReason.SOURCE_UNSUPPORTED -> application.stringResource(MR.strings.source_unsupported)
+            UnsupportedReason.NOT_EPUB -> application.stringResource(MR.strings.epub_reader_unsupported_book)
+            UnsupportedReason.REMOTE_METADATA_UNAVAILABLE -> {
+                application.stringResource(MR.strings.epub_reader_remote_metadata_unavailable)
+            }
+            null -> application.stringResource(MR.strings.epub_reader_open_failed)
+        }
+    }
+
+    enum class UnsupportedReason {
+        MANGA_NOT_FOUND,
+        CHAPTER_NOT_FOUND,
+        SOURCE_UNSUPPORTED,
+        NOT_EPUB,
+        REMOTE_METADATA_UNAVAILABLE,
+    }
+}

--- a/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
@@ -1,0 +1,89 @@
+package koharia.epub.service
+
+import android.app.Application
+import koharia.epub.model.EpubOpenRequest
+import koharia.epub.session.EpubReaderSession
+import logcat.LogPriority
+import org.readium.r2.navigator.epub.EpubNavigatorFactory
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.FileExtension
+import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.asset.ResourceAsset
+import org.readium.r2.shared.util.format.Format
+import org.readium.r2.shared.util.format.FormatSpecification
+import org.readium.r2.shared.util.format.Specification
+import org.readium.r2.shared.util.getOrElse
+import org.readium.r2.shared.util.http.HttpRequest
+import org.readium.r2.shared.util.http.fetchString
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.readium.r2.shared.util.resource.Resource
+import org.readium.r2.shared.util.resource.StringResource
+import org.readium.r2.shared.util.resource.filename
+import org.readium.r2.shared.util.resource.mediaType
+import org.readium.r2.streamer.PublicationOpener
+import org.readium.r2.streamer.parser.DefaultPublicationParser
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class KomgaEpubPublicationService(
+    private val application: Application = Injekt.get(),
+    private val httpClientFactory: KomgaReadiumHttpClient = Injekt.get(),
+) {
+
+    suspend fun open(
+        request: EpubOpenRequest,
+        initialLocator: Locator?,
+    ): EpubReaderSession {
+        val bookUrl = requireNotNull(request.bookUrl) { "Missing Komga book URL" }
+        val manifestUrl = requireNotNull(AbsoluteUrl("$bookUrl/manifest/epub")) {
+            "Invalid Komga manifest URL"
+        }
+        logcat(LogPriority.DEBUG) {
+            "EPUB remote open start chapterId=${request.chapterId} manifestUrl=$manifestUrl"
+        }
+        val httpClient = httpClientFactory.create(request.sourceId)
+        val assetRetriever = AssetRetriever(application.contentResolver, httpClient)
+        val publicationOpener = PublicationOpener(
+            DefaultPublicationParser(application, httpClient, assetRetriever, null),
+        )
+        val manifestJson = httpClient.fetchString(HttpRequest(manifestUrl))
+            .getOrElse {
+                throw IllegalStateException("Failed to fetch Komga EPUB manifest: ${it.message}")
+            }
+        val manifestResource = StringResource(
+            string = manifestJson,
+            source = manifestUrl,
+            properties = Resource.Properties {
+                mediaType = MediaType.READIUM_WEBPUB_MANIFEST
+                filename = "manifest.json"
+            },
+        )
+        val manifestAsset = ResourceAsset(
+            format = Format(
+                specification = FormatSpecification(Specification.Json, Specification.Rwpm),
+                mediaType = MediaType.READIUM_WEBPUB_MANIFEST,
+                fileExtension = FileExtension("json"),
+            ),
+            resource = manifestResource,
+        )
+
+        val publication = publicationOpener.open(manifestAsset, allowUserInteraction = false)
+            .getOrElse {
+                manifestAsset.close()
+                throw IllegalStateException(it.message)
+            }
+        logcat(LogPriority.DEBUG) {
+            "EPUB remote open success chapterId=${request.chapterId} readingOrder=${publication.readingOrder.size} toc=${publication.tableOfContents.size}"
+        }
+
+        return EpubReaderSession(
+            chapterId = request.chapterId,
+            title = request.title,
+            publication = publication,
+            navigatorFactory = EpubNavigatorFactory(publication),
+            initialLocator = initialLocator,
+        )
+    }
+}

--- a/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
@@ -43,7 +43,7 @@ class KomgaEpubPublicationService(
         logcat(LogPriority.DEBUG) {
             "EPUB remote open start chapterId=${request.chapterId} manifestUrl=$manifestUrl"
         }
-        val httpClient = httpClientFactory.create(request.sourceId)
+        val httpClient = httpClientFactory.create(request.sourceId, request.publisherStylesOverride)
         val assetRetriever = AssetRetriever(application.contentResolver, httpClient)
         val publicationOpener = PublicationOpener(
             DefaultPublicationParser(application, httpClient, assetRetriever, null),

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -1,23 +1,29 @@
 package koharia.epub.service
 
+import koharia.epub.injectEpubParagraphIndentStyle
 import koharia.source.komga.KomgaSource
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import logcat.LogPriority
+import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.http.DefaultHttpClient
 import org.readium.r2.shared.util.http.HttpRequest
+import org.readium.r2.shared.util.http.HttpStreamResponse
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.ByteArrayInputStream
 import java.util.concurrent.atomic.AtomicInteger
 
 class KomgaReadiumHttpClient(
     private val sourceManager: SourceManager = Injekt.get(),
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) {
 
     private val requestLogCount = AtomicInteger(0)
 
-    fun create(sourceId: Long): DefaultHttpClient {
+    fun create(sourceId: Long, publisherStylesOverride: Boolean? = null): HttpClient {
         val client = DefaultHttpClient()
         client.callback = object : DefaultHttpClient.Callback {
             override suspend fun onStartRequest(request: HttpRequest) = Try.success(
@@ -41,6 +47,48 @@ class KomgaReadiumHttpClient(
                 },
             )
         }
-        return client
+        return ParagraphIndentNormalizingHttpClient(client) {
+            !(publisherStylesOverride
+                ?: scopedPreferenceStoreFactory.epubLayoutPreferences(sourceId).publisherStyles.get())
+        }
+    }
+}
+
+private class ParagraphIndentNormalizingHttpClient(
+    private val delegate: HttpClient,
+    private val shouldNormalize: () -> Boolean,
+) : HttpClient {
+
+    override suspend fun stream(request: HttpRequest): org.readium.r2.shared.util.http.HttpTry<HttpStreamResponse> {
+        return delegate.stream(request).map { streamResponse ->
+            if (!request.url.toString().substringBefore('?').endsWith(".xhtml") || !shouldNormalize()) {
+                return@map streamResponse
+            }
+
+            val source = streamResponse.body.use { it.readBytes() }.toString(Charsets.UTF_8)
+            val matches = leadingParagraphIndent.findAll(source).count()
+            val paragraphCount = paragraphTag.findAll(source).count()
+            val declaredTextIndentCount = declaredTextIndent.findAll(source).count()
+            val normalized = leadingParagraphIndent
+                .replace(source) { match -> match.groupValues[1] }
+                .injectEpubParagraphIndentStyle()
+
+            logcat(LogPriority.DEBUG) {
+                "EPUB normalized paragraph indents url=${request.url} removedSpaces=$matches " +
+                    "paragraphs=$paragraphCount declaredTextIndents=$declaredTextIndentCount injectedIndentStyle=true"
+            }
+            HttpStreamResponse(
+                response = streamResponse.response,
+                body = ByteArrayInputStream(
+                    normalized.toByteArray(Charsets.UTF_8),
+                ),
+            )
+        }
+    }
+
+    private companion object {
+        val leadingParagraphIndent = Regex("""(<p\b[^>]*>)\u3000+""", RegexOption.IGNORE_CASE)
+        val paragraphTag = Regex("""<p\b""", RegexOption.IGNORE_CASE)
+        val declaredTextIndent = Regex("""text-indent\s*:""", RegexOption.IGNORE_CASE)
     }
 }

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -65,7 +65,9 @@ private class ParagraphIndentNormalizingHttpClient(
         return delegate.stream(request).map { streamResponse ->
             val path = request.url.toString().substringBefore('?')
             val isHtml = htmlExtensions.any { path.endsWith(it, ignoreCase = true) }
-            if (!isHtml || !shouldNormalize()) {
+            val isFullGet = request.method == HttpRequest.Method.GET &&
+                request.headers.keys.none { it.equals("Range", ignoreCase = true) }
+            if (!isHtml || !isFullGet || !shouldNormalize()) {
                 return@map streamResponse
             }
 
@@ -76,16 +78,19 @@ private class ParagraphIndentNormalizingHttpClient(
             val normalized = leadingParagraphIndent
                 .replace(source) { match -> match.groupValues[1] }
                 .injectEpubParagraphIndentStyle()
+            val normalizedBytes = normalized.toByteArray(Charsets.UTF_8)
+            val normalizedResponse = streamResponse.response.copy(
+                headers = streamResponse.response.headers
+                    .filterKeys { !it.equals("Content-Length", ignoreCase = true) },
+            )
 
             logcat(LogPriority.DEBUG) {
                 "EPUB normalized paragraph indents url=${request.url} removedSpaces=$matches " +
                     "paragraphs=$paragraphCount declaredTextIndents=$declaredTextIndentCount injectedIndentStyle=true"
             }
             HttpStreamResponse(
-                response = streamResponse.response,
-                body = ByteArrayInputStream(
-                    normalized.toByteArray(Charsets.UTF_8),
-                ),
+                response = normalizedResponse,
+                body = ByteArrayInputStream(normalizedBytes),
             )
         }
     }

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -1,0 +1,46 @@
+package koharia.epub.service
+
+import koharia.source.komga.KomgaSource
+import logcat.LogPriority
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.http.HttpRequest
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.util.concurrent.atomic.AtomicInteger
+
+class KomgaReadiumHttpClient(
+    private val sourceManager: SourceManager = Injekt.get(),
+) {
+
+    private val requestLogCount = AtomicInteger(0)
+
+    fun create(sourceId: Long): DefaultHttpClient {
+        val client = DefaultHttpClient()
+        client.callback = object : DefaultHttpClient.Callback {
+            override suspend fun onStartRequest(request: HttpRequest) = Try.success(
+                request.copy {
+                    val source = sourceManager.get(sourceId) as? KomgaSource
+                    val baseUrl = source?.baseUrl?.trimEnd('/').orEmpty()
+                    val shouldInjectHeaders = request.url.toString().startsWith(baseUrl)
+                    source?.currentReadiumHeaders()
+                        .takeIf { shouldInjectHeaders }
+                        ?.let { headers ->
+                            headers.names().forEach { name ->
+                                setHeader(name, headers.values(name))
+                            }
+                        }
+
+                    if (requestLogCount.getAndIncrement() < 20) {
+                        logcat(LogPriority.DEBUG) {
+                            "EPUB http request url=${request.url} injectHeaders=$shouldInjectHeaders baseUrl=$baseUrl"
+                        }
+                    }
+                },
+            )
+        }
+        return client
+    }
+}

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -1,12 +1,12 @@
 package koharia.epub.service
 
 import koharia.epub.injectEpubParagraphIndentStyle
-import koharia.source.komga.KomgaSource
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import koharia.source.komga.KomgaSource
 import logcat.LogPriority
-import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.http.HttpRequest
 import org.readium.r2.shared.util.http.HttpStreamResponse
 import tachiyomi.core.common.util.system.logcat
@@ -48,8 +48,10 @@ class KomgaReadiumHttpClient(
             )
         }
         return ParagraphIndentNormalizingHttpClient(client) {
-            !(publisherStylesOverride
-                ?: scopedPreferenceStoreFactory.epubLayoutPreferences(sourceId).publisherStyles.get())
+            !(
+                publisherStylesOverride
+                    ?: scopedPreferenceStoreFactory.epubLayoutPreferences(sourceId).publisherStyles.get()
+                )
         }
     }
 }
@@ -61,7 +63,9 @@ private class ParagraphIndentNormalizingHttpClient(
 
     override suspend fun stream(request: HttpRequest): org.readium.r2.shared.util.http.HttpTry<HttpStreamResponse> {
         return delegate.stream(request).map { streamResponse ->
-            if (!request.url.toString().substringBefore('?').endsWith(".xhtml") || !shouldNormalize()) {
+            val path = request.url.toString().substringBefore('?')
+            val isHtml = htmlExtensions.any { path.endsWith(it, ignoreCase = true) }
+            if (!isHtml || !shouldNormalize()) {
                 return@map streamResponse
             }
 
@@ -88,6 +92,7 @@ private class ParagraphIndentNormalizingHttpClient(
 
     private companion object {
         val leadingParagraphIndent = Regex("""(<p\b[^>]*>)\u3000+""", RegexOption.IGNORE_CASE)
+        val htmlExtensions = listOf(".xhtml", ".html", ".htm")
         val paragraphTag = Regex("""<p\b""", RegexOption.IGNORE_CASE)
         val declaredTextIndent = Regex("""text-indent\s*:""", RegexOption.IGNORE_CASE)
     }

--- a/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
@@ -1,0 +1,60 @@
+package koharia.epub.service
+
+import android.app.Application
+import android.net.Uri
+import koharia.epub.model.EpubOpenRequest
+import koharia.epub.session.EpubReaderSession
+import logcat.LogPriority
+import org.readium.r2.navigator.epub.EpubNavigatorFactory
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.shared.util.getOrElse
+import org.readium.r2.shared.util.http.DefaultHttpClient
+import org.readium.r2.shared.util.mediatype.MediaType
+import org.readium.r2.shared.util.toAbsoluteUrl
+import org.readium.r2.streamer.PublicationOpener
+import org.readium.r2.streamer.parser.DefaultPublicationParser
+import tachiyomi.core.common.util.system.logcat
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class LocalEpubPublicationService(
+    private val application: Application = Injekt.get(),
+) {
+
+    suspend fun open(
+        request: EpubOpenRequest,
+        initialLocator: Locator?,
+    ): EpubReaderSession {
+        val url = requireNotNull(Uri.parse(requireNotNull(request.localUri)).toAbsoluteUrl()) {
+            "Invalid local EPUB URL"
+        }
+        logcat(LogPriority.DEBUG) {
+            "EPUB local open start chapterId=${request.chapterId} url=$url"
+        }
+        val httpClient = DefaultHttpClient()
+        val assetRetriever = AssetRetriever(application.contentResolver, httpClient)
+        val publicationOpener = PublicationOpener(
+            DefaultPublicationParser(application, httpClient, assetRetriever, null),
+        )
+
+        val asset = assetRetriever.retrieve(url, MediaType.EPUB)
+            .getOrElse { throw IllegalStateException(it.message) }
+        val publication = publicationOpener.open(asset, allowUserInteraction = false)
+            .getOrElse {
+                asset.close()
+                throw IllegalStateException(it.message)
+            }
+        logcat(LogPriority.DEBUG) {
+            "EPUB local open success chapterId=${request.chapterId} readingOrder=${publication.readingOrder.size} toc=${publication.tableOfContents.size}"
+        }
+
+        return EpubReaderSession(
+            chapterId = request.chapterId,
+            title = request.title,
+            publication = publication,
+            navigatorFactory = EpubNavigatorFactory(publication),
+            initialLocator = initialLocator,
+        )
+    }
+}

--- a/app/src/main/java/koharia/epub/session/EpubReaderSession.kt
+++ b/app/src/main/java/koharia/epub/session/EpubReaderSession.kt
@@ -1,0 +1,17 @@
+package koharia.epub.session
+
+import org.readium.r2.navigator.epub.EpubNavigatorFactory
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+
+data class EpubReaderSession(
+    val chapterId: Long,
+    val title: String,
+    val publication: Publication,
+    val navigatorFactory: EpubNavigatorFactory,
+    val initialLocator: Locator?,
+) {
+    fun close() {
+        publication.close()
+    }
+}

--- a/app/src/main/java/koharia/epub/session/EpubReaderSessionRepository.kt
+++ b/app/src/main/java/koharia/epub/session/EpubReaderSessionRepository.kt
@@ -1,0 +1,17 @@
+package koharia.epub.session
+
+class EpubReaderSessionRepository {
+
+    private val sessions = mutableMapOf<Long, EpubReaderSession>()
+
+    @Synchronized
+    fun get(chapterId: Long): EpubReaderSession? = sessions[chapterId]
+
+    @Synchronized
+    fun put(session: EpubReaderSession) {
+        sessions.put(session.chapterId, session)?.close()
+    }
+
+    @Synchronized
+    fun remove(chapterId: Long): EpubReaderSession? = sessions.remove(chapterId)
+}

--- a/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
@@ -1,0 +1,180 @@
+package koharia.epub.settings
+
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.preference.getEnum
+import kotlin.math.roundToInt
+
+class EpubLayoutPreferences(
+    preferenceStore: PreferenceStore,
+) {
+
+    val readingMode: Preference<ReadingMode> =
+        preferenceStore.getEnum("epub_layout_reading_mode", ReadingMode.PAGINATED)
+
+    val pageDirection: Preference<PageDirection> =
+        preferenceStore.getEnum("epub_layout_page_direction", PageDirection.LEFT_TO_RIGHT)
+
+    val theme: Preference<Theme> =
+        preferenceStore.getEnum("epub_layout_theme", Theme.LIGHT)
+
+    val customBackgroundColor: Preference<Int> =
+        preferenceStore.getInt("epub_layout_custom_background_color", DEFAULT_CUSTOM_BACKGROUND_COLOR)
+
+    val customBackgroundColors: Preference<String> =
+        preferenceStore.getString("epub_layout_custom_background_colors", "")
+
+    val backgroundColors: Preference<String> =
+        preferenceStore.getString("epub_layout_background_colors", "")
+
+    val fontSize: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_font_size", 1.0f)
+
+    val lineHeight: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_line_height", 1.2f)
+
+    val paragraphSpacing: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_paragraph_spacing", 0.0f)
+
+    val paragraphIndent: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_paragraph_indent", 2.0f)
+
+    val pageMargins: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_page_margins", 1.0f)
+
+    val verticalMargins: Preference<Float> =
+        preferenceStore.getFloat("epub_layout_vertical_margins", 1.0f)
+
+    val spacingMode: Preference<SpacingMode> =
+        preferenceStore.getEnum("epub_layout_spacing_mode", SpacingMode.CUSTOM)
+
+    val fontFamily: Preference<FontFamily> =
+        preferenceStore.getEnum("epub_layout_font_family", FontFamily.ORIGINAL)
+
+    val publisherStyles: Preference<Boolean> =
+        preferenceStore.getBoolean("epub_layout_publisher_styles", true)
+
+    enum class ReadingMode {
+        PAGINATED,
+        SCROLL,
+    }
+
+    enum class PageDirection {
+        LEFT_TO_RIGHT,
+        RIGHT_TO_LEFT,
+    }
+
+    enum class Theme {
+        LIGHT,
+        DARK,
+        SEPIA,
+        MINT,
+        BLUE,
+        PINK,
+        GRAY,
+        CUSTOM,
+    }
+
+    enum class FontFamily {
+        ORIGINAL,
+        SERIF,
+        SANS_SERIF,
+        MONOSPACE,
+        OPEN_DYSLEXIC,
+    }
+
+    enum class SpacingMode(
+        val lineHeight: Float?,
+        val paragraphSpacing: Float?,
+        val paragraphIndent: Float?,
+        val verticalMargins: Float?,
+        val horizontalMargins: Float?,
+    ) {
+        COMPACT(1.55f, 0.0f, 2.0f, 0.85f, 0.9f),
+        STANDARD(1.7f, 0.05f, 2.0f, 1.0f, 1.0f),
+        RELAXED(1.85f, 0.15f, 2.0f, 1.1f, 1.1f),
+        NONE(1.2f, 0.0f, 2.0f, 0.0f, 0.0f),
+        CUSTOM(null, null, null, null, null),
+    }
+
+    fun applySpacingMode(mode: SpacingMode) {
+        spacingMode.set(mode)
+        publisherStyles.set(false)
+        if (mode == SpacingMode.CUSTOM) return
+        lineHeight.set(checkNotNull(mode.lineHeight))
+        paragraphSpacing.set(checkNotNull(mode.paragraphSpacing))
+        paragraphIndent.set(checkNotNull(mode.paragraphIndent))
+        verticalMargins.set(checkNotNull(mode.verticalMargins))
+        pageMargins.set(checkNotNull(mode.horizontalMargins))
+    }
+
+    companion object {
+        const val BASE_FONT_SIZE = 16
+        const val MIN_FONT_SIZE = 13
+        const val MAX_FONT_SIZE = 32
+        const val MAX_CUSTOM_BACKGROUND_COLORS = 5
+        const val MAX_BACKGROUND_COLORS = 12
+        val DEFAULT_CUSTOM_BACKGROUND_COLOR = 0xFFF5E6CC.toInt()
+        val DEFAULT_BACKGROUND_COLORS = listOf(
+            0xFFFFFFFF.toInt(),
+            0xFF000000.toInt(),
+            0xFFFBF0D9.toInt(),
+            0xFFC4EDC8.toInt(),
+            0xFFE0F0FC.toInt(),
+            0xFFFBE4EE.toInt(),
+            0xFFF1F3F5.toInt(),
+        )
+
+        val FONT_SIZE_VALUES = listOf(0.8f, 0.9f, 1.0f, 1.1f, 1.25f, 1.5f, 1.75f, 2.0f)
+        const val VERTICAL_MARGIN_BASE_DP = 12f
+        val LINE_HEIGHT_VALUES = listOf(1.0f, 1.2f, 1.4f, 1.6f, 1.8f, 2.0f)
+        val PARAGRAPH_SPACING_VALUES = listOf(0.0f, 0.3f, 0.6f, 1.0f, 1.5f, 2.0f)
+        val PARAGRAPH_INDENT_VALUES = listOf(0.0f, 1.0f, 1.5f, 2.0f, 2.5f, 3.0f)
+        val VERTICAL_MARGIN_VALUES = listOf(0.0f, 0.5f, 1.0f, 1.3f, 1.6f, 2.0f)
+        val PAGE_MARGIN_VALUES = listOf(0.0f, 0.5f, 1.0f, 1.4f, 2.0f, 3.0f, 4.0f)
+
+        fun fontSizeFromScale(scale: Float): Int {
+            return (scale * BASE_FONT_SIZE).roundToInt().coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE)
+        }
+
+        fun scaleFromFontSize(fontSize: Int): Float {
+            return fontSize.coerceIn(MIN_FONT_SIZE, MAX_FONT_SIZE).toFloat() / BASE_FONT_SIZE
+        }
+
+        fun decodeCustomBackgroundColors(serialized: String): List<Int> {
+            return serialized
+                .split(',')
+                .mapNotNull { value -> value.toLongOrNull(16)?.toInt() }
+                .distinct()
+                .take(MAX_CUSTOM_BACKGROUND_COLORS)
+        }
+
+        fun encodeCustomBackgroundColors(colors: List<Int>): String {
+            return colors
+                .distinct()
+                .take(MAX_CUSTOM_BACKGROUND_COLORS)
+                .joinToString(",") { color -> "%08X".format(color) }
+        }
+
+        fun initialBackgroundColors(legacyCustomColors: String): List<Int> {
+            return (DEFAULT_BACKGROUND_COLORS + decodeCustomBackgroundColors(legacyCustomColors))
+                .distinct()
+                .take(MAX_BACKGROUND_COLORS)
+        }
+
+        fun decodeBackgroundColors(serialized: String): List<Int> {
+            return serialized
+                .split(',')
+                .mapNotNull { value -> value.toLongOrNull(16)?.toInt() }
+                .distinct()
+                .take(MAX_BACKGROUND_COLORS)
+        }
+
+        fun encodeBackgroundColors(colors: List<Int>): String {
+            return colors
+                .distinct()
+                .take(MAX_BACKGROUND_COLORS)
+                .joinToString(",") { color -> "%08X".format(color) }
+        }
+    }
+}

--- a/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
@@ -1,0 +1,113 @@
+package koharia.epub.settings
+
+import androidx.core.graphics.ColorUtils
+import org.readium.r2.navigator.epub.EpubPreferences
+import org.readium.r2.navigator.preferences.ReadingProgression
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.navigator.preferences.Color as ReadiumColor
+import org.readium.r2.navigator.preferences.FontFamily as ReadiumFontFamily
+import org.readium.r2.navigator.preferences.Theme as ReadiumTheme
+
+@OptIn(ExperimentalReadiumApi::class)
+class EpubPreferencesBridge {
+
+    fun toReadiumPreferences(preferences: EpubLayoutPreferences): EpubPreferences {
+        return toReadiumPreferences(
+            readingMode = preferences.readingMode.get(),
+            pageDirection = preferences.pageDirection.get(),
+            theme = preferences.theme.get(),
+            fontSize = preferences.fontSize.get(),
+            lineHeight = preferences.lineHeight.get(),
+            paragraphSpacing = preferences.paragraphSpacing.get(),
+            paragraphIndent = preferences.paragraphIndent.get(),
+            pageMargins = preferences.pageMargins.get(),
+            fontFamily = preferences.fontFamily.get(),
+            publisherStyles = preferences.publisherStyles.get(),
+            customBackgroundColor = preferences.customBackgroundColor.get(),
+        )
+    }
+
+    fun toReadiumPreferences(
+        readingMode: EpubLayoutPreferences.ReadingMode,
+        pageDirection: EpubLayoutPreferences.PageDirection,
+        theme: EpubLayoutPreferences.Theme,
+        fontSize: Float,
+        lineHeight: Float,
+        paragraphSpacing: Float,
+        paragraphIndent: Float,
+        pageMargins: Float,
+        fontFamily: EpubLayoutPreferences.FontFamily,
+        publisherStyles: Boolean,
+        customBackgroundColor: Int = EpubLayoutPreferences.DEFAULT_CUSTOM_BACKGROUND_COLOR,
+    ): EpubPreferences {
+        return EpubPreferences(
+            scroll = readingMode == EpubLayoutPreferences.ReadingMode.SCROLL,
+            readingProgression = pageDirection.toReadiumReadingProgression(),
+            theme = theme.toReadiumTheme(customBackgroundColor),
+            backgroundColor = ReadiumColor(theme.backgroundColor(customBackgroundColor)),
+            textColor = ReadiumColor(theme.textColor(customBackgroundColor)),
+            fontSize = fontSize.toDouble(),
+            lineHeight = lineHeight.toDouble(),
+            paragraphSpacing = paragraphSpacing.toDouble(),
+            paragraphIndent = paragraphIndent.toDouble(),
+            pageMargins = pageMargins.toDouble(),
+            fontFamily = fontFamily.toReadiumFontFamily(),
+            publisherStyles = publisherStyles,
+        )
+    }
+
+    private fun EpubLayoutPreferences.Theme.toReadiumTheme(customBackgroundColor: Int): ReadiumTheme {
+        return when (this) {
+            EpubLayoutPreferences.Theme.LIGHT -> ReadiumTheme.LIGHT
+            EpubLayoutPreferences.Theme.DARK -> ReadiumTheme.DARK
+            EpubLayoutPreferences.Theme.SEPIA -> ReadiumTheme.SEPIA
+            EpubLayoutPreferences.Theme.MINT,
+            EpubLayoutPreferences.Theme.BLUE,
+            EpubLayoutPreferences.Theme.PINK,
+            EpubLayoutPreferences.Theme.GRAY,
+            -> ReadiumTheme.LIGHT
+            EpubLayoutPreferences.Theme.CUSTOM -> if (customBackgroundColor.isDark()) {
+                ReadiumTheme.DARK
+            } else {
+                ReadiumTheme.LIGHT
+            }
+        }
+    }
+
+    private fun EpubLayoutPreferences.Theme.backgroundColor(customBackgroundColor: Int): Int {
+        return when (this) {
+            EpubLayoutPreferences.Theme.LIGHT -> 0xFFFFFFFF.toInt()
+            EpubLayoutPreferences.Theme.DARK -> 0xFF000000.toInt()
+            EpubLayoutPreferences.Theme.SEPIA -> 0xFFFAF4E8.toInt()
+            EpubLayoutPreferences.Theme.MINT -> 0xFFC4EDC8.toInt()
+            EpubLayoutPreferences.Theme.BLUE -> 0xFFE0F0FC.toInt()
+            EpubLayoutPreferences.Theme.PINK -> 0xFFFBE4EE.toInt()
+            EpubLayoutPreferences.Theme.GRAY -> 0xFFF1F3F5.toInt()
+            EpubLayoutPreferences.Theme.CUSTOM -> customBackgroundColor
+        }
+    }
+
+    private fun EpubLayoutPreferences.Theme.textColor(customBackgroundColor: Int): Int {
+        val backgroundColor = backgroundColor(customBackgroundColor)
+        return if (backgroundColor.isDark()) 0xFFFEFEFE.toInt() else 0xFF121212.toInt()
+    }
+
+    private fun Int.isDark(): Boolean = ColorUtils.calculateLuminance(this) < 0.35
+
+    private fun EpubLayoutPreferences.FontFamily.toReadiumFontFamily(): ReadiumFontFamily? {
+        return when (this) {
+            EpubLayoutPreferences.FontFamily.ORIGINAL -> null
+            EpubLayoutPreferences.FontFamily.SERIF -> ReadiumFontFamily.SERIF
+            EpubLayoutPreferences.FontFamily.SANS_SERIF -> ReadiumFontFamily.SANS_SERIF
+            EpubLayoutPreferences.FontFamily.MONOSPACE -> ReadiumFontFamily.MONOSPACE
+            EpubLayoutPreferences.FontFamily.OPEN_DYSLEXIC -> ReadiumFontFamily.OPEN_DYSLEXIC
+        }
+    }
+}
+
+internal fun EpubLayoutPreferences.PageDirection.toReadiumReadingProgression(): ReadingProgression {
+    return when (this) {
+        EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT -> ReadingProgression.LTR
+        EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT -> ReadingProgression.RTL
+    }
+}

--- a/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
@@ -1,0 +1,19 @@
+package koharia.epub.settings
+
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class EpubReaderPreferences(
+    preferenceStore: PreferenceStore,
+) {
+
+    val enableNativeReader: Preference<Boolean> = preferenceStore.getBoolean("epub_reader_enabled", true)
+
+    val preferLocalFile: Preference<Boolean> = preferenceStore.getBoolean("epub_reader_prefer_local_file", true)
+
+    val syncProgressionToKomga: Preference<Boolean> =
+        preferenceStore.getBoolean("epub_reader_sync_progression_komga", true)
+
+    val completionThresholdPercent: Preference<Int> =
+        preferenceStore.getInt("epub_reader_completion_threshold_percent", 98)
+}

--- a/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
@@ -7,8 +7,6 @@ class EpubReaderPreferences(
     preferenceStore: PreferenceStore,
 ) {
 
-    val enableNativeReader: Preference<Boolean> = preferenceStore.getBoolean("epub_reader_enabled", true)
-
     val preferLocalFile: Preference<Boolean> = preferenceStore.getBoolean("epub_reader_prefer_local_file", true)
 
     val syncProgressionToKomga: Preference<Boolean> =

--- a/app/src/main/java/koharia/komga/api/dto/Dto.kt
+++ b/app/src/main/java/koharia/komga/api/dto/Dto.kt
@@ -173,6 +173,15 @@ data class BookDto(
     val metadata: BookMetadataDto,
 )
 
+val MediaDto.isEpub: Boolean
+    get() = mediaProfile == "EPUB"
+
+val MediaDto.isDivinaCompatibleEpub: Boolean
+    get() = isEpub && epubDivinaCompatible
+
+val BookDto.isEpub: Boolean
+    get() = media.isEpub
+
 @Serializable
 data class PageDto(
     val number: Int,

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -124,7 +124,6 @@ class KomgaRepository(
             val books = apiClient.parsePageWrapper<BookDto>(it).content
             val isFromReadList = apiClient.isReadList(it.request.url.toString())
             books
-                .filter { book -> book.media.mediaProfile != "EPUB" || book.media.epubDivinaCompatible }
                 .mapIndexed { index, book ->
                     val number = if (isFromReadList) index + 1F else book.metadata.numberSort
                     book.toChapter(baseUrl, chapterNameTemplate, isFromReadList, number)

--- a/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
@@ -9,6 +9,8 @@ import eu.kanade.tachiyomi.core.security.PrivacyPreferences
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import koharia.epub.settings.EpubLayoutPreferences
+import koharia.epub.settings.EpubReaderPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -61,9 +63,9 @@ class KomgaLocalConfigManager(
     }
 
     override fun currentScope(): PreferenceScope {
-        return resolveScope(
+        return scopeForServer(
             mode = serverPreferences.localConfigMode.get(),
-            activeServerId = serverPreferences.activeServerId.get(),
+            serverId = serverPreferences.activeServerId.get(),
         )
     }
 
@@ -71,7 +73,7 @@ class KomgaLocalConfigManager(
         return combine(
             serverPreferences.localConfigMode.changes(),
             serverPreferences.activeServerId.changes(),
-            ::resolveScope,
+            ::scopeForServer,
         ).distinctUntilChanged()
     }
 
@@ -210,14 +212,7 @@ class KomgaLocalConfigManager(
         mode: LocalConfigMode,
         activeServerId: Long,
     ): PreferenceScope {
-        return when {
-            mode == LocalConfigMode.Separate && activeServerId != KomgaServerPreferences.NO_ACTIVE_SERVER ->
-                PreferenceScope(
-                    prefix = serverScopePrefix(activeServerId),
-                    allowLegacyFallback = false,
-                )
-            else -> sharedScope
-        }
+        return scopeForServer(mode, activeServerId)
     }
 
     companion object {
@@ -238,6 +233,8 @@ class KomgaLocalConfigManager(
             SourcePreferences(recorder)
             LibraryPreferences(recorder)
             ReaderPreferences(recorder)
+            EpubReaderPreferences(recorder)
+            EpubLayoutPreferences(recorder)
             DownloadPreferences(recorder)
             NetworkPreferences(recorder, verboseLoggingDefault)
             SecurityPreferences(recorder)
@@ -251,6 +248,20 @@ class KomgaLocalConfigManager(
         }
 
         fun serverScopeName(serverId: Long): String = "komga_local_server_$serverId"
+
+        fun scopeForServer(
+            mode: LocalConfigMode,
+            serverId: Long,
+        ): PreferenceScope {
+            return when {
+                mode == LocalConfigMode.Separate && serverId != KomgaServerPreferences.NO_ACTIVE_SERVER ->
+                    PreferenceScope(
+                        prefix = serverScopePrefix(serverId),
+                        allowLegacyFallback = false,
+                    )
+                else -> sharedScope
+            }
+        }
 
         private fun serverScopePrefix(serverId: Long): String = "${serverScopeName(serverId)}::"
 

--- a/app/src/main/java/koharia/source/komga/KomgaScopedPreferenceStoreFactory.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaScopedPreferenceStoreFactory.kt
@@ -1,0 +1,120 @@
+package koharia.source.komga
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import eu.kanade.domain.base.BasePreferences
+import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import koharia.epub.settings.EpubLayoutPreferences
+import koharia.epub.settings.EpubReaderPreferences
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import tachiyomi.core.common.preference.PreferenceScope
+import tachiyomi.core.common.preference.PreferenceScopeProvider
+import tachiyomi.core.common.preference.PreferenceStore
+import tachiyomi.core.common.preference.ScopedPreferenceStore
+import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.library.service.LibraryPreferences
+
+class KomgaScopedPreferenceStoreFactory(
+    private val app: Application,
+    private val preferenceStore: PreferenceStore,
+    private val serverPreferences: KomgaServerPreferences,
+) {
+
+    fun storeForServer(serverId: Long): ScopedPreferenceStore {
+        return ScopedPreferenceStore(
+            preferenceStore = preferenceStore,
+            scopeProvider = FixedKomgaScopeProvider(serverPreferences, serverId),
+        )
+    }
+
+    fun readerPreferences(serverId: Long): ReaderPreferences {
+        return ReaderPreferences(storeForServer(serverId))
+    }
+
+    fun epubReaderPreferences(serverId: Long): EpubReaderPreferences {
+        return EpubReaderPreferences(storeForServer(serverId))
+    }
+
+    fun epubLayoutPreferences(serverId: Long): EpubLayoutPreferences {
+        return EpubLayoutPreferences(storeForServer(serverId))
+    }
+
+    fun basePreferences(serverId: Long): BasePreferences {
+        return BasePreferences(app, storeForServer(serverId))
+    }
+
+    fun downloadPreferences(serverId: Long): DownloadPreferences {
+        return DownloadPreferences(storeForServer(serverId))
+    }
+
+    fun trackPreferences(serverId: Long): TrackPreferences {
+        return TrackPreferences(storeForServer(serverId))
+    }
+
+    fun libraryPreferences(serverId: Long): LibraryPreferences {
+        return LibraryPreferences(storeForServer(serverId))
+    }
+
+    fun readerPreferencesForSavedSource(savedState: SavedStateHandle): ReaderPreferences? {
+        return sourceIdFrom(savedState)?.let(::readerPreferences)
+    }
+
+    fun epubReaderPreferencesForSavedSource(savedState: SavedStateHandle): EpubReaderPreferences? {
+        return sourceIdFrom(savedState)?.let(::epubReaderPreferences)
+    }
+
+    fun epubLayoutPreferencesForSavedSource(savedState: SavedStateHandle): EpubLayoutPreferences? {
+        return sourceIdFrom(savedState)?.let(::epubLayoutPreferences)
+    }
+
+    fun basePreferencesForSavedSource(savedState: SavedStateHandle): BasePreferences? {
+        return sourceIdFrom(savedState)?.let(::basePreferences)
+    }
+
+    fun downloadPreferencesForSavedSource(savedState: SavedStateHandle): DownloadPreferences? {
+        return sourceIdFrom(savedState)?.let(::downloadPreferences)
+    }
+
+    fun trackPreferencesForSavedSource(savedState: SavedStateHandle): TrackPreferences? {
+        return sourceIdFrom(savedState)?.let(::trackPreferences)
+    }
+
+    fun libraryPreferencesForSavedSource(savedState: SavedStateHandle): LibraryPreferences? {
+        return sourceIdFrom(savedState)?.let(::libraryPreferences)
+    }
+
+    private fun sourceIdFrom(savedState: SavedStateHandle): Long? {
+        return (
+            savedState.get<Long>("source_id")
+                ?: savedState.get<Long>("source")
+            )
+            ?.takeIf { it > 0L }
+    }
+}
+
+private class FixedKomgaScopeProvider(
+    private val serverPreferences: KomgaServerPreferences,
+    private val serverId: Long,
+) : PreferenceScopeProvider {
+
+    override fun currentScope(): PreferenceScope {
+        return KomgaLocalConfigManager.scopeForServer(
+            mode = serverPreferences.localConfigMode.get(),
+            serverId = serverId,
+        )
+    }
+
+    override fun scopeChanges(): Flow<PreferenceScope> {
+        return serverPreferences.localConfigMode.changes()
+            .map { mode ->
+                KomgaLocalConfigManager.scopeForServer(
+                    mode = mode,
+                    serverId = serverId,
+                )
+            }
+            .distinctUntilChanged()
+    }
+}

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -94,6 +94,14 @@ class KomgaSource(
 
     fun currentHeaders(): Headers = headersBuilder().build()
 
+    fun currentReadiumHeaders(): Headers = currentHeaders().newBuilder()
+        .also { builder ->
+            if (apiKey.isBlank() && username.isNotBlank() && password.isNotBlank()) {
+                builder.set("Authorization", Credentials.basic(username, password))
+            }
+        }
+        .build()
+
     override fun headersBuilder() = super.headersBuilder()
         .set("User-Agent", "KohariaKomga/${AppInfo.getVersionName()}")
         .also { builder ->

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -96,8 +96,15 @@ class KomgaSource(
 
     fun currentReadiumHeaders(): Headers = currentHeaders().newBuilder()
         .also { builder ->
-            if (apiKey.isBlank() && username.isNotBlank() && password.isNotBlank()) {
-                builder.set("Authorization", Credentials.basic(username, password))
+            builder.removeAll("X-API-Key")
+            builder.removeAll("Authorization")
+            when (authMode) {
+                AUTH_MODE_API_KEY -> if (apiKey.isNotBlank()) {
+                    builder.set("X-API-Key", apiKey)
+                }
+                AUTH_MODE_CREDENTIALS -> if (username.isNotBlank() && password.isNotBlank()) {
+                    builder.set("Authorization", Credentials.basic(username, password))
+                }
             }
         }
         .build()

--- a/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
@@ -1,0 +1,22 @@
+package koharia.epub.settings
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.readium.r2.navigator.preferences.ReadingProgression
+
+class EpubPreferencesBridgeTest {
+
+    @Test
+    fun `left to right mode is submitted to Readium`() {
+        val progression = EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT.toReadiumReadingProgression()
+
+        assertEquals(ReadingProgression.LTR, progression)
+    }
+
+    @Test
+    fun `right to left mode is submitted to Readium`() {
+        val progression = EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT.toReadiumReadingProgression()
+
+        assertEquals(ReadingProgression.RTL, progression)
+    }
+}

--- a/data/src/main/java/koharia/data/epub/EpubProgressRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubProgressRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package koharia.data.epub
+
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.repository.EpubProgressRepository
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.Database
+import java.util.Date
+
+class EpubProgressRepositoryImpl(
+    private val database: Database,
+) : EpubProgressRepository {
+
+    override suspend fun getProgress(chapterId: Long): EpubProgress? {
+        return database.epub_progressQueries
+            .getByChapterId(chapterId, ::mapEpubProgress)
+            .awaitAsOneOrNull()
+    }
+
+    override suspend fun upsertProgress(progress: EpubProgress) {
+        try {
+            database.epub_progressQueries.upsert(
+                chapterId = progress.chapterId,
+                mangaId = progress.mangaId,
+                bookUrl = progress.bookUrl,
+                locatorJson = progress.locatorJson,
+                progression = progress.progression,
+                positionIndex = progress.positionIndex,
+                updatedAt = progress.updatedAt,
+                lastSyncedAt = progress.lastSyncedAt,
+            )
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to upsert EPUB progress for chapterId=${progress.chapterId}" }
+        }
+    }
+
+    override suspend fun deleteProgress(chapterId: Long) {
+        try {
+            database.epub_progressQueries.deleteByChapterId(chapterId)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e) { "Failed to delete EPUB progress for chapterId=$chapterId" }
+        }
+    }
+
+    private fun mapEpubProgress(
+        chapter_id: Long,
+        manga_id: Long,
+        book_url: String?,
+        locator_json: String,
+        progression: Double?,
+        position_index: Long?,
+        updated_at: Date,
+        last_synced_at: Date?,
+    ): EpubProgress {
+        return EpubProgress(
+            chapterId = chapter_id,
+            mangaId = manga_id,
+            bookUrl = book_url,
+            locatorJson = locator_json,
+            progression = progression,
+            positionIndex = position_index,
+            updatedAt = updated_at,
+            lastSyncedAt = last_synced_at,
+        )
+    }
+}

--- a/data/src/main/sqldelight/tachiyomi/data/epub_progress.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/epub_progress.sq
@@ -1,0 +1,69 @@
+import java.util.Date;
+
+CREATE TABLE epub_progress(
+    chapter_id INTEGER NOT NULL PRIMARY KEY,
+    manga_id INTEGER NOT NULL,
+    book_url TEXT,
+    locator_json TEXT NOT NULL,
+    progression REAL,
+    position_index INTEGER,
+    updated_at INTEGER AS Date NOT NULL,
+    last_synced_at INTEGER AS Date,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX epub_progress_manga_id_index ON epub_progress(manga_id);
+CREATE INDEX epub_progress_updated_at_index ON epub_progress(updated_at);
+
+getByChapterId:
+SELECT
+chapter_id,
+manga_id,
+book_url,
+locator_json,
+progression,
+position_index,
+updated_at,
+last_synced_at
+FROM epub_progress
+WHERE chapter_id = :chapterId;
+
+upsert:
+INSERT INTO epub_progress(
+    chapter_id,
+    manga_id,
+    book_url,
+    locator_json,
+    progression,
+    position_index,
+    updated_at,
+    last_synced_at
+)
+VALUES (
+    :chapterId,
+    :mangaId,
+    :bookUrl,
+    :locatorJson,
+    :progression,
+    :positionIndex,
+    :updatedAt,
+    :lastSyncedAt
+)
+ON CONFLICT(chapter_id)
+DO UPDATE
+SET
+    manga_id = :mangaId,
+    book_url = :bookUrl,
+    locator_json = :locatorJson,
+    progression = :progression,
+    position_index = :positionIndex,
+    updated_at = :updatedAt,
+    last_synced_at = :lastSyncedAt
+WHERE chapter_id = :chapterId;
+
+deleteByChapterId:
+DELETE FROM epub_progress
+WHERE chapter_id = :chapterId;

--- a/data/src/main/sqldelight/tachiyomi/migrations/13.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/13.sqm
@@ -1,0 +1,17 @@
+CREATE TABLE epub_progress(
+    chapter_id INTEGER NOT NULL PRIMARY KEY,
+    manga_id INTEGER NOT NULL,
+    book_url TEXT,
+    locator_json TEXT NOT NULL,
+    progression REAL,
+    position_index INTEGER,
+    updated_at INTEGER NOT NULL,
+    last_synced_at INTEGER,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX epub_progress_manga_id_index ON epub_progress(manga_id);
+CREATE INDEX epub_progress_updated_at_index ON epub_progress(updated_at);

--- a/domain/src/main/java/koharia/domain/epub/interactor/GetEpubProgress.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/GetEpubProgress.kt
@@ -1,0 +1,13 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.repository.EpubProgressRepository
+
+class GetEpubProgress(
+    private val repository: EpubProgressRepository,
+) {
+
+    suspend fun await(chapterId: Long): EpubProgress? {
+        return repository.getProgress(chapterId)
+    }
+}

--- a/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubProgress.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubProgress.kt
@@ -1,0 +1,13 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.repository.EpubProgressRepository
+
+class UpsertEpubProgress(
+    private val repository: EpubProgressRepository,
+) {
+
+    suspend fun await(progress: EpubProgress) {
+        repository.upsertProgress(progress)
+    }
+}

--- a/domain/src/main/java/koharia/domain/epub/model/EpubProgress.kt
+++ b/domain/src/main/java/koharia/domain/epub/model/EpubProgress.kt
@@ -1,0 +1,14 @@
+package koharia.domain.epub.model
+
+import java.util.Date
+
+data class EpubProgress(
+    val chapterId: Long,
+    val mangaId: Long,
+    val bookUrl: String?,
+    val locatorJson: String,
+    val progression: Double?,
+    val positionIndex: Long?,
+    val updatedAt: Date,
+    val lastSyncedAt: Date?,
+)

--- a/domain/src/main/java/koharia/domain/epub/repository/EpubProgressRepository.kt
+++ b/domain/src/main/java/koharia/domain/epub/repository/EpubProgressRepository.kt
@@ -1,0 +1,12 @@
+package koharia.domain.epub.repository
+
+import koharia.domain.epub.model.EpubProgress
+
+interface EpubProgressRepository {
+
+    suspend fun getProgress(chapterId: Long): EpubProgress?
+
+    suspend fun upsertProgress(progress: EpubProgress)
+
+    suspend fun deleteProgress(chapterId: Long)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-benchmark = "1.4.1"
 androidx-biometric = "1.2.0-alpha05"
 androidx-compose-bom = "2026.05.01"
 androidx-constraintLayout = "2.2.1"
+androidx-fragment = "1.8.9"
 androidx-core = "1.18.0"
 androidx-coreSplashScreen = "1.2.0"
 androidx-glance = "1.1.1"
@@ -87,6 +88,7 @@ androidx-compose-animationGraphics = { module = "androidx.compose.animation:anim
 androidx-compose-bom = { module = "androidx.compose:compose-bom-alpha", version.ref = "androidx-compose-bom" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "androidx-fragment" }
 androidx-compose-materialIcons = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime" }
 androidx-compose-runtimeAnnotation = { module = "androidx.compose.runtime:runtime-annotation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ okio = "3.17.0"
 photoView = "2.3.0"
 quickJs = "547f5b1597"
 reorderable = "3.1.0"
+readium = "3.3.0"
 rxJava = "1.3.8"
 shizuku = "13.1.5"
 spotless = "8.5.1"
@@ -163,6 +164,9 @@ okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 photoView = { module = "com.github.chrisbanes:PhotoView", version.ref = "photoView" }
 quickJs = { module = "com.github.zhanghai.quickjs-java:quickjs-android", version.ref = "quickJs" }
+readium-navigator = { module = "org.readium.kotlin-toolkit:readium-navigator", version.ref = "readium" }
+readium-shared = { module = "org.readium.kotlin-toolkit:readium-shared", version.ref = "readium" }
+readium-streamer = { module = "org.readium.kotlin-toolkit:readium-streamer", version.ref = "readium" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 rxJava = { module = "io.reactivex:rxjava", version.ref = "rxJava" }
 shizuku-api = { module = "dev.rikka.shizuku:api", version.ref = "shizuku" }


### PR DESCRIPTION
## 概述

新增 Koharia 原生 EPUB 阅读器的 Foundation 层：基于 Readium Kotlin 打开本地与 Komga 远程 EPUB，提供稳定 Locator/progression、本地进度保存、Komga 同步、按服务器隔离的阅读配置及基础阅读闭环。

PR #16 是依赖本 PR 的堆叠 PR2，当前保持 Draft；本 PR 合并并传播最终修复后再继续 Reader UI 层审查。

## 主要修改

- Readium publication、navigator、session 与本地/远程 EPUB 打开流程
- 原生 EPUB 支持判定及不支持时回退图片阅读器
- Readium preferences bridge、排版配置与 publisher styles 处理
- 按 Komga server 隔离 Reader/EPUB/Layout preferences，并兼容 legacy/shared 配置
- 本地 `epub_progress`、Locator 恢复与 Komga progression 同步
- 完成阈值、章节已读、历史时长、通知入口与 deep link 闭环
- 关闭 publisher styles 时规范化 `.xhtml/.html/.htm` 段落缩进

## 审查修复

- 通知入口移除主线程 `runBlocking`，使用 `goAsync()` 与 IO 协程
- 使用官方 `AndroidFragment` 替代私有 FragmentManager 反射
- 退出阅读时在独立 IO scope 串行保存最终 Locator
- 以实际 chapter source 作为 scoped preferences 的最终权威
- 修复 deep link 提前 pop 导致启动协程取消
- 清理已删除的 `enableNativeReader` 观察者和设置入口
- 移除与 Readium AAR 内嵌类冲突的重复 PhotoView 依赖

## 数据库边界

- Foundation 包含 `epub_progress.sq` 与迁移 `13.sqm`
- 书签表与迁移属于 PR2，不应出现在本 PR

## 验证

- `./gradlew.bat spotlessApply`
- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:checkDebugDuplicateClasses`
- `./gradlew.bat :app:assembleDebug`
- `./gradlew.bat :data:generateDebugDatabaseInterface`
- `./gradlew.bat :app:testDebugUnitTest --tests "koharia.epub.settings.EpubPreferencesBridgeTest"`

以上自动验证均通过；偏好桥接 LTR/RTL 共 2 项测试通过。PR1 手动阅读场景已确认完成。
