### PR TITLE
feat(epub): add progression sync and visual pagination

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -30,8 +30,8 @@ import koharia.domain.epub.interactor.GetEpubBookmarks
 import koharia.domain.epub.interactor.GetEpubPaginationCache
 import koharia.domain.epub.interactor.GetEpubProgress
 import koharia.domain.epub.interactor.UpdateEpubBookmarkNote
-import koharia.domain.epub.interactor.UpsertEpubProgress
 import koharia.domain.epub.interactor.UpsertEpubPaginationCache
+import koharia.domain.epub.interactor.UpsertEpubProgress
 import koharia.domain.epub.repository.EpubBookmarkRepository
 import koharia.domain.epub.repository.EpubPaginationCacheRepository
 import koharia.domain.epub.repository.EpubProgressRepository

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -21,15 +21,19 @@ import eu.kanade.domain.track.interactor.SyncChapterProgressWithTrack
 import eu.kanade.domain.track.interactor.TrackChapter
 import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
 import koharia.data.epub.EpubBookmarkRepositoryImpl
+import koharia.data.epub.EpubPaginationCacheRepositoryImpl
 import koharia.data.epub.EpubProgressRepositoryImpl
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
 import koharia.domain.epub.interactor.AddEpubBookmark
 import koharia.domain.epub.interactor.DeleteEpubBookmark
 import koharia.domain.epub.interactor.GetEpubBookmarks
+import koharia.domain.epub.interactor.GetEpubPaginationCache
 import koharia.domain.epub.interactor.GetEpubProgress
 import koharia.domain.epub.interactor.UpdateEpubBookmarkNote
 import koharia.domain.epub.interactor.UpsertEpubProgress
+import koharia.domain.epub.interactor.UpsertEpubPaginationCache
 import koharia.domain.epub.repository.EpubBookmarkRepository
+import koharia.domain.epub.repository.EpubPaginationCacheRepository
 import koharia.domain.epub.repository.EpubProgressRepository
 import koharia.domain.upcoming.interactor.GetUpcomingManga
 import tachiyomi.data.category.CategoryRepositoryImpl
