### PR TITLE
Fix EPUB navigator readiness during session reload

### DIFF
--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -46,7 +46,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
     private var awaitingMeasuredCallback = false
     private var readinessJob: Job? = null
     private val beginScanRunnable = Runnable {
-        if (!isAdded || view == null) return@Runnable
+        if (!isAdded || view == null || scanStarted) return@Runnable
         beginScan()
     }
     private val pageCounts by lazy {
@@ -115,17 +115,22 @@ internal class EpubPaginationScannerFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        if (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) == null) {
-            val navigator = childFragmentManager.fragmentFactory.instantiate(
+        val navigator = (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment) ?: run {
+            val createdNavigator = childFragmentManager.fragmentFactory.instantiate(
                 requireContext().classLoader,
                 EpubNavigatorFragment::class.java.name,
-            )
+            ) as EpubNavigatorFragment
             childFragmentManager.commitNow {
                 setReorderingAllowed(true)
-                replace(containerId, navigator, NAVIGATOR_TAG)
+                replace(containerId, createdNavigator, NAVIGATOR_TAG)
+            }
+            createdNavigator
+        }
+        navigator.viewLifecycleOwnerLiveData.observe(viewLifecycleOwner) { owner ->
+            if (owner != null && isAdded && this@EpubPaginationScannerFragment.view != null && !scanStarted) {
+                this@EpubPaginationScannerFragment.view?.post(beginScanRunnable)
             }
         }
-        view.post(beginScanRunnable)
     }
 
     override fun onDestroyView() {
@@ -144,14 +149,14 @@ internal class EpubPaginationScannerFragment : Fragment() {
         if (nextLink == null) {
             reportProgress(isComplete = true)
         } else {
-            navigatorFragment()?.go(nextLink)
+            readyNavigatorFragment()?.go(nextLink)
         }
     }
 
     private suspend fun awaitStableLayout(): Boolean {
         val loaded = withTimeoutOrNull(RESOURCE_READY_TIMEOUT_MS) {
             while (true) {
-                val navigator = navigatorFragment() ?: return@withTimeoutOrNull false
+                val navigator = readyNavigatorFragment() ?: return@withTimeoutOrNull false
                 val result = runCatching {
                     navigator.evaluateJavascript(RESOURCE_READY_SCRIPT)
                 }.getOrNull() ?: return@withTimeoutOrNull false
@@ -176,7 +181,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
         advancePastCachedResources()
         val nextLink = readingOrder().getOrNull(scanIndex)
         if (nextLink != null) {
-            navigatorFragment()?.go(nextLink)
+            readyNavigatorFragment()?.go(nextLink)
         } else {
             reportProgress(isComplete = true)
         }
@@ -205,6 +210,9 @@ internal class EpubPaginationScannerFragment : Fragment() {
         if (!isAdded) return null
         return childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
     }
+
+    private fun readyNavigatorFragment(): EpubNavigatorFragment? =
+        navigatorFragment()?.takeIf { it.view != null }
 
     private fun String.isSameResourceHref(other: String): Boolean {
         val first = resourceKey()

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -75,6 +75,8 @@ class EpubReaderFragment : Fragment() {
     private var host: Host? = null
     private var containerId: Int = View.NO_ID
     private var scannerContainerId: Int = View.NO_ID
+    private var observedNavigator: EpubNavigatorFragment? = null
+    private var navigatorInputListener: InputListener? = null
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
 
@@ -202,6 +204,11 @@ class EpubReaderFragment : Fragment() {
         super.onDetach()
     }
 
+    override fun onDestroyView() {
+        clearNavigatorInputListener()
+        super.onDestroyView()
+    }
+
     fun goTo(link: Link): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
         return navigator.go(link)
@@ -307,18 +314,20 @@ class EpubReaderFragment : Fragment() {
         logcat(LogPriority.DEBUG) {
             "EPUB fragment observe navigator chapterId=$chapterId"
         }
-        navigator.addInputListener(
-            object : InputListener {
-                override fun onTap(event: TapEvent): Boolean {
-                    val width = navigator.publicationView.width.toFloat().takeIf { it > 0f } ?: return false
-                    val height = navigator.publicationView.height.toFloat().takeIf { it > 0f } ?: return false
-                    return host?.onTap(
-                        positionX = event.point.x / width,
-                        positionY = event.point.y / height,
-                    ) ?: false
-                }
-            },
-        )
+        clearNavigatorInputListener()
+        val inputListener = object : InputListener {
+            override fun onTap(event: TapEvent): Boolean {
+                val width = navigator.publicationView.width.toFloat().takeIf { it > 0f } ?: return false
+                val height = navigator.publicationView.height.toFloat().takeIf { it > 0f } ?: return false
+                return host?.onTap(
+                    positionX = event.point.x / width,
+                    positionY = event.point.y / height,
+                ) ?: false
+            }
+        }
+        observedNavigator = navigator
+        navigatorInputListener = inputListener
+        navigator.addInputListener(inputListener)
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -328,6 +337,14 @@ class EpubReaderFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun clearNavigatorInputListener() {
+        navigatorInputListener?.let { listener ->
+            observedNavigator?.removeInputListener(listener)
+        }
+        navigatorInputListener = null
+        observedNavigator = null
     }
 
     private fun observeNavigatorViewReady(navigator: EpubNavigatorFragment) {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -159,23 +159,22 @@ class EpubReaderFragment : Fragment() {
             host?.onSessionMissing(chapterId)
             return
         }
-        if (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) == null) {
+        val navigator = (childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment) ?: run {
             logcat(LogPriority.DEBUG) {
                 "EPUB fragment create navigator chapterId=$chapterId containerId=$containerId"
             }
-            val navigatorFragment = childFragmentManager.fragmentFactory.instantiate(
+            val createdNavigator = childFragmentManager.fragmentFactory.instantiate(
                 requireContext().classLoader,
                 EpubNavigatorFragment::class.java.name,
-            )
+            ) as EpubNavigatorFragment
             childFragmentManager.commitNow {
                 setReorderingAllowed(true)
-                replace(containerId, navigatorFragment, NAVIGATOR_TAG)
+                replace(containerId, createdNavigator, NAVIGATOR_TAG)
             }
+            createdNavigator
         }
-        observeNavigator()
-        if (navigatorFragment() != null) {
-            host?.onNavigatorReady(this)
-        }
+        observeNavigator(navigator)
+        observeNavigatorViewReady(navigator)
         val viewportView = view.findViewById<View>(containerId) ?: view
         viewportView.addOnLayoutChangeListener { _, left, top, right, bottom, oldLeft, oldTop, oldRight, oldBottom ->
             val width = right - left
@@ -204,23 +203,23 @@ class EpubReaderFragment : Fragment() {
     }
 
     fun goTo(link: Link): Boolean {
-        val navigator = navigatorFragment() ?: return false
+        val navigator = readyNavigatorFragment() ?: return false
         return navigator.go(link)
     }
 
     fun goTo(locator: Locator): Boolean {
-        val navigator = navigatorFragment() ?: return false
+        val navigator = readyNavigatorFragment() ?: return false
         val publication = sessionRepository.get(chapterId)?.publication ?: return false
         return navigator.go(publication.toNavigatorLocator(locator))
     }
 
     fun goForward(): Boolean {
-        val navigator = navigatorFragment() ?: return false
+        val navigator = readyNavigatorFragment() ?: return false
         return navigator.goForward()
     }
 
     fun goBackward(): Boolean {
-        val navigator = navigatorFragment() ?: return false
+        val navigator = readyNavigatorFragment() ?: return false
         return navigator.goBackward()
     }
 
@@ -241,7 +240,7 @@ class EpubReaderFragment : Fragment() {
     private fun applyParagraphIndentOverride() {
         if (!isAdded || view == null) return
         viewLifecycleOwner.lifecycleScope.launch {
-            val navigator = navigatorFragment() ?: return@launch
+            val navigator = readyNavigatorFragment() ?: return@launch
             navigator.evaluateJavascript(
                 if (paragraphIndentOverrideEnabled) {
                     APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
@@ -258,7 +257,8 @@ class EpubReaderFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             delay(PARAGRAPH_INDENT_DEBUG_DELAY_MS)
             if (debugGeneration != paragraphIndentDebugGeneration || !isAdded || view == null) return@launch
-            val result = navigatorFragment()?.evaluateJavascript(PARAGRAPH_INDENT_DEBUG_SCRIPT) ?: return@launch
+            val result = readyNavigatorFragment()?.evaluateJavascript(PARAGRAPH_INDENT_DEBUG_SCRIPT)
+                ?: return@launch
             logcat(LogPriority.DEBUG) {
                 "EPUB paragraph indent computed chapterId=$chapterId result=$result"
             }
@@ -303,8 +303,7 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
-    private fun observeNavigator() {
-        val navigator = navigatorFragment() ?: return
+    private fun observeNavigator(navigator: EpubNavigatorFragment) {
         logcat(LogPriority.DEBUG) {
             "EPUB fragment observe navigator chapterId=$chapterId"
         }
@@ -331,10 +330,20 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
+    private fun observeNavigatorViewReady(navigator: EpubNavigatorFragment) {
+        navigator.viewLifecycleOwnerLiveData.observe(viewLifecycleOwner) { owner ->
+            if (owner == null || !isAdded || view == null) return@observe
+            host?.onNavigatorReady(this)
+        }
+    }
+
     private fun navigatorFragment(): EpubNavigatorFragment? {
         if (!isAdded) return null
         return childFragmentManager.findFragmentByTag(NAVIGATOR_TAG) as? EpubNavigatorFragment
     }
+
+    private fun readyNavigatorFragment(): EpubNavigatorFragment? =
+        navigatorFragment()?.takeIf { it.view != null }
 
     private fun paginationScannerFragment(): EpubPaginationScannerFragment? {
         if (!isAdded) return null


### PR DESCRIPTION
## Summary

- report the visible EPUB Navigator as ready only after its child Fragment view lifecycle exists
- execute navigation and JavaScript only against Navigator fragments with an active view
- start the hidden pagination scanner only after its nested Navigator view is created, while preventing duplicate scan scheduling

## Root cause

Enabling publisher styles reloads the EPUB session. The parent reader Fragment previously treated the presence of the child `EpubNavigatorFragment` object as readiness and immediately submitted preferences. Readium initializes its `resourcePager` inside the child Fragment's `onCreateView()`, so the paragraph-indent JavaScript could call `evaluateJavascript()` before `resourcePager` was initialized.

## Verification

- `./gradlew.bat spotlessCheck --no-daemon`
- `./gradlew.bat :app:compileDebugKotlin --no-daemon`
- Android emulator: enabling publisher styles after session reload no longer crashes the EPUB reader

Base: `28e3b320a7cde1533ff892b94e13d4a305f0cf6d`
