### PR TITLE
fix(download): preserve active raw download state

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -117,7 +117,9 @@ class DownloadManager(
      * Tells the downloader to resume a specific download.
      */
     fun resumeDownload(download: Download) {
-        downloader.resume(download)
+        if (downloader.resume(download)) {
+            startQueuedDownloadsOnly()
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrder.kt
@@ -4,6 +4,7 @@ internal fun isValidDownloadQueueReorder(
     currentChapterIds: List<Long>,
     reorderedChapterIds: List<Long>,
 ): Boolean {
-    return currentChapterIds.size == reorderedChapterIds.size &&
-        currentChapterIds.toSet() == reorderedChapterIds.toSet()
+    val reorderedChapterIdSet = reorderedChapterIds.toSet()
+    return reorderedChapterIdSet.size == reorderedChapterIds.size &&
+        reorderedChapterIdSet.containsAll(currentChapterIds)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrder.kt
@@ -1,0 +1,9 @@
+package eu.kanade.tachiyomi.data.download
+
+internal fun isValidDownloadQueueReorder(
+    currentChapterIds: List<Long>,
+    reorderedChapterIds: List<Long>,
+): Boolean {
+    return currentChapterIds.size == reorderedChapterIds.size &&
+        currentChapterIds.toSet() == reorderedChapterIds.toSet()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -224,6 +224,12 @@ class Downloader(
             .filter { it.status == Download.State.DOWNLOADING }
             .forEach { it.status = Download.State.ERROR }
 
+        logcat(LogPriority.INFO) {
+            "Downloader.stop(): reason=${reason ?: "<none>"}, " +
+                "isPaused=$isPaused, queueSize=${queueState.value.size}, " +
+                "statusSummary=${queueState.value.statusSummary()}"
+        }
+
         if (reason != null) {
             notifier.onWarning(reason)
             return
@@ -264,7 +270,7 @@ class Downloader(
     /**
      * Resumes a specific download
      */
-    fun resume(download: Download) {
+    fun resume(download: Download): Boolean {
         if (
             download.status == Download.State.PAUSED ||
             download.status == Download.State.ERROR ||
@@ -273,12 +279,10 @@ class Downloader(
             if (download.status != Download.State.QUEUE) {
                 download.status = Download.State.QUEUE
             }
-            if (isRunning) {
-                notifyQueueChanged()
-            } else {
-                start()
-            }
+            notifyQueueChanged()
+            return true
         }
+        return false
     }
 
     fun resumeAllPaused() {
@@ -291,6 +295,10 @@ class Downloader(
      * Removes everything from the queue.
      */
     fun clearQueue() {
+        logcat(LogPriority.INFO) {
+            "Downloader.clearQueue(): queueSize=${queueState.value.size}, " +
+                "statusSummary=${queueState.value.statusSummary()}"
+        }
         cancelDownloaderJob()
 
         internalClearQueue()
@@ -1055,6 +1063,10 @@ class Downloader(
 
     private fun removeFromQueue(download: Download) {
         _queueState.update {
+            logcat(LogPriority.INFO) {
+                "Downloader.removeFromQueue(): chapterId=${download.chapter.id}, " +
+                    "status=${download.status}"
+            }
             store.remove(download)
             if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
                 download.status = Download.State.NOT_DOWNLOADED
@@ -1066,6 +1078,12 @@ class Downloader(
     private inline fun removeFromQueueIf(predicate: (Download) -> Boolean) {
         _queueState.update { queue ->
             val downloads = queue.filter { predicate(it) }
+            if (downloads.isNotEmpty()) {
+                logcat(LogPriority.INFO) {
+                    "Downloader.removeFromQueueIf(): chapterIds=${downloads.map { it.chapter.id }}, " +
+                        "statusSummary=${downloads.statusSummary()}"
+                }
+            }
             store.removeAll(downloads)
             downloads.forEach { download ->
                 if (download.status == Download.State.DOWNLOADING || download.status == Download.State.QUEUE) {
@@ -1098,14 +1116,20 @@ class Downloader(
     }
 
     fun updateQueue(downloads: List<Download>) {
-        val wasRunning = isRunning
-        val previousStatuses = queueState.value.associate { it.chapter.id to it.status }
-
-        if (downloads.isEmpty()) {
-            clearQueue()
-            stop()
+        val currentQueue = queueState.value
+        val currentChapterIds = currentQueue.map { it.chapter.id }
+        val reorderedChapterIds = downloads.map { it.chapter.id }
+        if (!isValidDownloadQueueReorder(currentChapterIds, reorderedChapterIds)) {
+            logcat(LogPriority.WARN) {
+                "Downloader.updateQueue(): ignoring incomplete reorder, " +
+                    "currentChapterIds=$currentChapterIds, reorderedChapterIds=$reorderedChapterIds"
+            }
             return
         }
+        if (downloads.isEmpty()) return
+
+        val wasRunning = isRunning
+        val previousStatuses = currentQueue.associate { it.chapter.id to it.status }
 
         pause()
         internalClearQueue()

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrderTest.kt
@@ -17,9 +17,15 @@ class DownloadQueueOrderTest {
     }
 
     @Test
-    fun `reorder rejects missing added or duplicated chapters`() {
+    fun `reorder accepts new chapters without losing existing chapters`() {
+        assertTrue(isValidDownloadQueueReorder(emptyList(), listOf(1L)))
+        assertTrue(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(3L, 1L, 2L)))
+    }
+
+    @Test
+    fun `reorder rejects missing or duplicated chapters`() {
         assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L)))
-        assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L, 2L, 3L)))
         assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L, 1L)))
+        assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L, 3L)))
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/DownloadQueueOrderTest.kt
@@ -1,0 +1,25 @@
+package eu.kanade.tachiyomi.data.download
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DownloadQueueOrderTest {
+
+    @Test
+    fun `reorder accepts the same chapters in a different order`() {
+        assertTrue(isValidDownloadQueueReorder(listOf(1L, 2L, 3L), listOf(3L, 1L, 2L)))
+    }
+
+    @Test
+    fun `reorder rejects a transient empty adapter snapshot`() {
+        assertFalse(isValidDownloadQueueReorder(listOf(1L), emptyList()))
+    }
+
+    @Test
+    fun `reorder rejects missing added or duplicated chapters`() {
+        assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L)))
+        assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L, 2L, 3L)))
+        assertFalse(isValidDownloadQueueReorder(listOf(1L, 2L), listOf(1L, 1L)))
+    }
+}


### PR DESCRIPTION
## Summary

- prevent transient or incomplete download-queue UI snapshots from deleting active downloads
- resume individual downloads through the foreground `DownloadJob` instead of starting the downloader directly
- add focused diagnostics for downloader stop, clear, and queue removal paths
- add regression tests for valid reorder-only queue updates

## Root cause and behavior

Logcat and the download directory showed that the reported EPUB stopped at 44% (`3,200,032 / 7,159,457` bytes), left only an `.epub_tmp` file, and disappeared from the persisted queue. The detail screen correctly treated the missing finalized `.epub` as not downloaded.

Queue reordering previously accepted an empty or incomplete adapter snapshot as a request to clear the real queue. Reordering now requires exactly the same chapter IDs, so UI teardown or stale snapshots cannot remove active work. Explicit cancel and clear actions continue to use their dedicated APIs.

Individual resume actions now restart through WorkManager/`DownloadJob`, retaining foreground execution and network checks. Existing `.epub_tmp` files remain resumable and are only recognized as downloaded after successful finalization.

## Verification

- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat :app:testDebugUnitTest --tests "eu.kanade.tachiyomi.data.download.DownloadQueueOrderTest"`
- `./gradlew.bat :app:assembleDebug`
- emulator regression confirmed by the reporter: raw EPUB download completes and the detail screen reports the downloaded state

No database, schema, preference, or EPUB reader behavior is changed.
