### PR TITLE
Fix EPUB fragment race during layout changes

### DIFF
--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -802,9 +802,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         openInBrowser(url.toUri(), forceDefaultBrowser = false)
     }
 
-    override fun onNavigatorReady() {
+    override fun onNavigatorReady(fragment: EpubReaderFragment) {
+        readerFragment = fragment
         if (paginationViewportJob?.isActive != true) {
-            applyCurrentReadiumPreferences()
+            applyCurrentReadiumPreferences(fragment)
         }
     }
 
@@ -936,11 +937,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             .launchIn(lifecycleScope)
     }
 
-    private fun applyCurrentReadiumPreferences() {
-        val fragment = epubReaderFragment() ?: return
+    private fun applyCurrentReadiumPreferences(fragment: EpubReaderFragment? = epubReaderFragment()) {
+        val activeFragment = fragment?.takeIf { it.isAdded && it.view != null } ?: return
         val viewport = paginationViewport ?: return
         val preferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences)
-        fragment.submitPreferences(preferences)
+        activeFragment.submitPreferences(preferences)
         paginationJob?.cancel()
         paginationJob = lifecycleScope.launch {
             val snapshot = EpubPaginationLayoutSnapshot.from(epubLayoutPreferences, viewport)
@@ -958,12 +959,14 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                     "phase=${stateAfter.paginationPhase} " +
                     "pages=${stateAfter.currentVisualPage}/${stateAfter.totalVisualPages}"
             }
-            if (request.generation == viewModel.state.value.paginationGeneration) {
-                fragment.startPagination(request)
+            if (request.generation == viewModel.state.value.paginationGeneration &&
+                activeFragment.isAdded && activeFragment.view != null && readerFragment === activeFragment
+            ) {
+                activeFragment.startPagination(request)
                 if (!request.shouldScan &&
                     viewModel.state.value.paginationPhase != EpubPaginationPhase.UNAVAILABLE
                 ) {
-                    viewModel.currentLocator()?.let(fragment::goTo)
+                    viewModel.currentLocator()?.let(activeFragment::goTo)
                 }
             }
         }
@@ -1017,7 +1020,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     private fun epubReaderFragment(): EpubReaderFragment? {
-        return readerFragment
+        return readerFragment?.takeIf { it.isAdded && it.view != null }
     }
 
     private fun openAdjacentBook(chapterId: Long) {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -53,7 +53,7 @@ class EpubReaderFragment : Fragment() {
 
         fun onExternalLinkActivated(url: AbsoluteUrl)
 
-        fun onNavigatorReady()
+        fun onNavigatorReady(fragment: EpubReaderFragment)
 
         fun onSessionMissing(chapterId: Long)
     }
@@ -174,7 +174,7 @@ class EpubReaderFragment : Fragment() {
         }
         observeNavigator()
         if (navigatorFragment() != null) {
-            host?.onNavigatorReady()
+            host?.onNavigatorReady(this)
         }
         val viewportView = view.findViewById<View>(containerId) ?: view
         viewportView.addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
@@ -225,6 +225,7 @@ class EpubReaderFragment : Fragment() {
     }
 
     fun submitPreferences(preferences: EpubPreferences) {
+        if (!isAdded || view == null) return
         paragraphIndentOverrideEnabled = preferences.publisherStyles == false
         navigatorFragment()?.submitPreferences(preferences)
         applyParagraphIndentOverride()
@@ -265,6 +266,7 @@ class EpubReaderFragment : Fragment() {
     }
 
     internal fun startPagination(request: EpubPaginationRequest) {
+        if (!isAdded || view == null) return
         val existing = paginationScannerFragment()
         if (!request.shouldScan) {
             if (existing != null) {
@@ -329,11 +331,15 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
-    private fun navigatorFragment(): EpubNavigatorFragment? =
-        childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
+    private fun navigatorFragment(): EpubNavigatorFragment? {
+        if (!isAdded) return null
+        return childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
+    }
 
-    private fun paginationScannerFragment(): EpubPaginationScannerFragment? =
-        childFragmentManager.findFragmentByTag(PAGINATION_SCANNER_TAG) as? EpubPaginationScannerFragment
+    private fun paginationScannerFragment(): EpubPaginationScannerFragment? {
+        if (!isAdded) return null
+        return childFragmentManager.findFragmentByTag(PAGINATION_SCANNER_TAG) as? EpubPaginationScannerFragment
+    }
 
     companion object {
         private const val ARG_CHAPTER_ID = "chapter_id"


### PR DESCRIPTION
## Summary

- bind the Navigator-ready callback to the Fragment instance that emitted it
- reject detached or viewless reader Fragment references in the Activity and Fragment public operations
- revalidate the active Fragment after asynchronous pagination preparation before applying results

## Root cause

Changing a spacing preset disables publisher styles and can reload the EPUB session. The new session token replaces the Compose-hosted reader Fragment. During the synchronous Fragment transaction, the new Fragment reaches `onViewCreated()` and reports that its Navigator is ready before `AndroidFragment.onUpdate` replaces the Activity's cached Fragment reference. The Activity therefore submitted preferences to the detached old Fragment, which threw while accessing its child FragmentManager.

## Verification

- `./gradlew.bat spotlessCheck --no-daemon`
- `./gradlew.bat :app:compileDebugKotlin --no-daemon`
- Xiaomi 2106118C / Android 16: spacing changes no longer crash the EPUB reader

Base: `fbd05e9c410a0cc45741db49047d530fd1d0774d`