@@ -166,6 +170,9 @@ class DomainModule : InjektModule {
         addSingletonFactory<EpubProgressRepository> { EpubProgressRepositoryImpl(get()) }
         addFactory { GetEpubProgress(get()) }
         addFactory { UpsertEpubProgress(get()) }
+        addSingletonFactory<EpubPaginationCacheRepository> { EpubPaginationCacheRepositoryImpl(get()) }
+        addFactory { GetEpubPaginationCache(get()) }
+        addFactory { UpsertEpubPaginationCache(get()) }
         addSingletonFactory<EpubBookmarkRepository> { EpubBookmarkRepositoryImpl(get()) }
         addFactory { GetEpubBookmarks(get()) }
         addFactory { AddEpubBookmark(get()) }

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -829,14 +829,15 @@ private fun LazyListScope.sharedChapterItems(
                     date = relativeDateText(item.chapter.dateUpload),
                     readProgress = when {
                         item.chapter.read -> null
-                        item.epubProgressPercent != null -> item.epubProgressPercent
-                            .takeIf { it > 0 }
-                            ?.let {
-                                stringResource(
-                                    MR.strings.epub_chapter_progress,
-                                    it,
-                                )
-                            }
+                        item.epubProgressPercent != null ->
+                            item.epubProgressPercent
+                                .takeIf { it > 0 }
+                                ?.let {
+                                    stringResource(
+                                        MR.strings.epub_chapter_progress,
+                                        it,
+                                    )
+                                }
                         item.chapter.lastPageRead > 0L -> {
                             stringResource(
                                 MR.strings.chapter_progress,

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -827,14 +827,24 @@ private fun LazyListScope.sharedChapterItems(
                         item.chapter.name
                     },
                     date = relativeDateText(item.chapter.dateUpload),
-                    readProgress = item.chapter.lastPageRead
-                        .takeIf { !item.chapter.read && it > 0L }
-                        ?.let {
+                    readProgress = when {
+                        item.chapter.read -> null
+                        item.epubProgressPercent != null -> item.epubProgressPercent
+                            .takeIf { it > 0 }
+                            ?.let {
+                                stringResource(
+                                    MR.strings.epub_chapter_progress,
+                                    it,
+                                )
+                            }
+                        item.chapter.lastPageRead > 0L -> {
                             stringResource(
                                 MR.strings.chapter_progress,
-                                it + 1,
+                                item.chapter.lastPageRead + 1,
                             )
-                        },
+                        }
+                        else -> null
+                    },
                     scanlator = item.chapter.scanlator.takeIf { !it.isNullOrBlank() },
                     read = item.chapter.read,
                     bookmark = item.chapter.bookmark,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -118,6 +118,7 @@ class KomgaApi(
                             seriesUrl = url,
                             url = "$baseUrl/api/v1/books/${book.id}",
                             readProgress = book.readProgress,
+                            isEpub = book.media?.mediaProfile == "EPUB",
                         )
                     }
             }
@@ -147,6 +148,7 @@ class KomgaApi(
                                 seriesUrl = "$baseUrl/api/v1/series/${book.seriesId}",
                                 url = "$baseUrl/api/v1/books/${book.id}",
                                 readProgress = book.readProgress,
+                                isEpub = book.media?.mediaProfile == "EPUB",
                             )
                         }
                 }
@@ -234,5 +236,6 @@ class KomgaApi(
         val seriesUrl: String? = null,
         val url: String,
         val readProgress: BookReadProgressDto?,
+        val isEpub: Boolean = false,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
@@ -112,10 +112,16 @@ data class PageWrapperDto<T>(
 )
 
 @Serializable
+data class BookMediaDto(
+    val mediaProfile: String = "",
+)
+
+@Serializable
 data class BookDto(
     val id: String,
     val seriesId: String = "",
     val readProgress: BookReadProgressDto? = null,
+    val media: BookMediaDto? = null,
 )
 
 @Serializable

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -155,11 +155,14 @@ class KomgaProgressSyncService(
                     )
                 }
 
-            if (newRead != localChapter.read || newLastPageRead != localChapter.lastPageRead) {
+            val shouldUpdatePage = !remote.isEpub &&
+                newLastPageRead != localChapter.lastPageRead
+
+            if (newRead != localChapter.read || shouldUpdatePage) {
                 chapterUpdates += ChapterUpdate(
                     id = localChapter.id,
                     read = newRead,
-                    lastPageRead = newLastPageRead,
+                    lastPageRead = newLastPageRead.takeUnless { remote.isEpub },
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -43,6 +43,7 @@ import tachiyomi.data.Chapters
 import tachiyomi.data.Database
 import tachiyomi.data.DateColumnAdapter
 import tachiyomi.data.Epub_bookmark
+import tachiyomi.data.Epub_pagination_cache
 import tachiyomi.data.Epub_progress
 import tachiyomi.data.History
 import tachiyomi.data.Mangas
@@ -94,6 +95,9 @@ class AppModule(val app: Application) : InjektModule {
                 ),
                 epub_bookmarkAdapter = Epub_bookmark.Adapter(
                     created_atAdapter = DateColumnAdapter,
+                ),
+                epub_pagination_cacheAdapter = Epub_pagination_cache.Adapter(
+                    updated_atAdapter = DateColumnAdapter,
                 ),
                 mangasAdapter = Mangas.Adapter(
                     genreAdapter = StringListColumnAdapter,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -45,6 +45,8 @@ import eu.kanade.tachiyomi.util.chapter.getNextUnread
 import eu.kanade.tachiyomi.util.removeCovers
 import eu.kanade.tachiyomi.util.system.toast
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
+import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.domain.epub.model.EpubProgress
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
@@ -91,6 +93,7 @@ import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlin.math.floor
+import kotlin.math.roundToInt
 
 class MangaScreenModel(
     private val context: Context,
@@ -122,6 +125,7 @@ class MangaScreenModel(
     private val mangaRepository: MangaRepository = Injekt.get(),
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get(),
     private val komgaProgressSyncService: KomgaProgressSyncService = Injekt.get(),
+    private val getEpubProgress: GetEpubProgress = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -172,15 +176,19 @@ class MangaScreenModel(
         screenModelScope.launchIO {
             combine(
                 getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
+                getEpubProgress.subscribeByMangaId(mangaId),
                 downloadCache.changes,
                 downloadManager.queueState,
-            ) { mangaAndChapters, _, _ -> mangaAndChapters }
+            ) { mangaAndChapters, epubProgresses, _, _ ->
+                mangaAndChapters to epubProgresses
+            }
                 .flowWithLifecycle(lifecycle)
-                .collectLatest { (manga, chapters) ->
+                .collectLatest { (mangaAndChapters, epubProgresses) ->
+                    val (manga, chapters) = mangaAndChapters
                     updateSuccessState {
                         it.copy(
                             manga = manga,
-                            chapters = chapters.toChapterListItems(manga),
+                            chapters = chapters.toChapterListItems(manga, epubProgresses.associateBy { it.chapterId }),
                         )
                     }
                 }
@@ -212,8 +220,10 @@ class MangaScreenModel(
 
         screenModelScope.launchIO {
             val manga = getMangaAndChapters.awaitManga(mangaId)
+            val epubProgresses = getEpubProgress.awaitByMangaId(mangaId)
+                .associateBy { it.chapterId }
             val chapters = getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true)
-                .toChapterListItems(manga)
+                .toChapterListItems(manga, epubProgresses)
             val source = Injekt.get<SourceManager>().getOrStub(manga.source)
 
             if (!manga.favorite) {
@@ -557,7 +567,10 @@ class MangaScreenModel(
         }
     }
 
-    private fun List<Chapter>.toChapterListItems(manga: Manga): List<ChapterList.Item> {
+    private fun List<Chapter>.toChapterListItems(
+        manga: Manga,
+        epubProgresses: Map<Long, EpubProgress> = emptyMap(),
+    ): List<ChapterList.Item> {
         return map { chapter ->
             val activeDownload = downloadManager.getQueuedDownloadOrNull(chapter.id)
             val downloaded = downloadManager.isChapterDownloaded(
@@ -577,6 +590,13 @@ class MangaScreenModel(
                 chapter = chapter,
                 downloadState = downloadState,
                 downloadProgress = activeDownload?.progress ?: 0,
+                epubProgressPercent = epubProgresses[chapter.id]
+                    ?.progression
+                    ?.let { progression ->
+                        (progression.coerceIn(0.0, 1.0) * 100)
+                            .roundToInt()
+                            .coerceAtMost(if (chapter.read) 100 else 99)
+                    },
                 selected = chapter.id in selectedChapterIds,
             )
         }
@@ -1245,6 +1265,7 @@ sealed class ChapterList {
         val chapter: Chapter,
         val downloadState: Download.State,
         val downloadProgress: Int,
+        val epubProgressPercent: Int? = null,
         val selected: Boolean = false,
     ) : ChapterList() {
         val id = chapter.id

--- a/app/src/main/java/koharia/epub/EpubPaginationModels.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationModels.kt
@@ -1,0 +1,126 @@
+package koharia.epub
+
+import koharia.epub.settings.EpubLayoutPreferences
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.security.MessageDigest
+
+enum class EpubPaginationPhase {
+    CACHED,
+    CALCULATING,
+    READY,
+    UNAVAILABLE,
+}
+
+internal data class EpubPaginationLayoutSnapshot(
+    val readingMode: String,
+    val pageDirection: String,
+    val fontSize: Float,
+    val lineHeight: Float,
+    val paragraphSpacing: Float,
+    val paragraphIndent: Float,
+    val pageMargins: Float,
+    val verticalMargins: Float,
+    val fontFamily: String,
+    val publisherStyles: Boolean,
+    val viewportWidthPx: Int,
+    val viewportHeightPx: Int,
+    val densityDpi: Int,
+    val fontScale: Float,
+    val webViewVersion: String,
+) {
+    val json: String
+        get() = buildJsonObject {
+            put("algorithmVersion", PAGINATION_ALGORITHM_VERSION)
+            put("readiumVersion", READIUM_VERSION)
+            put("readingMode", readingMode)
+            put("pageDirection", pageDirection)
+            put("fontSize", fontSize.toDouble())
+            put("lineHeight", lineHeight.toDouble())
+            put("paragraphSpacing", paragraphSpacing.toDouble())
+            put("paragraphIndent", paragraphIndent.toDouble())
+            put("pageMargins", pageMargins.toDouble())
+            put("verticalMargins", verticalMargins.toDouble())
+            put("fontFamily", fontFamily)
+            put("publisherStyles", publisherStyles)
+            put("viewportWidthPx", viewportWidthPx)
+            put("viewportHeightPx", viewportHeightPx)
+            put("densityDpi", densityDpi)
+            put("fontScale", fontScale.toDouble())
+            put("webViewVersion", webViewVersion)
+        }.toString()
+
+    val key: String
+        get() = json.sha256()
+
+    companion object {
+        fun from(
+            preferences: EpubLayoutPreferences,
+            viewport: EpubPaginationViewport,
+        ): EpubPaginationLayoutSnapshot {
+            return EpubPaginationLayoutSnapshot(
+                readingMode = preferences.readingMode.get().name,
+                pageDirection = preferences.pageDirection.get().name,
+                fontSize = preferences.fontSize.get(),
+                lineHeight = preferences.lineHeight.get(),
+                paragraphSpacing = preferences.paragraphSpacing.get(),
+                paragraphIndent = preferences.paragraphIndent.get(),
+                pageMargins = preferences.pageMargins.get(),
+                verticalMargins = preferences.verticalMargins.get(),
+                fontFamily = preferences.fontFamily.get().name,
+                publisherStyles = preferences.publisherStyles.get(),
+                viewportWidthPx = viewport.widthPx,
+                viewportHeightPx = viewport.heightPx,
+                densityDpi = viewport.densityDpi,
+                fontScale = viewport.fontScale,
+                webViewVersion = viewport.webViewVersion,
+            )
+        }
+    }
+}
+
+data class EpubPaginationViewport(
+    val widthPx: Int,
+    val heightPx: Int,
+    val densityDpi: Int,
+    val fontScale: Float,
+    val webViewVersion: String,
+)
+
+internal data class EpubPaginationRequest(
+    val generation: Long,
+    val publicationKey: String,
+    val layoutKey: String,
+    val layoutSnapshotJson: String,
+    val initialPageCounts: Map<String, Int>,
+    val shouldScan: Boolean,
+)
+
+internal fun Map<String, Int>.toPageCountsJson(): String {
+    return buildJsonObject {
+        toSortedMap().forEach { (href, count) -> put(href, count) }
+    }.toString()
+}
+
+internal fun String.toPageCounts(): Map<String, Int> {
+    return runCatching {
+        Json.parseToJsonElement(this).jsonObject.mapNotNull { (href, element) ->
+            element.jsonPrimitive.intOrNull
+                ?.takeIf { it > 0 }
+                ?.let { href to it }
+        }.toMap()
+    }.getOrDefault(emptyMap())
+}
+
+private fun String.sha256(): String {
+    return MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray())
+        .joinToString("") { byte -> "%02x".format(byte) }
+}
+
+private const val PAGINATION_ALGORITHM_VERSION = 3
+private const val READIUM_VERSION = "3.3.0"

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -208,6 +208,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
     private fun String.isSameResourceHref(other: String): Boolean {
         val first = resourceKey()
         val second = other.resourceKey()
+        if (first.isBlank() || second.isBlank()) return false
         return first == second || first.endsWith("/$second") || second.endsWith("/$first")
     }
 

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -148,10 +148,12 @@ internal class EpubPaginationScannerFragment : Fragment() {
     }
 
     private suspend fun awaitStableLayout(): Boolean {
-        val navigator = navigatorFragment() ?: return false
         val loaded = withTimeoutOrNull(RESOURCE_READY_TIMEOUT_MS) {
             while (true) {
-                val result = navigator.evaluateJavascript(RESOURCE_READY_SCRIPT)
+                val navigator = navigatorFragment() ?: return@withTimeoutOrNull false
+                val result = runCatching {
+                    navigator.evaluateJavascript(RESOURCE_READY_SCRIPT)
+                }.getOrNull() ?: return@withTimeoutOrNull false
                 if (result == "true") break
                 delay(RESOURCE_READY_POLL_MS)
             }

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -1,0 +1,245 @@
+package koharia.epub
+
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.commitNow
+import androidx.lifecycle.lifecycleScope
+import koharia.epub.session.EpubReaderSessionRepository
+import koharia.epub.settings.EpubLayoutPreferences
+import koharia.epub.settings.EpubPreferencesBridge
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Locator
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+@OptIn(ExperimentalReadiumApi::class)
+internal class EpubPaginationScannerFragment : Fragment() {
+
+    private val sessionRepository: EpubReaderSessionRepository = Injekt.get()
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get()
+    private val epubPreferencesBridge = EpubPreferencesBridge()
+    private val chapterId: Long
+        get() = requireArguments().getLong(ARG_CHAPTER_ID)
+    private val sourceId: Long
+        get() = requireArguments().getLong(ARG_SOURCE_ID, -1L)
+    private val generation: Long
+        get() = requireArguments().getLong(ARG_GENERATION)
+    private val epubLayoutPreferences by lazy {
+        (activity as? EpubReaderActivity)?.sessionEpubLayoutPreferences() ?: if (sourceId > 0L) {
+            scopedPreferenceStoreFactory.epubLayoutPreferences(sourceId)
+        } else {
+            Injekt.get<EpubLayoutPreferences>()
+        }
+    }
+    private var containerId: Int = View.NO_ID
+    private var scanIndex = 0
+    private var scanStarted = false
+    private var awaitingMeasuredCallback = false
+    private var readinessJob: Job? = null
+    private val beginScanRunnable = Runnable {
+        if (!isAdded || view == null) return@Runnable
+        beginScan()
+    }
+    private val pageCounts by lazy {
+        requireArguments().getString(ARG_INITIAL_PAGE_COUNTS).orEmpty().toPageCounts().toMutableMap()
+    }
+
+    @Suppress("DEPRECATION")
+    private val paginationListener = object : EpubNavigatorFragment.PaginationListener {
+        override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
+            if (!isAdded || view == null) return
+            if (!scanStarted) return
+            val expectedLink = readingOrder().getOrNull(scanIndex) ?: return
+            if (!expectedLink.href.toString().isSameResourceHref(locator.href.toString())) return
+
+            if (awaitingMeasuredCallback) {
+                awaitingMeasuredCallback = false
+                recordPageCount(totalPages, locator)
+            } else if (readinessJob == null) {
+                readinessJob = viewLifecycleOwner.lifecycleScope.launch {
+                    if (!epubLayoutPreferences.publisherStyles.get()) {
+                        navigatorFragment()?.evaluateJavascript(APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT)
+                    }
+                    val ready = awaitStableLayout()
+                    readinessJob = null
+                    if (!ready) {
+                        reportProgress(isComplete = false)
+                        scanStarted = false
+                        return@launch
+                    }
+                    awaitingMeasuredCallback = true
+                    navigatorFragment()?.go(expectedLink)
+                }
+            }
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val session = sessionRepository.get(chapterId)
+        val firstMissingLink = session?.publication?.readingOrder?.firstOrNull { link ->
+            pageCounts.keys.none { cachedHref -> cachedHref.isSameResourceHref(link.href.toString()) }
+        } ?: session?.publication?.readingOrder?.firstOrNull()
+        val firstLocator = session?.let { readerSession ->
+            firstMissingLink?.let(readerSession.publication::locatorFromLink)
+        }
+        childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
+            initialLocator = firstLocator,
+            initialPreferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences),
+            paginationListener = paginationListener,
+            configuration = EpubNavigatorFragment.Configuration(
+                shouldApplyInsetsPadding = false,
+            ),
+        ) ?: EpubNavigatorFragment.createDummyFactory()
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(
+        inflater: android.view.LayoutInflater,
+        container: android.view.ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return FragmentContainerView(requireContext()).apply {
+            id = View.generateViewId()
+            containerId = id
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        if (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) == null) {
+            val navigator = childFragmentManager.fragmentFactory.instantiate(
+                requireContext().classLoader,
+                EpubNavigatorFragment::class.java.name,
+            )
+            childFragmentManager.commitNow {
+                setReorderingAllowed(true)
+                replace(containerId, navigator, NAVIGATOR_TAG)
+            }
+        }
+        view.post(beginScanRunnable)
+    }
+
+    override fun onDestroyView() {
+        view?.removeCallbacks(beginScanRunnable)
+        readinessJob?.cancel()
+        readinessJob = null
+        scanStarted = false
+        awaitingMeasuredCallback = false
+        super.onDestroyView()
+    }
+
+    private fun beginScan() {
+        scanStarted = true
+        advancePastCachedResources()
+        val nextLink = readingOrder().getOrNull(scanIndex)
+        if (nextLink == null) {
+            reportProgress(isComplete = true)
+        } else {
+            navigatorFragment()?.go(nextLink)
+        }
+    }
+
+    private suspend fun awaitStableLayout(): Boolean {
+        val navigator = navigatorFragment() ?: return false
+        val loaded = withTimeoutOrNull(RESOURCE_READY_TIMEOUT_MS) {
+            while (true) {
+                val result = navigator.evaluateJavascript(RESOURCE_READY_SCRIPT)
+                if (result == "true") break
+                delay(RESOURCE_READY_POLL_MS)
+            }
+            true
+        } ?: false
+        if (loaded) delay(STABLE_LAYOUT_DELAY_MS)
+        return loaded
+    }
+
+    private fun recordPageCount(totalPages: Int, locator: Locator) {
+        if (totalPages <= 0) return
+        val expectedLink = readingOrder().getOrNull(scanIndex) ?: return
+        val expectedHref = expectedLink.href.toString().resourceKey()
+        if (!expectedHref.isSameResourceHref(locator.href.toString())) return
+
+        pageCounts[expectedHref] = totalPages
+        reportProgress(isComplete = false)
+        scanIndex += 1
+        advancePastCachedResources()
+        val nextLink = readingOrder().getOrNull(scanIndex)
+        if (nextLink != null) {
+            navigatorFragment()?.go(nextLink)
+        } else {
+            reportProgress(isComplete = true)
+        }
+    }
+
+    private fun advancePastCachedResources() {
+        val order = readingOrder()
+        while (scanIndex < order.size) {
+            val href = order[scanIndex].href.toString()
+            if (pageCounts.keys.none { it.isSameResourceHref(href) }) break
+            scanIndex += 1
+        }
+    }
+
+    private fun reportProgress(isComplete: Boolean) {
+        (parentFragment as? EpubReaderFragment)?.onBookPaginationCalculated(
+            generation = generation,
+            pageCounts = pageCounts.toMap(),
+            isComplete = isComplete,
+        )
+    }
+
+    private fun readingOrder() = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+
+    private fun navigatorFragment(): EpubNavigatorFragment? {
+        if (!isAdded) return null
+        return childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
+    }
+
+    private fun String.isSameResourceHref(other: String): Boolean {
+        val first = resourceKey()
+        val second = other.resourceKey()
+        return first == second || first.endsWith("/$second") || second.endsWith("/$first")
+    }
+
+    private fun String.resourceKey(): String =
+        substringBefore('#')
+            .substringBefore('?')
+            .trimStart('/')
+
+    companion object {
+        private const val ARG_CHAPTER_ID = "chapter_id"
+        private const val ARG_SOURCE_ID = "source_id"
+        private const val ARG_GENERATION = "generation"
+        private const val ARG_INITIAL_PAGE_COUNTS = "initial_page_counts"
+        private const val NAVIGATOR_TAG = "epub_pagination_navigator"
+        private const val RESOURCE_READY_TIMEOUT_MS = 8_000L
+        private const val RESOURCE_READY_POLL_MS = 75L
+        private const val STABLE_LAYOUT_DELAY_MS = 40L
+        private const val RESOURCE_READY_SCRIPT =
+            "document.fonts.status === 'loaded' && " +
+                "Array.from(document.images).every(function(image) { return image.complete; })"
+
+        fun newInstance(
+            chapterId: Long,
+            sourceId: Long,
+            request: EpubPaginationRequest,
+        ): EpubPaginationScannerFragment {
+            return EpubPaginationScannerFragment().apply {
+                arguments = Bundle().apply {
+                    putLong(ARG_CHAPTER_ID, chapterId)
+                    putLong(ARG_SOURCE_ID, sourceId)
+                    putLong(ARG_GENERATION, request.generation)
+                    putString(ARG_INITIAL_PAGE_COUNTS, request.initialPageCounts.toPageCountsJson())
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -786,7 +786,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         paginationViewportJob?.cancel()
         if (state.isReady) {
             paginationJob?.cancel()
-            viewModel.invalidatePaginationCalculation()
+            viewModel.invalidatePaginationDisplay()
             epubReaderFragment()?.stopPagination()
             paginationViewportJob = lifecycleScope.launch {
                 kotlinx.coroutines.delay(PAGINATION_VIEWPORT_DEBOUNCE_MS)

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -80,6 +80,7 @@ import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -113,7 +114,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     companion object {
         private const val READER_EDGE_PADDING_DP = 8
-        private const val LAYOUT_SETTINGS_DEBOUNCE_MS = 250L
+        private const val PAGINATION_SETTINGS_DEBOUNCE_MS = 250L
+        private const val PAGINATION_VIEWPORT_DEBOUNCE_MS = 250L
 
         fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, sourceId: Long? = null): Intent {
             return Intent(context, EpubReaderActivity::class.java).apply {
@@ -164,6 +166,9 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private val epubReaderLauncher by lazy { EpubReaderLauncher() }
     private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, window.decorView) }
     private var isReaderResumed = false
+    private var paginationViewport: EpubPaginationViewport? = null
+    private var paginationViewportJob: Job? = null
+    private var paginationJob: Job? = null
     private var currentPublisherStyles: Boolean? = null
     private var readerFragment: EpubReaderFragment? = null
 
@@ -589,6 +594,26 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 )
             }
 
+            state.serverTimeOffsetMinutes?.let { offsetMinutes ->
+                AlertDialog(
+                    onDismissRequest = viewModel::dismissServerTimeWarning,
+                    title = { Text(stringResource(MR.strings.epub_reader_server_time_warning_title)) },
+                    text = {
+                        Text(
+                            stringResource(
+                                MR.strings.epub_reader_server_time_warning_message,
+                                offsetMinutes,
+                            ),
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = viewModel::dismissServerTimeWarning) {
+                            Text(stringResource(MR.strings.action_ok))
+                        }
+                    },
+                )
+            }
+
             if (showBookInfoDialog) {
                 EpubBookInfoDialog(
                     state = state,
@@ -643,6 +668,9 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     override fun onPause() {
         isReaderResumed = false
+        paginationViewportJob?.cancel()
+        paginationJob?.cancel()
+        epubReaderFragment()?.stopPagination()
         lifecycleScope.launchNonCancellable {
             viewModel.saveCurrentProgress()
             viewModel.updateHistory()
@@ -657,12 +685,16 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         isReaderResumed = true
         applyCurrentEpubBrightness()
         updateSystemBars(viewModel.state.value.menuVisible)
-        if (viewModel.state.value.isReady) {
+        if (viewModel.state.value.isReady &&
+            paginationViewport != null &&
+            paginationViewportJob?.isActive != true
+        ) {
             applyCurrentReadiumPreferences()
         }
     }
 
     override fun onLowMemory() {
+        epubReaderFragment()?.stopPagination()
         lifecycleScope.launchNonCancellable { viewModel.saveCurrentProgress() }
         super.onLowMemory()
     }
@@ -724,12 +756,56 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         viewModel.updateLocator(locator)
     }
 
+    override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
+        viewModel.updateVisualPage(pageIndex, totalPages, locator)
+    }
+
+    override fun onBookPaginationChanged(
+        generation: Long,
+        pageCounts: Map<String, Int>,
+        isComplete: Boolean,
+    ) {
+        viewModel.updateBookPagination(generation, pageCounts, isComplete)
+        if (isComplete && generation == viewModel.state.value.paginationGeneration) {
+            viewModel.currentLocator()?.let { locator ->
+                epubReaderFragment()?.goTo(locator)
+            }
+        }
+    }
+
+    override fun onPaginationViewportChanged(viewport: EpubPaginationViewport) {
+        val previousViewport = paginationViewport
+        if (viewport == previousViewport) return
+        val state = viewModel.state.value
+        logcat(LogPriority.DEBUG) {
+            "EPUB pagination viewport changed old=$previousViewport new=$viewport " +
+                "ready=${state.isReady} phase=${state.paginationPhase} " +
+                "pages=${state.currentVisualPage}/${state.totalVisualPages}"
+        }
+        paginationViewport = viewport
+        paginationViewportJob?.cancel()
+        if (state.isReady) {
+            paginationJob?.cancel()
+            viewModel.invalidatePaginationCalculation()
+            epubReaderFragment()?.stopPagination()
+            paginationViewportJob = lifecycleScope.launch {
+                kotlinx.coroutines.delay(PAGINATION_VIEWPORT_DEBOUNCE_MS)
+                if (paginationViewport == viewport && viewModel.state.value.isReady) {
+                    logcat(LogPriority.DEBUG) { "EPUB pagination viewport settled viewport=$viewport" }
+                    applyCurrentReadiumPreferences()
+                }
+            }
+        }
+    }
+
     override fun onExternalLinkActivated(url: AbsoluteUrl) {
         openInBrowser(url.toUri(), forceDefaultBrowser = false)
     }
 
     override fun onNavigatorReady() {
-        applyCurrentReadiumPreferences()
+        if (paginationViewportJob?.isActive != true) {
+            applyCurrentReadiumPreferences()
+        }
     }
 
     override fun onSessionMissing(chapterId: Long) {
@@ -821,7 +897,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             }
             .launchIn(lifecycleScope)
 
-        val layoutAffectingChanges = listOf(
+        val paginationAffectingChanges = listOf(
             epubLayoutPreferences.readingMode.changes().map { it as Any },
             epubLayoutPreferences.pageDirection.changes().map { it as Any },
             epubLayoutPreferences.fontSize.changes().map { it as Any },
@@ -833,10 +909,20 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             epubLayoutPreferences.fontFamily.changes().map { it as Any },
             epubLayoutPreferences.publisherStyles.changes().map { it as Any },
         )
-        combine(layoutAffectingChanges) { values -> values.toList() }
+        combine(paginationAffectingChanges) { values -> values.toList() }
             .distinctUntilChanged()
             .drop(1)
-            .debounce(LAYOUT_SETTINGS_DEBOUNCE_MS)
+            .onEach { values ->
+                val state = viewModel.state.value
+                logcat(LogPriority.DEBUG) {
+                    "EPUB pagination settings changed values=$values phase=${state.paginationPhase} " +
+                        "pages=${state.currentVisualPage}/${state.totalVisualPages}"
+                }
+                paginationJob?.cancel()
+                viewModel.invalidatePaginationDisplay()
+                epubReaderFragment()?.stopPagination()
+            }
+            .debounce(PAGINATION_SETTINGS_DEBOUNCE_MS)
             .onEach { values ->
                 val publisherStyles = values.last() as Boolean
                 val shouldReload = publisherStyles != currentPublisherStyles
@@ -852,7 +938,35 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     private fun applyCurrentReadiumPreferences() {
         val fragment = epubReaderFragment() ?: return
-        fragment.submitPreferences(epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences))
+        val viewport = paginationViewport ?: return
+        val preferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences)
+        fragment.submitPreferences(preferences)
+        paginationJob?.cancel()
+        paginationJob = lifecycleScope.launch {
+            val snapshot = EpubPaginationLayoutSnapshot.from(epubLayoutPreferences, viewport)
+            val stateBefore = viewModel.state.value
+            logcat(LogPriority.DEBUG) {
+                "EPUB pagination prepare requested key=${snapshot.key.take(12)} viewport=$viewport " +
+                    "phase=${stateBefore.paginationPhase} " +
+                    "pages=${stateBefore.currentVisualPage}/${stateBefore.totalVisualPages}"
+            }
+            val request = viewModel.preparePagination(snapshot)
+            val stateAfter = viewModel.state.value
+            logcat(LogPriority.DEBUG) {
+                "EPUB pagination prepare completed key=${snapshot.key.take(12)} " +
+                    "generation=${request.generation} shouldScan=${request.shouldScan} " +
+                    "phase=${stateAfter.paginationPhase} " +
+                    "pages=${stateAfter.currentVisualPage}/${stateAfter.totalVisualPages}"
+            }
+            if (request.generation == viewModel.state.value.paginationGeneration) {
+                fragment.startPagination(request)
+                if (!request.shouldScan &&
+                    viewModel.state.value.paginationPhase != EpubPaginationPhase.UNAVAILABLE
+                ) {
+                    viewModel.currentLocator()?.let(fragment::goTo)
+                }
+            }
+        }
     }
 
     private fun reloadEpubSessionForPublisherStyles(enabled: Boolean) {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -175,7 +175,8 @@ class EpubReaderFragment : Fragment() {
         if (navigatorFragment() != null) {
             host?.onNavigatorReady()
         }
-        view.addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+        val viewportView = view.findViewById<View>(containerId) ?: view
+        viewportView.addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
             val width = right - left
             val height = bottom - top
             if (width <= 0 || height <= 0 ||

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -3,6 +3,7 @@ package koharia.epub
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
@@ -10,6 +11,7 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import koharia.epub.locator.toNavigatorLocator
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
@@ -38,6 +40,16 @@ class EpubReaderFragment : Fragment() {
 
         fun onLocatorChanged(locator: Locator)
 
+        fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator)
+
+        fun onBookPaginationChanged(
+            generation: Long,
+            pageCounts: Map<String, Int>,
+            isComplete: Boolean,
+        )
+
+        fun onPaginationViewportChanged(viewport: EpubPaginationViewport)
+
         fun onExternalLinkActivated(url: AbsoluteUrl)
 
         fun onNavigatorReady()
@@ -61,6 +73,7 @@ class EpubReaderFragment : Fragment() {
     }
     private var host: Host? = null
     private var containerId: Int = View.NO_ID
+    private var scannerContainerId: Int = View.NO_ID
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
 
@@ -80,6 +93,7 @@ class EpubReaderFragment : Fragment() {
     @Suppress("DEPRECATION")
     private val paginationListener = object : EpubNavigatorFragment.PaginationListener {
         override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
+            host?.onPageChanged(pageIndex, totalPages, locator)
             applyParagraphIndentOverride()
         }
     }
@@ -122,6 +136,18 @@ class EpubReaderFragment : Fragment() {
                     FrameLayout.LayoutParams.MATCH_PARENT,
                 ),
             )
+            addView(
+                FragmentContainerView(requireContext()).apply {
+                    id = View.generateViewId()
+                    scannerContainerId = id
+                    visibility = View.INVISIBLE
+                    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS
+                },
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                ),
+            )
         }
     }
 
@@ -149,6 +175,25 @@ class EpubReaderFragment : Fragment() {
         if (navigatorFragment() != null) {
             host?.onNavigatorReady()
         }
+        view.addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
+            val width = right - left
+            val height = bottom - top
+            if (width <= 0 || height <= 0 ||
+                (width == oldRight - oldLeft && height == oldBottom - oldTop)
+            ) {
+                return@addOnLayoutChangeListener
+            }
+            val configuration = resources.configuration
+            host?.onPaginationViewportChanged(
+                EpubPaginationViewport(
+                    widthPx = width,
+                    heightPx = height,
+                    densityDpi = configuration.densityDpi,
+                    fontScale = configuration.fontScale,
+                    webViewVersion = WebView.getCurrentWebViewPackage()?.versionName.orEmpty(),
+                ),
+            )
+        }
     }
 
     override fun onDetach() {
@@ -163,7 +208,8 @@ class EpubReaderFragment : Fragment() {
 
     fun goTo(locator: Locator): Boolean {
         val navigator = navigatorFragment() ?: return false
-        return navigator.go(locator)
+        val publication = sessionRepository.get(chapterId)?.publication ?: return false
+        return navigator.go(publication.toNavigatorLocator(locator))
     }
 
     fun goForward(): Boolean {
@@ -216,6 +262,43 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
+    internal fun startPagination(request: EpubPaginationRequest) {
+        val existing = paginationScannerFragment()
+        if (!request.shouldScan) {
+            if (existing != null) {
+                childFragmentManager.commitNow { remove(existing) }
+            }
+            return
+        }
+        childFragmentManager.commitNow {
+            setReorderingAllowed(true)
+            replace(
+                scannerContainerId,
+                EpubPaginationScannerFragment.newInstance(chapterId, sourceId, request),
+                PAGINATION_SCANNER_TAG,
+            )
+        }
+    }
+
+    fun stopPagination() {
+        paginationScannerFragment()?.let { scanner ->
+            if (!childFragmentManager.isStateSaved) {
+                childFragmentManager.commitNow { remove(scanner) }
+            }
+        }
+    }
+
+    internal fun onBookPaginationCalculated(
+        generation: Long,
+        pageCounts: Map<String, Int>,
+        isComplete: Boolean,
+    ) {
+        host?.onBookPaginationChanged(generation, pageCounts, isComplete)
+        if (isComplete) {
+            view?.post(::stopPagination)
+        }
+    }
+
     private fun observeNavigator() {
         val navigator = navigatorFragment() ?: return
         logcat(LogPriority.DEBUG) {
@@ -247,10 +330,14 @@ class EpubReaderFragment : Fragment() {
     private fun navigatorFragment(): EpubNavigatorFragment? =
         childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
 
+    private fun paginationScannerFragment(): EpubPaginationScannerFragment? =
+        childFragmentManager.findFragmentByTag(PAGINATION_SCANNER_TAG) as? EpubPaginationScannerFragment
+
     companion object {
         private const val ARG_CHAPTER_ID = "chapter_id"
         private const val ARG_SOURCE_ID = "source_id"
         private const val NAVIGATOR_TAG = "epub_navigator"
+        private const val PAGINATION_SCANNER_TAG = "epub_pagination_scanner"
         private const val PARAGRAPH_INDENT_DEBUG_DELAY_MS = 600L
         private val PARAGRAPH_INDENT_DEBUG_SCRIPT =
             """

--- a/app/src/main/java/koharia/epub/EpubReaderUiState.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderUiState.kt
@@ -25,6 +25,8 @@ data class EpubReaderUiState(
     val totalPositions: Int = 1,
     val currentVisualPage: Int? = null,
     val totalVisualPages: Int? = null,
+    val paginationPhase: EpubPaginationPhase = EpubPaginationPhase.CALCULATING,
+    val paginationGeneration: Long = 0,
     val sessionToken: Long = 0,
     val isLoading: Boolean = false,
     val isReady: Boolean = false,

--- a/app/src/main/java/koharia/epub/EpubReaderUiState.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderUiState.kt
@@ -32,6 +32,7 @@ data class EpubReaderUiState(
     val isReady: Boolean = false,
     val menuVisible: Boolean = true,
     val errorMessage: String? = null,
+    val serverTimeOffsetMinutes: Long? = null,
     val isIncognito: Boolean = false,
     val bookmarks: List<EpubBookmark> = emptyList(),
     val currentBookmarkId: Long? = null,

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -820,23 +820,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
         }
     }
 
-    fun locatorAtPosition(index: Int): Locator? = publicationPositions.getOrNull(index)
-
-    fun locatorAtProgression(progression: Double): Locator? {
-        if (publicationPositions.isEmpty()) return null
-        val index = (progression.coerceIn(0.0, 1.0) * (publicationPositions.size - 1))
-            .roundToInt()
-        return publicationPositions.getOrNull(index)
-    }
-
-    fun currentLocator(): Locator? = latestLocator
-
-    suspend fun saveCurrentProgress() {
-        if (!isIncognito()) {
-            latestLocator?.let { persistLocator(it) }
-        }
-    }
-
     fun tableOfContents(): List<EpubTocEntry> {
         val session = sessionRepository.get(chapterId) ?: return emptyList()
         return flattenLinks(session.publication.tableOfContents)
@@ -1057,106 +1040,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
             }
         }
         publicationPositions = emptyList()
-        resetVisualPagination()
-    }
-
-    override fun onCleared() {
-        searchIterator?.close()
-        searchIterator = null
-        super.onCleared()
-    }
-
-    private suspend fun refreshBookmarks() {
-        val chapterId = chapterId.takeIf { it > 0 } ?: return
-        val bookmarks = getEpubBookmarks.await(chapterId)
-        val currentBookmarkId = findBookmarkForLocator(bookmarks, latestLocator)?.id
-        mutableState.update {
-            it.copy(
-                bookmarks = bookmarks,
-                currentBookmarkId = currentBookmarkId,
-            )
-        }
-    }
-
-    private suspend fun performSearch(query: String) {
-        searchIterator?.close()
-        searchIterator = null
-        if (query.isBlank()) {
-            mutableState.update {
-                it.copy(
-                    searchResults = emptyList(),
-                    isSearchLoading = false,
-                    searchErrorMessage = null,
-                )
-            }
-            return
-        }
-
-        val session = sessionRepository.get(chapterId)
-        if (session == null || !session.publication.isSearchable) {
-            mutableState.update {
-                it.copy(
-                    searchResults = emptyList(),
-                    isSearchLoading = false,
-                    searchErrorMessage = application.stringResource(MR.strings.epub_reader_search_not_supported),
-                )
-            }
-            return
-        }
-
-        mutableState.update {
-            it.copy(
-                isSearchLoading = true,
-                searchErrorMessage = null,
-            )
-        }
-
-        runCatching {
-            val iterator = session.publication.search(query)
-                ?: error(application.stringResource(MR.strings.epub_reader_search_not_supported))
-            searchIterator = iterator
-            val results = buildList {
-                while (true) {
-                    val collection = iterator.next().getOrElse { error ->
-                        throw IllegalStateException(error.message)
-                    } ?: break
-                    collection.locators.forEach { locator ->
-                        add(
-                            EpubSearchResult(
-                                locator = locator,
-                                title = locator.title,
-                                before = locator.text.before,
-                                highlight = locator.text.highlight,
-                                after = locator.text.after,
-                            ),
-                        )
-                    }
-                }
-            }
-            results
-        }.onSuccess { results ->
-            mutableState.update {
-                it.copy(
-                    searchResults = results,
-                    isSearchLoading = false,
-                    searchErrorMessage = null,
-                )
-            }
-        }.onFailure { error ->
-            logcat(LogPriority.WARN, error) {
-                "EPUB search failed chapterId=$chapterId query=$query"
-            }
-            mutableState.update {
-                it.copy(
-                    searchResults = emptyList(),
-                    isSearchLoading = false,
-                    searchErrorMessage = error.message
-                        ?: application.stringResource(MR.strings.epub_reader_search_error),
-                )
-            }
-        }
-        publicationPositions = emptyList()
         publicationPositionByHref = emptyMap()
+        resetVisualPagination()
     }
 
     override fun onCleared() {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -9,11 +9,15 @@ import eu.kanade.tachiyomi.data.download.DownloadProvider
 import koharia.domain.epub.interactor.AddEpubBookmark
 import koharia.domain.epub.interactor.DeleteEpubBookmark
 import koharia.domain.epub.interactor.GetEpubBookmarks
+import koharia.domain.epub.interactor.GetEpubPaginationCache
 import koharia.domain.epub.interactor.GetEpubProgress
 import koharia.domain.epub.interactor.UpdateEpubBookmarkNote
+import koharia.domain.epub.interactor.UpsertEpubPaginationCache
 import koharia.domain.epub.interactor.UpsertEpubProgress
 import koharia.domain.epub.model.EpubBookmark
+import koharia.domain.epub.model.EpubPaginationCache
 import koharia.domain.epub.model.EpubProgress
+import koharia.epub.locator.toPersistentLocator
 import koharia.epub.model.EpubOpenRequest
 import koharia.epub.model.EpubSearchResult
 import koharia.epub.model.EpubTocEntry
@@ -44,6 +48,7 @@ import logcat.LogPriority
 import org.json.JSONObject
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Layout
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.publication.services.search.SearchIterator
@@ -73,6 +78,9 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 
+private const val SERVER_TIME_WARNING_THRESHOLD_MS = 5 * 60 * 1_000L
+private const val PAGINATION_LOCATOR_PROGRESSION_TOLERANCE = 0.0001
+
 @OptIn(ExperimentalReadiumApi::class)
 class EpubReaderViewModel @JvmOverloads constructor(
     private val savedState: SavedStateHandle,
@@ -87,6 +95,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private val sessionRepository: EpubReaderSessionRepository = Injekt.get(),
     private val getEpubProgress: GetEpubProgress = Injekt.get(),
     private val upsertEpubProgress: UpsertEpubProgress = Injekt.get(),
+    private val getEpubPaginationCache: GetEpubPaginationCache = Injekt.get(),
+    private val upsertEpubPaginationCache: UpsertEpubPaginationCache = Injekt.get(),
     private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val upsertHistory: UpsertHistory = Injekt.get(),
@@ -146,6 +156,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var latestLocator: Locator? = null
     private var publicationPositions: List<Locator> = emptyList()
     private var publicationPositionByHref: Map<String, Int> = emptyMap()
+    private var visualPageNumber: Int? = null
+    private var lastVisualHref: String? = null
+    private var lastVisualPageIndex: Int? = null
+    private var lastVisualTotalPages: Int? = null
+    private var bookVisualPageCounts: Map<String, Int> = emptyMap()
+    private var paginationGeneration = 0L
+    private var paginationLayoutKey: String? = null
+    private var paginationLayoutJson: String? = null
+    private var currentPublicationKey: String? = null
     private var currentChapterUrl: String? = null
     private var currentChapterRead = false
     private var currentChapterBookmark = false
@@ -283,6 +302,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 }
 
                 currentBookUrl = remoteBookUrl
+                currentPublicationKey = when {
+                    !bookDetails?.fileHash.isNullOrBlank() -> "komga:${bookDetails.fileHash}"
+                    bookDetails != null -> "komga:${bookDetails.fileLastModified}:${bookDetails.sizeBytes}"
+                    localFile != null -> "local:${localUri}:${localFile.lastModified()}:${localFile.length()}"
+                    else -> "book:${chapter.id}:${chapter.url}"
+                }
 
                 val incognito = isIncognito()
                 val localProgress = if (incognito) {
@@ -296,7 +321,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         }
                         .getOrNull()
                 }
-                val remoteProgress = if (incognito || remoteBookUrl == null ||
+                val remotePull = if (incognito || remoteBookUrl == null ||
                     !epubReaderPreferences.syncProgressionToKomga.get()
                 ) {
                     null
@@ -309,6 +334,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         }
                         .getOrNull()
                 }
+                val remoteProgress = remotePull?.progression
+                val serverTimeOffsetMinutes = remotePull?.serverDate?.serverTimeOffsetMinutes()
                 val persistedLocator = localProgress?.toLocatorOrNull()
                 val savedStateLocator = restoreLocator()
                 val initialLocator = savedStateLocator
@@ -351,6 +378,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         }
                     }
                 }
+                resetVisualPagination()
                 val initialPosition = initialLocator.positionIn(publicationPositions)
                 val initialProgression = initialLocator?.totalProgressionValue()
                     ?: initialPosition.toProgression(publicationPositions.size)
@@ -392,11 +420,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         totalPositions = publicationPositions.size.coerceAtLeast(1),
                         currentVisualPage = null,
                         totalVisualPages = null,
+                        paginationPhase = EpubPaginationPhase.CALCULATING,
                         sessionToken = it.sessionToken + 1,
                         isLoading = false,
                         isReady = true,
                         menuVisible = true,
                         errorMessage = null,
+                        serverTimeOffsetMinutes = serverTimeOffsetMinutes,
                         isIncognito = incognito,
                         bookmarks = bookmarks,
                         currentBookmarkId = findBookmarkForLocator(bookmarks, initialLocator)?.id,
@@ -463,25 +493,330 @@ class EpubReaderViewModel @JvmOverloads constructor(
     }
 
     fun updateLocator(locator: Locator) {
-        latestLocator = locator
-        val newLocatorJson = locator.toJSON().toString()
+        val persistentLocator = sessionRepository.get(chapterId)
+            ?.publication
+            ?.toPersistentLocator(locator)
+            ?: locator
+        latestLocator = persistentLocator
+        val newLocatorJson = persistentLocator.toJSON().toString()
         locatorJson = newLocatorJson
         logcat(LogPriority.DEBUG) {
-            "EPUB locator update chapterId=$chapterId ${locator.debugProgress()}"
+            "EPUB locator update chapterId=$chapterId navigatorHref=${locator.href} " +
+                persistentLocator.debugProgress()
         }
         mutableState.update {
             it.copy(
-                currentSectionTitle = locator.title ?: it.currentSectionTitle,
-                currentHref = locator.navigationHref(),
-                progression = locator.totalProgressionValue()
-                    ?: locator.positionIn(publicationPositions).toProgression(publicationPositions.size),
-                progressionPercent = locator.progressionPercent(),
-                currentPosition = locator.positionIn(publicationPositions),
-                currentBookmarkId = findBookmarkForLocator(it.bookmarks, locator)?.id,
+                currentSectionTitle = persistentLocator.title ?: it.currentSectionTitle,
+                currentHref = persistentLocator.navigationHref(),
+                progression = persistentLocator.totalProgressionValue()
+                    ?: persistentLocator.positionIn(publicationPositions).toProgression(publicationPositions.size),
+                progressionPercent = persistentLocator.progressionPercent(),
+                currentPosition = persistentLocator.positionIn(publicationPositions),
+                currentBookmarkId = findBookmarkForLocator(it.bookmarks, persistentLocator)?.id,
             )
         }
         if (!isIncognito()) {
-            locatorUpdates.tryEmit(locator)
+            locatorUpdates.tryEmit(persistentLocator)
+        }
+    }
+
+    fun updateVisualPage(pageIndex: Int, totalPages: Int, locator: Locator) {
+        if (pageIndex < 0 || totalPages <= 0 || publicationPositions.isEmpty()) return
+
+        val href = locator.href.toString().normalizedResourceHref()
+        lastVisualHref = href
+        lastVisualPageIndex = pageIndex
+        lastVisualTotalPages = totalPages
+
+        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        val exactPage = exactVisualPage(href, pageIndex, readingOrder, bookVisualPageCounts)
+        val exactTotalPages = bookVisualPageCounts.values.sum()
+            .takeIf { bookVisualPageCounts.size == readingOrder.size && it > 0 }
+        if (exactPage != null && exactTotalPages != null) {
+            val currentPage = exactPage.coerceIn(1, exactTotalPages)
+            visualPageNumber = currentPage
+            val previousState = mutableState.value
+            if (previousState.paginationPhase != EpubPaginationPhase.READY ||
+                previousState.totalVisualPages != exactTotalPages
+            ) {
+                logcat(LogPriority.DEBUG) {
+                    "EPUB pagination visual page resolved chapterId=$chapterId " +
+                        "from=${previousState.paginationPhase} " +
+                        "pages=${previousState.currentVisualPage}/${previousState.totalVisualPages} " +
+                        "to=$currentPage/$exactTotalPages"
+                }
+            }
+            mutableState.update {
+                it.copy(
+                    currentVisualPage = currentPage,
+                    totalVisualPages = exactTotalPages,
+                    paginationPhase = EpubPaginationPhase.READY,
+                )
+            }
+            viewModelScope.launch { persistPaginationCache(isComplete = true) }
+            return
+        }
+    }
+
+    fun invalidatePaginationDisplay() {
+        paginationGeneration += 1
+        bookVisualPageCounts = emptyMap()
+        visualPageNumber = null
+        lastVisualHref = null
+        lastVisualPageIndex = null
+        lastVisualTotalPages = null
+        mutableState.update {
+            it.copy(
+                currentVisualPage = null,
+                totalVisualPages = null,
+                paginationPhase = EpubPaginationPhase.CALCULATING,
+                paginationGeneration = paginationGeneration,
+            )
+        }
+    }
+
+    fun invalidatePaginationCalculation() {
+        paginationGeneration += 1
+        mutableState.update {
+            it.copy(paginationGeneration = paginationGeneration)
+        }
+    }
+
+    internal suspend fun preparePagination(snapshot: EpubPaginationLayoutSnapshot): EpubPaginationRequest {
+        paginationGeneration += 1
+        val generation = paginationGeneration
+        paginationLayoutKey = snapshot.key
+        paginationLayoutJson = snapshot.json
+        lastVisualHref = null
+        lastVisualPageIndex = null
+        lastVisualTotalPages = null
+
+        val publicationKey = currentPublicationKey ?: "chapter:$chapterId"
+        val publication = sessionRepository.get(chapterId)?.publication
+        if (publication?.metadata?.layout == Layout.FIXED) {
+            val fixedCounts = publication.readingOrder.associate { link ->
+                link.href.toString().normalizedResourceHref() to 1
+            }
+            bookVisualPageCounts = fixedCounts
+            val totalPages = fixedCounts.size.coerceAtLeast(1)
+            val currentPage = pageFromLocator(latestLocator, publication.readingOrder, fixedCounts) ?: 1
+            visualPageNumber = currentPage
+            mutableState.update {
+                it.copy(
+                    currentVisualPage = currentPage,
+                    totalVisualPages = totalPages,
+                    paginationPhase = EpubPaginationPhase.READY,
+                    paginationGeneration = generation,
+                )
+            }
+            persistPaginationCache(isComplete = true)
+            return EpubPaginationRequest(
+                generation = generation,
+                publicationKey = publicationKey,
+                layoutKey = snapshot.key,
+                layoutSnapshotJson = snapshot.json,
+                initialPageCounts = fixedCounts,
+                shouldScan = false,
+            )
+        }
+        if (snapshot.readingMode == koharia.epub.settings.EpubLayoutPreferences.ReadingMode.SCROLL.name) {
+            bookVisualPageCounts = emptyMap()
+            visualPageNumber = null
+            mutableState.update {
+                it.copy(
+                    currentVisualPage = null,
+                    totalVisualPages = null,
+                    paginationPhase = EpubPaginationPhase.UNAVAILABLE,
+                    paginationGeneration = generation,
+                )
+            }
+            return EpubPaginationRequest(
+                generation = generation,
+                publicationKey = publicationKey,
+                layoutKey = snapshot.key,
+                layoutSnapshotJson = snapshot.json,
+                initialPageCounts = emptyMap(),
+                shouldScan = false,
+            )
+        }
+
+        val cache = if (isIncognito()) {
+            null
+        } else {
+            getEpubPaginationCache.await(chapterId, publicationKey, snapshot.key)
+        }
+        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        val cachedCounts = cache?.resourcePageCountsJson
+            ?.toPageCounts()
+            ?.orderedFor(readingOrder)
+            .orEmpty()
+        val isComplete = cache?.isComplete == true && cachedCounts.size == readingOrder.size
+        val cachedLocator = cache?.currentLocatorJson
+            ?.let { locatorJson -> runCatching { Locator.fromJSON(JSONObject(locatorJson)) }.getOrNull() }
+        val locatorMatches = cachedLocator?.isSamePaginationLocation(latestLocator) == true
+
+        bookVisualPageCounts = cachedCounts
+        val cachedCurrentPage = cache?.currentVisualPage?.toInt()
+            ?.takeIf { locatorMatches }
+        val cachedTotalPages = cachedCounts.values.sum().takeIf { isComplete && it > 0 }
+        val hasCachedPagePair = cachedCurrentPage != null && cachedTotalPages != null
+        logcat(LogPriority.DEBUG) {
+            "EPUB pagination cache result chapterId=$chapterId key=${snapshot.key.take(12)} " +
+                "hit=${cache != null} complete=$isComplete resources=${cachedCounts.size}/${readingOrder.size} " +
+                "locatorMatches=$locatorMatches pages=$cachedCurrentPage/$cachedTotalPages"
+        }
+        visualPageNumber = cachedCurrentPage.takeIf { hasCachedPagePair }
+        mutableState.update {
+            it.copy(
+                currentVisualPage = cachedCurrentPage.takeIf { hasCachedPagePair },
+                totalVisualPages = cachedTotalPages.takeIf { hasCachedPagePair },
+                paginationPhase = if (hasCachedPagePair) {
+                    EpubPaginationPhase.CACHED
+                } else {
+                    EpubPaginationPhase.CALCULATING
+                },
+                paginationGeneration = generation,
+            )
+        }
+
+        return EpubPaginationRequest(
+            generation = generation,
+            publicationKey = publicationKey,
+            layoutKey = snapshot.key,
+            layoutSnapshotJson = snapshot.json,
+            initialPageCounts = cachedCounts,
+            shouldScan = !isComplete,
+        )
+    }
+
+    fun updateBookPagination(
+        generation: Long,
+        pageCounts: Map<String, Int>,
+        isComplete: Boolean,
+    ) {
+        if (generation != paginationGeneration) return
+        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        if (readingOrder.isEmpty()) return
+        val orderedCounts = pageCounts.orderedFor(readingOrder)
+        bookVisualPageCounts = orderedCounts
+        if (!isComplete || orderedCounts.size != readingOrder.size) {
+            viewModelScope.launch { persistPaginationCache(isComplete = false) }
+            return
+        }
+
+        val totalPages = orderedCounts.values.sum().coerceAtLeast(1)
+        val href = lastVisualHref
+            ?: latestLocator?.href?.toString()?.normalizedResourceHref()
+        val currentPage = lastVisualPageIndex
+            ?.let { exactVisualPage(href, it, readingOrder, orderedCounts) }
+        val coercedCurrentPage = currentPage?.coerceIn(1, totalPages)
+        logcat(LogPriority.DEBUG) {
+            "EPUB pagination scan complete chapterId=$chapterId generation=$generation " +
+                "resources=${orderedCounts.size}/${readingOrder.size} pages=$coercedCurrentPage/$totalPages"
+        }
+
+        visualPageNumber = coercedCurrentPage
+        mutableState.update {
+            it.copy(
+                currentVisualPage = coercedCurrentPage,
+                totalVisualPages = totalPages.takeIf { coercedCurrentPage != null },
+                paginationPhase = if (coercedCurrentPage != null) {
+                    EpubPaginationPhase.READY
+                } else {
+                    EpubPaginationPhase.CALCULATING
+                },
+            )
+        }
+
+        if (latestLocator != null) {
+            viewModelScope.launch {
+                persistPaginationCache(isComplete = true)
+                updateChapterPageProgress()
+            }
+        }
+    }
+
+    private fun Map<String, Int>.orderedFor(readingOrder: List<Link>): Map<String, Int> {
+        val source = this
+        return buildMap {
+            readingOrder.forEach { link ->
+                val href = link.href.toString().normalizedResourceHref()
+                source.entries.firstOrNull { (candidate, count) ->
+                    count > 0 && href.isSameResourceHref(candidate)
+                }?.value?.let { put(href, it) }
+            }
+        }
+    }
+
+    private fun pageFromLocator(
+        locator: Locator?,
+        readingOrder: List<Link>,
+        pageCounts: Map<String, Int>,
+    ): Int? {
+        locator ?: return null
+        if (pageCounts.size != readingOrder.size) return null
+        val href = locator.href.toString().normalizedResourceHref()
+        val resourcePages = pageCounts.entries.firstOrNull { (candidate, _) ->
+            href.isSameResourceHref(candidate)
+        }?.value ?: return null
+        val progression = (locator.locations.progression as? Number)?.toDouble() ?: 0.0
+        var pageIndex = (progression * resourcePages).roundToInt().coerceIn(0, resourcePages - 1)
+        val isRtl = runCatching {
+            JSONObject(paginationLayoutJson.orEmpty()).optString("pageDirection") ==
+                koharia.epub.settings.EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT.name
+        }.getOrDefault(false)
+        if (isRtl && pageIndex > 0) pageIndex -= 1
+        return exactVisualPage(href, pageIndex, readingOrder, pageCounts)
+    }
+
+    private fun exactVisualPage(
+        href: String?,
+        pageIndex: Int,
+        readingOrder: List<Link>,
+        pageCounts: Map<String, Int>,
+    ): Int? {
+        if (href.isNullOrBlank() || pageCounts.size != readingOrder.size) return null
+
+        var pagesBefore = 0
+        for (link in readingOrder) {
+            val resourceHref = link.href.toString().normalizedResourceHref()
+            val resourcePages = pageCounts[resourceHref] ?: return null
+            if (resourceHref.isSameResourceHref(href)) {
+                return pagesBefore + (pageIndex + 1).coerceIn(1, resourcePages)
+            }
+            pagesBefore += resourcePages
+        }
+        return null
+    }
+
+    private fun resetVisualPagination() {
+        visualPageNumber = null
+        lastVisualHref = null
+        lastVisualPageIndex = null
+        lastVisualTotalPages = null
+        bookVisualPageCounts = emptyMap()
+        paginationLayoutKey = null
+        paginationLayoutJson = null
+    }
+
+    fun dismissServerTimeWarning() {
+        mutableState.update { it.copy(serverTimeOffsetMinutes = null) }
+    }
+
+    fun locatorAtPosition(index: Int): Locator? = publicationPositions.getOrNull(index)
+
+    fun locatorAtProgression(progression: Double): Locator? {
+        if (publicationPositions.isEmpty()) return null
+        val index = (progression.coerceIn(0.0, 1.0) * (publicationPositions.size - 1))
+            .roundToInt()
+        return publicationPositions.getOrNull(index)
+    }
+
+    fun currentLocator(): Locator? = latestLocator
+
+    suspend fun saveCurrentProgress() {
+        if (!isIncognito()) {
+            latestLocator?.let { persistLocator(it) }
         }
     }
 
@@ -718,7 +1053,106 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         logcat(LogPriority.ERROR, error) {
                             "Failed to persist final EPUB locator for chapterId=$chapterId"
                         }
+                }
+            }
+        }
+        publicationPositions = emptyList()
+        resetVisualPagination()
+    }
+
+    override fun onCleared() {
+        searchIterator?.close()
+        searchIterator = null
+        super.onCleared()
+    }
+
+    private suspend fun refreshBookmarks() {
+        val chapterId = chapterId.takeIf { it > 0 } ?: return
+        val bookmarks = getEpubBookmarks.await(chapterId)
+        val currentBookmarkId = findBookmarkForLocator(bookmarks, latestLocator)?.id
+        mutableState.update {
+            it.copy(
+                bookmarks = bookmarks,
+                currentBookmarkId = currentBookmarkId,
+            )
+        }
+    }
+
+    private suspend fun performSearch(query: String) {
+        searchIterator?.close()
+        searchIterator = null
+        if (query.isBlank()) {
+            mutableState.update {
+                it.copy(
+                    searchResults = emptyList(),
+                    isSearchLoading = false,
+                    searchErrorMessage = null,
+                )
+            }
+            return
+        }
+
+        val session = sessionRepository.get(chapterId)
+        if (session == null || !session.publication.isSearchable) {
+            mutableState.update {
+                it.copy(
+                    searchResults = emptyList(),
+                    isSearchLoading = false,
+                    searchErrorMessage = application.stringResource(MR.strings.epub_reader_search_not_supported),
+                )
+            }
+            return
+        }
+
+        mutableState.update {
+            it.copy(
+                isSearchLoading = true,
+                searchErrorMessage = null,
+            )
+        }
+
+        runCatching {
+            val iterator = session.publication.search(query)
+                ?: error(application.stringResource(MR.strings.epub_reader_search_not_supported))
+            searchIterator = iterator
+            val results = buildList {
+                while (true) {
+                    val collection = iterator.next().getOrElse { error ->
+                        throw IllegalStateException(error.message)
+                    } ?: break
+                    collection.locators.forEach { locator ->
+                        add(
+                            EpubSearchResult(
+                                locator = locator,
+                                title = locator.title,
+                                before = locator.text.before,
+                                highlight = locator.text.highlight,
+                                after = locator.text.after,
+                            ),
+                        )
                     }
+                }
+            }
+            results
+        }.onSuccess { results ->
+            mutableState.update {
+                it.copy(
+                    searchResults = results,
+                    isSearchLoading = false,
+                    searchErrorMessage = null,
+                )
+            }
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) {
+                "EPUB search failed chapterId=$chapterId query=$query"
+            }
+            mutableState.update {
+                it.copy(
+                    searchResults = emptyList(),
+                    isSearchLoading = false,
+                    searchErrorMessage = error.message
+                        ?: application.stringResource(MR.strings.epub_reader_search_error),
+                )
             }
         }
         publicationPositions = emptyList()
@@ -856,6 +1290,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
         )
         upsertEpubProgress.await(progress)
         currentProgress = progress
+        persistPaginationCache(
+            isComplete = mutableState.value.paginationPhase in setOf(
+                EpubPaginationPhase.CACHED,
+                EpubPaginationPhase.READY,
+            ),
+        )
+        updateChapterPageProgress()
         markChapterCompletedIfNeeded(locator)
 
         val bookUrl = progress.bookUrl
@@ -872,6 +1313,17 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 }
             }
         }
+    }
+
+    private suspend fun updateChapterPageProgress() {
+        if (currentChapterRead) return
+        val currentPage = mutableState.value.currentVisualPage ?: return
+        updateChapter.await(
+            ChapterUpdate(
+                id = chapterId,
+                lastPageRead = (currentPage - 1).toLong(),
+            ),
+        )
     }
 
     private suspend fun markChapterCompletedIfNeeded(locator: Locator) {
@@ -907,6 +1359,30 @@ class EpubReaderViewModel @JvmOverloads constructor(
             positionIndex = locator.positionIndex(),
             updatedAt = updatedAt,
             lastSyncedAt = lastSyncedAt,
+        )
+    }
+
+    private suspend fun persistPaginationCache(isComplete: Boolean) {
+        if (isIncognito()) return
+        val publicationKey = currentPublicationKey ?: return
+        val layoutKey = paginationLayoutKey ?: return
+        val layoutJson = paginationLayoutJson ?: return
+        if (bookVisualPageCounts.isEmpty()) return
+        val state = mutableState.value
+        upsertEpubPaginationCache.await(
+            EpubPaginationCache(
+                chapterId = chapterId,
+                publicationKey = publicationKey,
+                layoutKey = layoutKey,
+                layoutSnapshotJson = layoutJson,
+                resourcePageCountsJson = bookVisualPageCounts.toPageCountsJson(),
+                currentLocatorJson = latestLocator?.toJSON()?.toString(),
+                currentVisualPage = state.currentVisualPage?.toLong(),
+                totalVisualPages = state.totalVisualPages?.toLong(),
+                isComplete = isComplete,
+                measuredResourceCount = bookVisualPageCounts.size.toLong(),
+                updatedAt = Date(),
+            ),
         )
     }
 
@@ -989,6 +1465,25 @@ class EpubReaderViewModel @JvmOverloads constructor(
         return fragment?.let { "$resourceHref#$it" } ?: resourceHref
     }
 
+    private fun Locator.resourceProgressionValue(): Double? {
+        return (locations.progression as? Number)?.toDouble()
+    }
+
+    private fun Locator.isSamePaginationLocation(other: Locator?): Boolean {
+        other ?: return false
+        if (!href.toString().isSameResourceHref(other.href.toString())) return false
+
+        val progression = resourceProgressionValue()
+        val otherProgression = other.resourceProgressionValue()
+        if (progression != null && otherProgression != null) {
+            return abs(progression - otherProgression) < PAGINATION_LOCATOR_PROGRESSION_TOLERANCE
+        }
+
+        val position = positionIndex()
+        val otherPosition = other.positionIndex()
+        return position != null && otherPosition != null && position == otherPosition
+    }
+
     private fun Locator?.positionIn(positions: List<Locator>): Int {
         val totalPositions = positions.size.coerceAtLeast(1)
         val explicitPosition = this?.positionIndex()?.toInt()
@@ -1003,6 +1498,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private fun Int.toProgression(totalPositions: Int): Double {
         if (totalPositions <= 1) return 0.0
         return ((this - 1).toDouble() / (totalPositions - 1)).coerceIn(0.0, 1.0)
+    }
+
+    private fun Date.serverTimeOffsetMinutes(): Long? {
+        val offsetMillis = time - System.currentTimeMillis()
+        if (abs(offsetMillis) < SERVER_TIME_WARNING_THRESHOLD_MS) return null
+        return (abs(offsetMillis) / 60_000.0).roundToLong().coerceAtLeast(1L)
     }
 
     private fun Locator?.debugProgress(): String {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -553,7 +553,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     paginationPhase = EpubPaginationPhase.READY,
                 )
             }
-            viewModelScope.launch { persistPaginationCache(isComplete = true) }
             return
         }
     }
@@ -572,13 +571,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 paginationPhase = EpubPaginationPhase.CALCULATING,
                 paginationGeneration = paginationGeneration,
             )
-        }
-    }
-
-    fun invalidatePaginationCalculation() {
-        paginationGeneration += 1
-        mutableState.update {
-            it.copy(paginationGeneration = paginationGeneration)
         }
     }
 

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -47,8 +47,8 @@ import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
 import org.json.JSONObject
 import org.readium.r2.shared.ExperimentalReadiumApi
-import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Layout
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.publication.services.search.SearchIterator
@@ -305,7 +305,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 currentPublicationKey = when {
                     !bookDetails?.fileHash.isNullOrBlank() -> "komga:${bookDetails.fileHash}"
                     bookDetails != null -> "komga:${bookDetails.fileLastModified}:${bookDetails.sizeBytes}"
-                    localFile != null -> "local:${localUri}:${localFile.lastModified()}:${localFile.length()}"
+                    localFile != null -> "local:$localUri:${localFile.lastModified()}:${localFile.length()}"
                     else -> "book:${chapter.id}:${chapter.url}"
                 }
 
@@ -1053,7 +1053,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         logcat(LogPriority.ERROR, error) {
                             "Failed to persist final EPUB locator for chapterId=$chapterId"
                         }
-                }
+                    }
             }
         }
         publicationPositions = emptyList()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -164,6 +164,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var paginationGeneration = 0L
     private var paginationLayoutKey: String? = null
     private var paginationLayoutJson: String? = null
+    private var isRtlLayout = false
     private var currentPublicationKey: String? = null
     private var currentChapterUrl: String? = null
     private var currentChapterRead = false
@@ -303,9 +304,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
                 currentBookUrl = remoteBookUrl
                 currentPublicationKey = when {
+                    primarySource == EpubOpenRequest.OpenSource.LOCAL && localFile != null ->
+                        "local:$localUri:${localFile.lastModified()}:${localFile.length()}"
+                    primarySource == EpubOpenRequest.OpenSource.LOCAL ->
+                        "local:$localUri"
                     !bookDetails?.fileHash.isNullOrBlank() -> "komga:${bookDetails.fileHash}"
                     bookDetails != null -> "komga:${bookDetails.fileLastModified}:${bookDetails.sizeBytes}"
-                    localFile != null -> "local:$localUri:${localFile.lastModified()}:${localFile.length()}"
                     else -> "book:${chapter.id}:${chapter.url}"
                 }
 
@@ -566,6 +570,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         lastVisualTotalPages = null
         paginationLayoutKey = null
         paginationLayoutJson = null
+        isRtlLayout = false
         mutableState.update {
             it.copy(
                 currentVisualPage = null,
@@ -581,6 +586,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
         val generation = paginationGeneration
         paginationLayoutKey = snapshot.key
         paginationLayoutJson = snapshot.json
+        isRtlLayout = snapshot.pageDirection ==
+            koharia.epub.settings.EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT.name
         lastVisualHref = null
         lastVisualPageIndex = null
         lastVisualTotalPages = null
@@ -754,11 +761,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         }?.value ?: return null
         val progression = (locator.locations.progression as? Number)?.toDouble() ?: 0.0
         var pageIndex = (progression * resourcePages).roundToInt().coerceIn(0, resourcePages - 1)
-        val isRtl = runCatching {
-            JSONObject(paginationLayoutJson.orEmpty()).optString("pageDirection") ==
-                koharia.epub.settings.EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT.name
-        }.getOrDefault(false)
-        if (isRtl && pageIndex > 0) pageIndex -= 1
+        if (isRtlLayout && pageIndex > 0) pageIndex -= 1
         return exactVisualPage(href, pageIndex, readingOrder, pageCounts)
     }
 
@@ -790,6 +793,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         bookVisualPageCounts = emptyMap()
         paginationLayoutKey = null
         paginationLayoutJson = null
+        isRtlLayout = false
     }
 
     fun dismissServerTimeWarning() {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -725,7 +725,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
         if (latestLocator != null) {
             viewModelScope.launch {
                 persistPaginationCache(isComplete = true)
-                updateChapterPageProgress()
             }
         }
     }
@@ -1175,7 +1174,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 EpubPaginationPhase.READY,
             ),
         )
-        updateChapterPageProgress()
         markChapterCompletedIfNeeded(locator)
 
         val bookUrl = progress.bookUrl
@@ -1192,17 +1190,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 }
             }
         }
-    }
-
-    private suspend fun updateChapterPageProgress() {
-        if (currentChapterRead) return
-        val currentPage = mutableState.value.currentVisualPage ?: return
-        updateChapter.await(
-            ChapterUpdate(
-                id = chapterId,
-                lastPageRead = (currentPage - 1).toLong(),
-            ),
-        )
     }
 
     private suspend fun markChapterCompletedIfNeeded(locator: Locator) {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -564,6 +564,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
         lastVisualHref = null
         lastVisualPageIndex = null
         lastVisualTotalPages = null
+        paginationLayoutKey = null
+        paginationLayoutJson = null
         mutableState.update {
             it.copy(
                 currentVisualPage = null,

--- a/app/src/main/java/koharia/epub/locator/EpubLocatorMapper.kt
+++ b/app/src/main/java/koharia/epub/locator/EpubLocatorMapper.kt
@@ -1,0 +1,71 @@
+package koharia.epub.locator
+
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+
+fun Publication.toNavigatorLocator(locator: Locator): Locator {
+    val resource = findResource(locator.href.toString()) ?: return locator
+    return locator.copy(href = resource.navigatorHref.withFragmentFrom(locator.href.toString()))
+}
+
+fun Publication.toPersistentLocator(locator: Locator): Locator {
+    val resource = findResource(locator.href.toString()) ?: return locator
+    val href = Url(resource.persistentHref.withFragmentFrom(locator.href.toString())) ?: return locator
+    return locator.copy(href = href)
+}
+
+private fun Publication.findResource(href: String): ResourceHref? {
+    val target = href.normalizedHref()
+    return readingOrder
+        .asSequence()
+        .map(Link::toResourceHref)
+        .firstOrNull { resource ->
+            resource.aliases.any { alias ->
+                alias == target || alias.endsWith("/$target") || target.endsWith("/$alias")
+            }
+        }
+}
+
+private fun Link.toResourceHref(): ResourceHref {
+    val navigatorHref = url()
+    val linkHref = href.toString().normalizedHref()
+    val navigatorAlias = navigatorHref.toString().normalizedHref()
+    val persistentHref = when {
+        "/resource/" in linkHref -> linkHref.substringAfter("/resource/")
+        !linkHref.hasScheme() -> linkHref
+        "/resource/" in navigatorAlias -> navigatorAlias.substringAfter("/resource/")
+        else -> linkHref
+    }.trimStart('/')
+
+    return ResourceHref(
+        navigatorHref = navigatorHref,
+        persistentHref = persistentHref,
+        aliases = setOf(linkHref, navigatorAlias, persistentHref),
+    )
+}
+
+private fun String.normalizedHref(): String =
+    substringBefore('#')
+        .substringBefore('?')
+        .trimStart('/')
+
+private fun String.hasScheme(): Boolean = substringBefore('/').contains(':')
+
+private fun Url.withFragmentFrom(originalHref: String): Url {
+    val fragment = originalHref.substringAfter('#', missingDelimiterValue = "")
+    if (fragment.isBlank()) return this
+    return Url("${toString().substringBefore('#')}#$fragment") ?: this
+}
+
+private fun String.withFragmentFrom(originalHref: String): String {
+    val fragment = originalHref.substringAfter('#', missingDelimiterValue = "")
+    return if (fragment.isBlank()) this else "${substringBefore('#')}#$fragment"
+}
+
+private data class ResourceHref(
+    val navigatorHref: Url,
+    val persistentHref: String,
+    val aliases: Set<String>,
+)

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -3,17 +3,21 @@ package koharia.epub.progress
 import android.os.Build
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.awaitSuccess
+import eu.kanade.tachiyomi.network.await
 import koharia.source.komga.KomgaSource
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import org.json.JSONArray
 import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.domain.source.service.SourceManager
 import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Date
 
 class KomgaEpubProgressSyncService(
@@ -24,27 +28,33 @@ class KomgaEpubProgressSyncService(
     suspend fun pullProgression(
         sourceId: Long,
         bookUrl: String,
-    ): RemoteProgression? = withIOContext {
-        val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext null
+    ): PullResult = withIOContext {
+        val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext PullResult()
         val normalizedBookUrl = normalizeBookUrl(bookUrl)
         source.client.newCall(GET("$normalizedBookUrl/progression", source.currentReadiumHeaders()))
-            .awaitSuccess()
+            .await()
             .use { response ->
+                response.requireSuccess("pull")
+                val serverDate = response.header("Date")?.let(::parseHttpDate)
                 val body = response.body.string().trim()
                 if (body.isBlank() || body == "\"\"") {
-                    return@withIOContext null
+                    return@withIOContext PullResult(serverDate = serverDate)
                 }
 
                 val json = JSONObject(body)
-                val locator = json.optJSONObject("locator")?.let(Locator::fromJSON) ?: return@withIOContext null
+                val locator = json.optJSONObject("locator")?.let(Locator::fromJSON)
                 val modifiedAt = json.optString("modified")
                     .takeIf(String::isNotBlank)
                     ?.let(::parseDate)
-                    ?: return@withIOContext null
+                val progression = if (locator != null && modifiedAt != null) {
+                    RemoteProgression(locator = locator, modifiedAt = modifiedAt)
+                } else {
+                    null
+                }
 
-                RemoteProgression(
-                    locator = locator,
-                    modifiedAt = modifiedAt,
+                PullResult(
+                    progression = progression,
+                    serverDate = serverDate,
                 )
             }
     }
@@ -65,7 +75,7 @@ class KomgaEpubProgressSyncService(
                     put("name", buildDeviceName())
                 },
             )
-            put("locator", locator.toJSON())
+            put("locator", locator.toKomgaJSON())
             put("modified", modifiedAt.toInstant().toString())
         }
         val request = Request.Builder()
@@ -74,7 +84,9 @@ class KomgaEpubProgressSyncService(
             .put(payload.toString().toRequestBody("application/json".toMediaType()))
             .build()
 
-        source.client.newCall(request).awaitSuccess().close()
+        source.client.newCall(request).await().use { response ->
+            response.requireSuccess("push")
+        }
     }
 
     private fun normalizeBookUrl(bookUrl: String): String = bookUrl.substringBefore('#').removeSuffix("/")
@@ -85,6 +97,12 @@ class KomgaEpubProgressSyncService(
             .getOrNull()
     }
 
+    private fun parseHttpDate(value: String): Date? {
+        return runCatching {
+            Date.from(ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant())
+        }.getOrNull()
+    }
+
     private fun buildDeviceName(): String {
         return listOfNotNull(
             Build.MANUFACTURER?.trim().takeIf { !it.isNullOrBlank() },
@@ -92,8 +110,47 @@ class KomgaEpubProgressSyncService(
         ).joinToString(" ").ifBlank { "Android" }
     }
 
+    private fun Locator.toKomgaJSON(): JSONObject = toJSON().apply {
+        val locations = optJSONObject("locations") ?: return@apply
+        if (!locations.has("fragments")) {
+            locations.put("fragments", JSONArray())
+        }
+    }
+
+    private fun Response.requireSuccess(operation: String) {
+        if (isSuccessful) return
+
+        val details = body.string()
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .take(MAX_ERROR_BODY_LENGTH)
+            .takeIf(String::isNotBlank)
+        throw IllegalStateException(
+            buildString {
+                append("Komga progression ")
+                append(operation)
+                append(" failed (HTTP ")
+                append(code)
+                append(')')
+                if (details != null) {
+                    append(": ")
+                    append(details)
+                }
+            },
+        )
+    }
+
+    data class PullResult(
+        val progression: RemoteProgression? = null,
+        val serverDate: Date? = null,
+    )
+
     data class RemoteProgression(
         val locator: Locator,
         val modifiedAt: Date,
     )
+
+    private companion object {
+        const val MAX_ERROR_BODY_LENGTH = 512
+    }
 }

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -120,11 +120,11 @@ class KomgaEpubProgressSyncService(
     private fun Response.requireSuccess(operation: String) {
         if (isSuccessful) return
 
-        val details = body.string()
-            .replace(Regex("\\s+"), " ")
-            .trim()
-            .take(MAX_ERROR_BODY_LENGTH)
-            .takeIf(String::isNotBlank)
+        val details = runCatching { peekBody(MAX_ERROR_BODY_LENGTH.toLong()).string() }
+            .getOrNull()
+            ?.replace(Regex("\\s+"), " ")
+            ?.trim()
+            ?.takeIf(String::isNotBlank)
         throw IllegalStateException(
             buildString {
                 append("Komga progression ")

--- a/app/src/main/java/koharia/epub/service/EpubPublicationResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubPublicationResolver.kt
@@ -1,5 +1,6 @@
 package koharia.epub.service
 
+import koharia.epub.locator.toNavigatorLocator
 import koharia.epub.model.EpubOpenRequest
 import koharia.epub.model.EpubOpenRequest.OpenSource
 import koharia.epub.session.EpubReaderSession
@@ -37,7 +38,11 @@ class EpubPublicationResolver(
                     OpenSource.REMOTE -> komgaService.open(request, initialLocator)
                 }
             }
-                .onSuccess { return it }
+                .onSuccess { session ->
+                    return session.copy(
+                        initialLocator = initialLocator?.let(session.publication::toNavigatorLocator),
+                    )
+                }
                 .onFailure { lastError = it }
         }
 

--- a/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
@@ -1,11 +1,13 @@
 package koharia.epub.service
 
 import android.app.Application
+import android.os.SystemClock
 import koharia.epub.model.EpubOpenRequest
 import koharia.epub.session.EpubReaderSession
 import logcat.LogPriority
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.FileExtension
 import org.readium.r2.shared.util.asset.AssetRetriever
@@ -76,6 +78,17 @@ class KomgaEpubPublicationService(
             }
         logcat(LogPriority.DEBUG) {
             "EPUB remote open success chapterId=${request.chapterId} readingOrder=${publication.readingOrder.size} toc=${publication.tableOfContents.size}"
+        }
+
+        // Readium 3.3.0's EPUB navigator reads positions through runBlocking on the main thread
+        // when it publishes the first location. Remote EPUB positions can require fetching every
+        // reading-order resource, so populate the service cache while this open coroutine is still
+        // showing the reader loading state.
+        val positionsStartedAt = SystemClock.elapsedRealtime()
+        val positions = publication.positions()
+        logcat(LogPriority.DEBUG) {
+            "EPUB positions ready chapterId=${request.chapterId} count=${positions.size} " +
+                "durationMs=${SystemClock.elapsedRealtime() - positionsStartedAt}"
         }
 
         return EpubReaderSession(

--- a/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
+++ b/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
@@ -1,0 +1,64 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class EpubPaginationModelsTest {
+
+    @Test
+    fun `layout key is stable for the same effective layout`() {
+        val first = snapshot()
+        val second = snapshot()
+
+        assertEquals(first.json, second.json)
+        assertEquals(first.key, second.key)
+    }
+
+    @Test
+    fun `layout key changes with typography viewport and WebView`() {
+        val original = snapshot()
+
+        assertNotEquals(original.key, snapshot(fontSize = 1.25f).key)
+        assertNotEquals(original.key, snapshot(paragraphSpacing = 0.5f).key)
+        assertNotEquals(original.key, snapshot(verticalMargins = 1.3f).key)
+        assertNotEquals(original.key, snapshot(viewportWidthPx = 1080).key)
+        assertNotEquals(original.key, snapshot(webViewVersion = "2").key)
+    }
+
+    @Test
+    fun `page count cache round trips normalized resource data`() {
+        val counts = linkedMapOf(
+            "item/chapter-1.xhtml" to 12,
+            "item/chapter-2.xhtml" to 18,
+        )
+
+        assertEquals(counts, counts.toPageCountsJson().toPageCounts())
+    }
+
+    private fun snapshot(
+        fontSize: Float = 1.0f,
+        paragraphSpacing: Float = 0.0f,
+        verticalMargins: Float = 1.0f,
+        viewportWidthPx: Int = 720,
+        webViewVersion: String = "1",
+    ): EpubPaginationLayoutSnapshot {
+        return EpubPaginationLayoutSnapshot(
+            readingMode = "PAGINATED",
+            pageDirection = "LEFT_TO_RIGHT",
+            fontSize = fontSize,
+            lineHeight = 1.2f,
+            paragraphSpacing = paragraphSpacing,
+            paragraphIndent = 2.0f,
+            pageMargins = 1.0f,
+            verticalMargins = verticalMargins,
+            fontFamily = "ORIGINAL",
+            publisherStyles = true,
+            viewportWidthPx = viewportWidthPx,
+            viewportHeightPx = 1280,
+            densityDpi = 420,
+            fontScale = 1.0f,
+            webViewVersion = webViewVersion,
+        )
+    }
+}

--- a/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import koharia.domain.epub.model.EpubPaginationCache
 import koharia.domain.epub.repository.EpubPaginationCacheRepository
 import logcat.LogPriority
+import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.data.Database
 import java.util.Date
@@ -23,29 +24,33 @@ class EpubPaginationCacheRepositoryImpl(
     }
 
     override suspend fun upsertCache(cache: EpubPaginationCache) {
-        try {
-            database.epub_pagination_cacheQueries.upsert(
-                chapterId = cache.chapterId,
-                publicationKey = cache.publicationKey,
-                layoutKey = cache.layoutKey,
-                layoutSnapshotJson = cache.layoutSnapshotJson,
-                resourcePageCountsJson = cache.resourcePageCountsJson,
-                currentLocatorJson = cache.currentLocatorJson,
-                currentVisualPage = cache.currentVisualPage,
-                totalVisualPages = cache.totalVisualPages,
-                isComplete = cache.isComplete,
-                measuredResourceCount = cache.measuredResourceCount,
-                updatedAt = cache.updatedAt,
-            )
-        } catch (error: Exception) {
-            logcat(LogPriority.ERROR, error) {
-                "Failed to upsert EPUB pagination cache for chapterId=${cache.chapterId}"
+        withIOContext {
+            try {
+                database.epub_pagination_cacheQueries.upsert(
+                    chapterId = cache.chapterId,
+                    publicationKey = cache.publicationKey,
+                    layoutKey = cache.layoutKey,
+                    layoutSnapshotJson = cache.layoutSnapshotJson,
+                    resourcePageCountsJson = cache.resourcePageCountsJson,
+                    currentLocatorJson = cache.currentLocatorJson,
+                    currentVisualPage = cache.currentVisualPage,
+                    totalVisualPages = cache.totalVisualPages,
+                    isComplete = cache.isComplete,
+                    measuredResourceCount = cache.measuredResourceCount,
+                    updatedAt = cache.updatedAt,
+                )
+            } catch (error: Exception) {
+                logcat(LogPriority.ERROR, error) {
+                    "Failed to upsert EPUB pagination cache for chapterId=${cache.chapterId}"
+                }
             }
         }
     }
 
     override suspend fun trimCaches(chapterId: Long, keepCount: Long) {
-        database.epub_pagination_cacheQueries.deleteOlderThanLatest(chapterId, keepCount)
+        withIOContext {
+            database.epub_pagination_cacheQueries.deleteOlderThanLatest(chapterId, keepCount)
+        }
     }
 
     private fun mapCache(

--- a/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
@@ -1,0 +1,78 @@
+package koharia.data.epub
+
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import koharia.domain.epub.model.EpubPaginationCache
+import koharia.domain.epub.repository.EpubPaginationCacheRepository
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.data.Database
+import java.util.Date
+
+class EpubPaginationCacheRepositoryImpl(
+    private val database: Database,
+) : EpubPaginationCacheRepository {
+
+    override suspend fun getCache(
+        chapterId: Long,
+        publicationKey: String,
+        layoutKey: String,
+    ): EpubPaginationCache? {
+        return database.epub_pagination_cacheQueries
+            .getByKey(chapterId, publicationKey, layoutKey, ::mapCache)
+            .awaitAsOneOrNull()
+    }
+
+    override suspend fun upsertCache(cache: EpubPaginationCache) {
+        try {
+            database.epub_pagination_cacheQueries.upsert(
+                chapterId = cache.chapterId,
+                publicationKey = cache.publicationKey,
+                layoutKey = cache.layoutKey,
+                layoutSnapshotJson = cache.layoutSnapshotJson,
+                resourcePageCountsJson = cache.resourcePageCountsJson,
+                currentLocatorJson = cache.currentLocatorJson,
+                currentVisualPage = cache.currentVisualPage,
+                totalVisualPages = cache.totalVisualPages,
+                isComplete = cache.isComplete,
+                measuredResourceCount = cache.measuredResourceCount,
+                updatedAt = cache.updatedAt,
+            )
+        } catch (error: Exception) {
+            logcat(LogPriority.ERROR, error) {
+                "Failed to upsert EPUB pagination cache for chapterId=${cache.chapterId}"
+            }
+        }
+    }
+
+    override suspend fun trimCaches(chapterId: Long, keepCount: Long) {
+        database.epub_pagination_cacheQueries.deleteOlderThanLatest(chapterId, keepCount)
+    }
+
+    private fun mapCache(
+        chapterId: Long,
+        publicationKey: String,
+        layoutKey: String,
+        layoutSnapshotJson: String,
+        resourcePageCountsJson: String,
+        currentLocatorJson: String?,
+        currentVisualPage: Long?,
+        totalVisualPages: Long?,
+        isComplete: Boolean,
+        measuredResourceCount: Long,
+        updatedAt: Date,
+    ): EpubPaginationCache {
+        return EpubPaginationCache(
+            chapterId = chapterId,
+            publicationKey = publicationKey,
+            layoutKey = layoutKey,
+            layoutSnapshotJson = layoutSnapshotJson,
+            resourcePageCountsJson = resourcePageCountsJson,
+            currentLocatorJson = currentLocatorJson,
+            currentVisualPage = currentVisualPage,
+            totalVisualPages = totalVisualPages,
+            isComplete = isComplete,
+            measuredResourceCount = measuredResourceCount,
+            updatedAt = updatedAt,
+        )
+    }
+}

--- a/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubPaginationCacheRepositoryImpl.kt
@@ -18,9 +18,11 @@ class EpubPaginationCacheRepositoryImpl(
         publicationKey: String,
         layoutKey: String,
     ): EpubPaginationCache? {
-        return database.epub_pagination_cacheQueries
-            .getByKey(chapterId, publicationKey, layoutKey, ::mapCache)
-            .awaitAsOneOrNull()
+        return withIOContext {
+            database.epub_pagination_cacheQueries
+                .getByKey(chapterId, publicationKey, layoutKey, ::mapCache)
+                .awaitAsOneOrNull()
+        }
     }
 
     override suspend fun upsertCache(cache: EpubPaginationCache) {

--- a/data/src/main/java/koharia/data/epub/EpubProgressRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubProgressRepositoryImpl.kt
@@ -1,11 +1,14 @@
 package koharia.data.epub
 
+import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import koharia.domain.epub.model.EpubProgress
 import koharia.domain.epub.repository.EpubProgressRepository
+import kotlinx.coroutines.flow.Flow
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.data.Database
+import tachiyomi.data.subscribeToList
 import java.util.Date
 
 class EpubProgressRepositoryImpl(
@@ -16,6 +19,18 @@ class EpubProgressRepositoryImpl(
         return database.epub_progressQueries
             .getByChapterId(chapterId, ::mapEpubProgress)
             .awaitAsOneOrNull()
+    }
+
+    override suspend fun getProgressesByMangaId(mangaId: Long): List<EpubProgress> {
+        return database.epub_progressQueries
+            .getByMangaId(mangaId, ::mapEpubProgress)
+            .awaitAsList()
+    }
+
+    override fun subscribeProgressesByMangaId(mangaId: Long): Flow<List<EpubProgress>> {
+        return database.epub_progressQueries
+            .getByMangaId(mangaId, ::mapEpubProgress)
+            .subscribeToList()
     }
 
     override suspend fun upsertProgress(progress: EpubProgress) {

--- a/data/src/main/sqldelight/tachiyomi/data/epub_pagination_cache.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/epub_pagination_cache.sq
@@ -1,0 +1,93 @@
+import java.util.Date;
+import kotlin.Boolean;
+
+CREATE TABLE epub_pagination_cache(
+    chapter_id INTEGER NOT NULL,
+    publication_key TEXT NOT NULL,
+    layout_key TEXT NOT NULL,
+    layout_snapshot_json TEXT NOT NULL,
+    resource_page_counts_json TEXT NOT NULL,
+    current_locator_json TEXT,
+    current_visual_page INTEGER,
+    total_visual_pages INTEGER,
+    is_complete INTEGER AS Boolean NOT NULL DEFAULT 0,
+    measured_resource_count INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER AS Date NOT NULL,
+    PRIMARY KEY(chapter_id, publication_key, layout_key),
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX epub_pagination_cache_chapter_id_index
+ON epub_pagination_cache(chapter_id);
+
+getByKey:
+SELECT
+chapter_id,
+publication_key,
+layout_key,
+layout_snapshot_json,
+resource_page_counts_json,
+current_locator_json,
+current_visual_page,
+total_visual_pages,
+is_complete,
+measured_resource_count,
+updated_at
+FROM epub_pagination_cache
+WHERE chapter_id = :chapterId
+AND publication_key = :publicationKey
+AND layout_key = :layoutKey;
+
+upsert:
+INSERT INTO epub_pagination_cache(
+    chapter_id,
+    publication_key,
+    layout_key,
+    layout_snapshot_json,
+    resource_page_counts_json,
+    current_locator_json,
+    current_visual_page,
+    total_visual_pages,
+    is_complete,
+    measured_resource_count,
+    updated_at
+)
+VALUES (
+    :chapterId,
+    :publicationKey,
+    :layoutKey,
+    :layoutSnapshotJson,
+    :resourcePageCountsJson,
+    :currentLocatorJson,
+    :currentVisualPage,
+    :totalVisualPages,
+    :isComplete,
+    :measuredResourceCount,
+    :updatedAt
+)
+ON CONFLICT(chapter_id, publication_key, layout_key)
+DO UPDATE SET
+    layout_snapshot_json = :layoutSnapshotJson,
+    resource_page_counts_json = :resourcePageCountsJson,
+    current_locator_json = :currentLocatorJson,
+    current_visual_page = :currentVisualPage,
+    total_visual_pages = :totalVisualPages,
+    is_complete = :isComplete,
+    measured_resource_count = :measuredResourceCount,
+    updated_at = :updatedAt;
+
+deleteOlderThanLatest:
+DELETE FROM epub_pagination_cache
+WHERE chapter_id = :chapterId
+AND rowid NOT IN (
+    SELECT rowid
+    FROM epub_pagination_cache
+    WHERE chapter_id = :chapterId
+    ORDER BY updated_at DESC
+    LIMIT :keepCount
+);
+
+deleteByChapterId:
+DELETE FROM epub_pagination_cache
+WHERE chapter_id = :chapterId;

--- a/data/src/main/sqldelight/tachiyomi/data/epub_progress.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/epub_progress.sq
@@ -31,6 +31,19 @@ last_synced_at
 FROM epub_progress
 WHERE chapter_id = :chapterId;
 
+getByMangaId:
+SELECT
+chapter_id,
+manga_id,
+book_url,
+locator_json,
+progression,
+position_index,
+updated_at,
+last_synced_at
+FROM epub_progress
+WHERE manga_id = :mangaId;
+
 upsert:
 INSERT INTO epub_progress(
     chapter_id,

--- a/data/src/main/sqldelight/tachiyomi/migrations/15.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/15.sqm
@@ -1,0 +1,22 @@
+import java.util.Date;
+import kotlin.Boolean;
+
+CREATE TABLE epub_pagination_cache(
+    chapter_id INTEGER NOT NULL,
+    publication_key TEXT NOT NULL,
+    layout_key TEXT NOT NULL,
+    layout_snapshot_json TEXT NOT NULL,
+    resource_page_counts_json TEXT NOT NULL,
+    current_locator_json TEXT,
+    current_visual_page INTEGER,
+    total_visual_pages INTEGER,
+    is_complete INTEGER AS Boolean NOT NULL DEFAULT 0,
+    measured_resource_count INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER AS Date NOT NULL,
+    PRIMARY KEY(chapter_id, publication_key, layout_key),
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX epub_pagination_cache_chapter_id_index
+ON epub_pagination_cache(chapter_id);

--- a/domain/src/main/java/koharia/domain/epub/interactor/GetEpubPaginationCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/GetEpubPaginationCache.kt
@@ -1,0 +1,15 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.model.EpubPaginationCache
+import koharia.domain.epub.repository.EpubPaginationCacheRepository
+
+class GetEpubPaginationCache(
+    private val repository: EpubPaginationCacheRepository,
+) {
+
+    suspend fun await(
+        chapterId: Long,
+        publicationKey: String,
+        layoutKey: String,
+    ): EpubPaginationCache? = repository.getCache(chapterId, publicationKey, layoutKey)
+}

--- a/domain/src/main/java/koharia/domain/epub/interactor/GetEpubProgress.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/GetEpubProgress.kt
@@ -2,6 +2,7 @@ package koharia.domain.epub.interactor
 
 import koharia.domain.epub.model.EpubProgress
 import koharia.domain.epub.repository.EpubProgressRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetEpubProgress(
     private val repository: EpubProgressRepository,
@@ -9,5 +10,13 @@ class GetEpubProgress(
 
     suspend fun await(chapterId: Long): EpubProgress? {
         return repository.getProgress(chapterId)
+    }
+
+    suspend fun awaitByMangaId(mangaId: Long): List<EpubProgress> {
+        return repository.getProgressesByMangaId(mangaId)
+    }
+
+    fun subscribeByMangaId(mangaId: Long): Flow<List<EpubProgress>> {
+        return repository.subscribeProgressesByMangaId(mangaId)
     }
 }

--- a/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubPaginationCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubPaginationCache.kt
@@ -1,0 +1,18 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.model.EpubPaginationCache
+import koharia.domain.epub.repository.EpubPaginationCacheRepository
+
+class UpsertEpubPaginationCache(
+    private val repository: EpubPaginationCacheRepository,
+) {
+
+    suspend fun await(cache: EpubPaginationCache) {
+        repository.upsertCache(cache)
+        repository.trimCaches(cache.chapterId, MAX_CACHES_PER_BOOK)
+    }
+
+    private companion object {
+        const val MAX_CACHES_PER_BOOK = 3L
+    }
+}

--- a/domain/src/main/java/koharia/domain/epub/model/EpubPaginationCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/model/EpubPaginationCache.kt
@@ -1,0 +1,17 @@
+package koharia.domain.epub.model
+
+import java.util.Date
+
+data class EpubPaginationCache(
+    val chapterId: Long,
+    val publicationKey: String,
+    val layoutKey: String,
+    val layoutSnapshotJson: String,
+    val resourcePageCountsJson: String,
+    val currentLocatorJson: String?,
+    val currentVisualPage: Long?,
+    val totalVisualPages: Long?,
+    val isComplete: Boolean,
+    val measuredResourceCount: Long,
+    val updatedAt: Date,
+)

--- a/domain/src/main/java/koharia/domain/epub/repository/EpubPaginationCacheRepository.kt
+++ b/domain/src/main/java/koharia/domain/epub/repository/EpubPaginationCacheRepository.kt
@@ -1,0 +1,16 @@
+package koharia.domain.epub.repository
+
+import koharia.domain.epub.model.EpubPaginationCache
+
+interface EpubPaginationCacheRepository {
+
+    suspend fun getCache(
+        chapterId: Long,
+        publicationKey: String,
+        layoutKey: String,
+    ): EpubPaginationCache?
+
+    suspend fun upsertCache(cache: EpubPaginationCache)
+
+    suspend fun trimCaches(chapterId: Long, keepCount: Long)
+}

--- a/domain/src/main/java/koharia/domain/epub/repository/EpubProgressRepository.kt
+++ b/domain/src/main/java/koharia/domain/epub/repository/EpubProgressRepository.kt
@@ -1,10 +1,14 @@
 package koharia.domain.epub.repository
 
 import koharia.domain.epub.model.EpubProgress
+import kotlinx.coroutines.flow.Flow
 
 interface EpubProgressRepository {
 
     suspend fun getProgress(chapterId: Long): EpubProgress?
+    suspend fun getProgressesByMangaId(mangaId: Long): List<EpubProgress>
+
+    fun subscribeProgressesByMangaId(mangaId: Long): Flow<List<EpubProgress>>
 
     suspend fun upsertProgress(progress: EpubProgress)
 


### PR DESCRIPTION
## 说明

这是原生 EPUB 功能拆分的第 3/3 个 PR，基于已合并的 Foundation PR #18 和 Reader UI PR #16，只包含进度同步与视觉分页增强。

## 主要改动

- 用 Readium `Locator`、`totalProgression` 和 positions 维持稳定的恢复位置、进度条与 Komga 同步语义。
- 规范持久化 Locator 到 Navigator Locator 的映射，避免相对/绝对资源 href 不一致导致恢复失败。
- 新增本地 EPUB 视觉分页缓存、SQLDelight migration `15.sqm`、排版/视口签名和最近布局缓存。
- 排版设置或视口变化后立即回退到真实百分比，隐藏旧页码；后台整书分页完成后原子显示当前页/总页数。
- 隐藏分页器按 generation 扫描 reading order，保存部分资源页数并忽略过时代次结果。
- 滚动模式仅显示百分比；视觉页数只保存在本地，不上传 Komga。
- 书籍详情页使用 Locator 百分比，避免把 Readium position 或单资源页数当成整书视觉页数。
- Komga progression 拉取返回服务器 `Date`；仅在真实时间偏移超过阈值时显示提醒。

## 拆分边界

- 不重复引入 PR #16 已合并的目录、书签、搜索、设置和控制栏基础 UI。
- `PaginationListener` 在本 PR 才转发单资源分页事件，并与整书资源页数、generation 和缓存共同合成视觉页码。
- Komga 仍只同步原始 Locator/progression；视觉页数依赖设备、WebView、字体和视口，不跨设备同步。

## 验证

- `./gradlew.bat spotlessApply --no-daemon`
- `./gradlew.bat spotlessCheck --no-daemon`
- `./gradlew.bat :data:generateDebugDatabaseInterface --no-daemon`
- `./gradlew.bat :app:compileDebugKotlin --no-daemon`
- `./gradlew.bat :app:testDebugUnitTest --tests "koharia.epub.EpubPaginationModelsTest" --no-daemon`

以上均通过；`EpubPaginationModelsTest` 3 项通过，覆盖布局签名稳定性、排版/视口/WebView 失效以及资源页数缓存序列化。

## 审查提示

- 当前审查 SHA：`d5f074e36`
- 基线：`main@f2d3b6435`
- 收敛时保留了 PR #16 的搜索音量键保护、独立 EPUB 音量键偏好、`sourceId` 复用及同 XHTML 锚点 TOC 导航修复。
- 已知非阻塞技术债继续记录在 `EPUB_STACKED_PR_ROLLOUT_PLAN.md`，不应因堆叠拆分视野把单资源 `pageIndex/totalPages` 直接当成整书页码。
