### PR TITLE
Fix EPUB reader restoration after rotation

### DIFF
--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
+import eu.kanade.tachiyomi.R
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
@@ -107,7 +108,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         return FragmentContainerView(requireContext()).apply {
-            id = View.generateViewId()
+            id = R.id.epub_pagination_scanner_navigator_container
             containerId = id
         }
     }

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -11,6 +11,7 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import eu.kanade.tachiyomi.R
 import koharia.epub.locator.toNavigatorLocator
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
@@ -128,7 +129,7 @@ class EpubReaderFragment : Fragment() {
         return FrameLayout(requireContext()).apply {
             addView(
                 FragmentContainerView(requireContext()).apply {
-                    id = View.generateViewId()
+                    id = R.id.epub_reader_navigator_container
                     containerId = id
                 },
                 FrameLayout.LayoutParams(
@@ -138,7 +139,7 @@ class EpubReaderFragment : Fragment() {
             )
             addView(
                 FragmentContainerView(requireContext()).apply {
-                    id = View.generateViewId()
+                    id = R.id.epub_reader_pagination_scanner_container
                     scannerContainerId = id
                     visibility = View.INVISIBLE
                     importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <item name="epub_pagination_scanner_navigator_container" type="id"/>
+    <item name="epub_reader_navigator_container" type="id"/>
+    <item name="epub_reader_pagination_scanner_container" type="id"/>
     <item name="reader_pager" type="id"/>
 </resources>


### PR DESCRIPTION
## Summary

- keep the visible EPUB Navigator container ID stable across activity recreation
- keep the hidden pagination scanner and its nested Navigator container IDs stable
- allow FragmentManager-restored child fragments to reattach to the recreated view hierarchy after rotation

## Root cause

The reader generated new container IDs with `View.generateViewId()` every time its view was recreated. After a configuration change, FragmentManager restored the existing child Navigator by tag with the old container ID, while the new view hierarchy used different IDs. The reader then skipped `replace()` because the tagged Navigator already existed, leaving the new visible container empty.

## Verification

- `./gradlew.bat spotlessCheck --no-daemon`
- `./gradlew.bat :app:compileDebugKotlin --no-daemon`
- Xiaomi 2106118C / Android 16: repeated portrait and landscape switching no longer produces a blank EPUB reader

Base: `bfac9c0984d9d93e8c76272c5383c457b9a2a8f0`
