### PR TITLE
feat(komga): filter history and updates by active server

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -10,14 +10,17 @@ import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.presentation.history.HistoryUiModel
 import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
 import eu.kanade.tachiyomi.util.lang.toLocalDate
+import koharia.source.komga.KomgaServerPreferences
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -60,6 +63,7 @@ class HistoryScreenModel(
     private val updateManga: UpdateManga = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
     private val sourceManager: SourceManager = Injekt.get(),
+    private val komgaServerPreferences: KomgaServerPreferences = Injekt.get(),
 ) : StateScreenModel<HistoryScreenModel.State>(State()) {
 
     private val _events: Channel<Event> = Channel(Channel.UNLIMITED)
@@ -71,10 +75,17 @@ class HistoryScreenModel(
         }
 
         screenModelScope.launch {
-            state.map { it.searchQuery }
-                .distinctUntilChanged()
-                .flatMapLatest { query ->
-                    getHistory.subscribe(query ?: "")
+            combine(
+                state.map { it.searchQuery }.distinctUntilChanged(),
+                komgaServerPreferences.activeServerId.changes().distinctUntilChanged(),
+            ) { query, sourceId -> query to sourceId }
+                .flatMapLatest { (query, sourceId) ->
+                    val history = if (sourceId == KomgaServerPreferences.NO_ACTIVE_SERVER) {
+                        flowOf(emptyList())
+                    } else {
+                        getHistory.subscribe(query ?: "", sourceId)
+                    }
+                    history
                         .distinctUntilChanged()
                         .catch { error ->
                             logcat(LogPriority.ERROR, error)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/history/HistoryScreenModel.kt
@@ -147,7 +147,10 @@ class HistoryScreenModel(
 
     fun removeAllHistory() {
         screenModelScope.launchIO {
-            val result = removeHistory.awaitAll()
+            val sourceId = komgaServerPreferences.activeServerId.get()
+                .takeUnless { it == KomgaServerPreferences.NO_ACTIVE_SERVER }
+                ?: return@launchIO
+            val result = removeHistory.awaitAll(sourceId)
             if (!result) return@launchIO
             _events.send(Event.HistoryCleared)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -109,13 +109,13 @@ class UpdatesScreenModel(
                 databaseUpdates,
                 downloadCache.changes,
                 downloadManager.queueState,
-                getUpdatesItemPreferenceFlow().distinctUntilChanged { old, new ->
-                    old.filterDownloaded == new.filterDownloaded
-                },
-            ) { updates, _, _, itemPreferences ->
+                getUpdatesItemPreferenceFlow()
+                    .map { it.filterDownloaded }
+                    .distinctUntilChanged(),
+            ) { updates, _, _, filterDownloaded ->
                 updates
                     .toUpdateItems()
-                    .applyFilters(itemPreferences)
+                    .applyDownloadedFilter(filterDownloaded)
                     .toPersistentList()
             }
                 .collectLatest { updateItems ->
@@ -153,11 +153,7 @@ class UpdatesScreenModel(
             .launchIn(screenModelScope)
     }
 
-    private fun List<UpdatesItem>.applyFilters(
-        preferences: ItemPreferences,
-    ): List<UpdatesItem> {
-        val filterDownloaded = preferences.filterDownloaded
-
+    private fun List<UpdatesItem>.applyDownloadedFilter(filterDownloaded: TriState): List<UpdatesItem> {
         val filterFnDownloaded: (UpdatesItem) -> Boolean = {
             applyFilter(filterDownloaded) {
                 it.downloadStateProvider() == Download.State.DOWNLOADED

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/UpdatesScreenModel.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.util.lang.toLocalDate
+import koharia.source.komga.KomgaServerPreferences
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.mutate
 import kotlinx.collections.immutable.persistentListOf
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -66,6 +68,7 @@ class UpdatesScreenModel(
     private val getChapter: GetChapter = Injekt.get(),
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val updatesPreferences: UpdatesPreferences = Injekt.get(),
+    private val komgaServerPreferences: KomgaServerPreferences = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<UpdatesScreenModel.State>(State()) {
 
@@ -80,25 +83,32 @@ class UpdatesScreenModel(
 
     init {
         screenModelScope.launchIO {
-            // Set date limit for recent chapters
             val limit = ZonedDateTime.now().minusMonths(3).toInstant()
-
-            combine(
-                // needed for SQL filters (unread, started, bookmarked, etc)
-                getUpdatesItemPreferenceFlow()
-                    .distinctUntilChanged()
-                    .flatMapLatest {
+            val databaseUpdates = combine(
+                komgaServerPreferences.activeServerId.changes().distinctUntilChanged(),
+                getUpdatesItemPreferenceFlow().distinctUntilChanged { old, new ->
+                    old.hasSameDatabaseFilters(new)
+                },
+            ) { sourceId, itemPreferences -> sourceId to itemPreferences }
+                .flatMapLatest { (sourceId, itemPreferences) ->
+                    if (sourceId == KomgaServerPreferences.NO_ACTIVE_SERVER) {
+                        flowOf(emptyList())
+                    } else {
                         getUpdates.subscribe(
                             limit,
-                            unread = it.filterUnread.toBooleanOrNull(),
-                            started = it.filterStarted.toBooleanOrNull(),
-                            bookmarked = it.filterBookmarked.toBooleanOrNull(),
-                            hideExcludedScanlators = it.filterExcludedScanlators,
+                            unread = itemPreferences.filterUnread.toBooleanOrNull(),
+                            started = itemPreferences.filterStarted.toBooleanOrNull(),
+                            bookmarked = itemPreferences.filterBookmarked.toBooleanOrNull(),
+                            hideExcludedScanlators = itemPreferences.filterExcludedScanlators,
+                            sourceId = sourceId,
                         ).distinctUntilChanged()
-                    },
+                    }
+                }
+
+            combine(
+                databaseUpdates,
                 downloadCache.changes,
                 downloadManager.queueState,
-                // needed for Kotlin filters (downloaded)
                 getUpdatesItemPreferenceFlow().distinctUntilChanged { old, new ->
                     old.filterDownloaded == new.filterDownloaded
                 },
@@ -447,7 +457,14 @@ class UpdatesScreenModel(
         val filterStarted: TriState,
         val filterBookmarked: TriState,
         val filterExcludedScanlators: Boolean,
-    )
+    ) {
+        fun hasSameDatabaseFilters(other: ItemPreferences): Boolean {
+            return filterUnread == other.filterUnread &&
+                filterStarted == other.filterStarted &&
+                filterBookmarked == other.filterBookmarked &&
+                filterExcludedScanlators == other.filterExcludedScanlators
+        }
+    }
 
     @Immutable
     data class State(

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -57,9 +57,13 @@ class HistoryRepositoryImpl(
         }
     }
 
-    override suspend fun deleteAllHistory(): Boolean {
+    override suspend fun deleteAllHistory(sourceId: Long?): Boolean {
         return try {
-            database.historyQueries.removeAllHistory()
+            if (sourceId == null) {
+                database.historyQueries.removeAllHistory()
+            } else {
+                database.historyQueries.removeHistoryBySourceId(sourceId)
+            }
             true
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, throwable = e)

--- a/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/history/HistoryRepositoryImpl.kt
@@ -17,9 +17,9 @@ class HistoryRepositoryImpl(
     private val database: Database,
 ) : HistoryRepository {
 
-    override fun getHistory(query: String): Flow<List<HistoryWithRelations>> {
+    override fun getHistory(query: String, sourceId: Long?): Flow<List<HistoryWithRelations>> {
         return database.historyViewQueries
-            .history(query, HistoryMapper::mapHistoryWithRelations)
+            .history(query, sourceId, HistoryMapper::mapHistoryWithRelations)
             .subscribeToList()
     }
 

--- a/data/src/main/java/tachiyomi/data/updates/UpdatesRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/updates/UpdatesRepositoryImpl.kt
@@ -35,6 +35,7 @@ class UpdatesRepositoryImpl(
         started: Boolean?,
         bookmarked: Boolean?,
         hideExcludedScanlators: Boolean,
+        sourceId: Long?,
     ): Flow<List<UpdatesWithRelations>> {
         return database.updatesViewQueries
             .getRecentUpdatesWithFilters(
@@ -44,6 +45,7 @@ class UpdatesRepositoryImpl(
                 started = started?.toLong(),
                 bookmarked = bookmarked,
                 hideExcludedScanlators = hideExcludedScanlators.toLong(),
+                sourceId = sourceId,
                 mapper = ::mapUpdatesWithRelations,
             )
             .subscribeToList()

--- a/data/src/main/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/history.sq
@@ -55,6 +55,16 @@ WHERE _id IN (
 removeAllHistory:
 DELETE FROM history;
 
+removeHistoryBySourceId:
+DELETE FROM history
+WHERE chapter_id IN (
+    SELECT C._id
+    FROM chapters C
+    INNER JOIN mangas M
+    ON C.manga_id = M._id
+    WHERE M.source = :sourceId
+);
+
 removeResettedHistory:
 DELETE FROM history
 WHERE last_read = 0;

--- a/data/src/main/sqldelight/tachiyomi/view/historyView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/historyView.sq
@@ -43,6 +43,7 @@ FROM historyView
 WHERE historyView.readAt > 0
 AND maxReadAtChapterId = historyView.chapterId
 AND lower(historyView.title) LIKE ('%' || :query || '%')
+AND (:sourceId IS NULL OR historyView.source = :sourceId)
 ORDER BY readAt DESC;
 
 getLatestHistory:

--- a/data/src/main/sqldelight/tachiyomi/view/updatesView.sq
+++ b/data/src/main/sqldelight/tachiyomi/view/updatesView.sq
@@ -46,6 +46,7 @@ AND (:bookmarked IS NULL OR bookmark = :bookmarked)
 AND (
     (excludedScanlator IS NULL OR :hideExcludedScanlators = 0)
 )
+AND (:sourceId IS NULL OR source = :sourceId)
 LIMIT :limit;
 
 getUpdatesByReadStatus:

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/GetHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/GetHistory.kt
@@ -13,7 +13,7 @@ class GetHistory(
         return repository.getHistoryByMangaId(mangaId)
     }
 
-    fun subscribe(query: String): Flow<List<HistoryWithRelations>> {
-        return repository.getHistory(query)
+    fun subscribe(query: String, sourceId: Long? = null): Flow<List<HistoryWithRelations>> {
+        return repository.getHistory(query, sourceId)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/history/interactor/RemoveHistory.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/interactor/RemoveHistory.kt
@@ -7,8 +7,8 @@ class RemoveHistory(
     private val repository: HistoryRepository,
 ) {
 
-    suspend fun awaitAll(): Boolean {
-        return repository.deleteAllHistory()
+    suspend fun awaitAll(sourceId: Long? = null): Boolean {
+        return repository.deleteAllHistory(sourceId)
     }
 
     suspend fun await(history: HistoryWithRelations) {

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -7,7 +7,7 @@ import tachiyomi.domain.history.model.HistoryWithRelations
 
 interface HistoryRepository {
 
-    fun getHistory(query: String): Flow<List<HistoryWithRelations>>
+    fun getHistory(query: String, sourceId: Long? = null): Flow<List<HistoryWithRelations>>
 
     suspend fun getLastHistory(): HistoryWithRelations?
 

--- a/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/history/repository/HistoryRepository.kt
@@ -19,7 +19,7 @@ interface HistoryRepository {
 
     suspend fun resetHistoryByMangaId(mangaId: Long)
 
-    suspend fun deleteAllHistory(): Boolean
+    suspend fun deleteAllHistory(sourceId: Long? = null): Boolean
 
     suspend fun upsertHistory(historyUpdate: HistoryUpdate)
 }

--- a/domain/src/main/java/tachiyomi/domain/updates/interactor/GetUpdates.kt
+++ b/domain/src/main/java/tachiyomi/domain/updates/interactor/GetUpdates.kt
@@ -19,6 +19,7 @@ class GetUpdates(
         started: Boolean?,
         bookmarked: Boolean?,
         hideExcludedScanlators: Boolean,
+        sourceId: Long? = null,
     ): Flow<List<UpdatesWithRelations>> {
         return repository.subscribeAll(
             instant.toEpochMilli(),
@@ -27,6 +28,7 @@ class GetUpdates(
             started = started,
             bookmarked = bookmarked,
             hideExcludedScanlators = hideExcludedScanlators,
+            sourceId = sourceId,
         )
     }
 

--- a/domain/src/main/java/tachiyomi/domain/updates/repository/UpdatesRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/updates/repository/UpdatesRepository.kt
@@ -14,6 +14,7 @@ interface UpdatesRepository {
         started: Boolean?,
         bookmarked: Boolean?,
         hideExcludedScanlators: Boolean,
+        sourceId: Long? = null,
     ): Flow<List<UpdatesWithRelations>>
 
     fun subscribeWithRead(read: Boolean, after: Long, limit: Long): Flow<List<UpdatesWithRelations>>

--- a/domain/src/test/java/tachiyomi/domain/history/interactor/GetHistoryTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/history/interactor/GetHistoryTest.kt
@@ -1,0 +1,36 @@
+package tachiyomi.domain.history.interactor
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.history.model.HistoryWithRelations
+import tachiyomi.domain.history.repository.HistoryRepository
+
+class GetHistoryTest {
+
+    private val repository = mockk<HistoryRepository>()
+    private val getHistory = GetHistory(repository)
+
+    @Test
+    fun `subscribe forwards source id to repository`() {
+        val expected = emptyFlow<List<HistoryWithRelations>>()
+        every { repository.getHistory("query", 42L) } returns expected
+
+        getHistory.subscribe("query", 42L) shouldBe expected
+
+        verify(exactly = 1) { repository.getHistory("query", 42L) }
+    }
+
+    @Test
+    fun `subscribe defaults to all sources`() {
+        val expected = emptyFlow<List<HistoryWithRelations>>()
+        every { repository.getHistory("", null) } returns expected
+
+        getHistory.subscribe("") shouldBe expected
+
+        verify(exactly = 1) { repository.getHistory("", null) }
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/history/interactor/RemoveHistoryTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/history/interactor/RemoveHistoryTest.kt
@@ -1,0 +1,33 @@
+package tachiyomi.domain.history.interactor
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.history.repository.HistoryRepository
+
+class RemoveHistoryTest {
+
+    private val repository = mockk<HistoryRepository>()
+    private val removeHistory = RemoveHistory(repository)
+
+    @Test
+    fun `awaitAll forwards source id to repository`() = runTest {
+        coEvery { repository.deleteAllHistory(42L) } returns true
+
+        removeHistory.awaitAll(42L) shouldBe true
+
+        coVerify(exactly = 1) { repository.deleteAllHistory(42L) }
+    }
+
+    @Test
+    fun `awaitAll defaults to all sources`() = runTest {
+        coEvery { repository.deleteAllHistory(null) } returns true
+
+        removeHistory.awaitAll() shouldBe true
+
+        coVerify(exactly = 1) { repository.deleteAllHistory(null) }
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/updates/interactor/GetUpdatesTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/updates/interactor/GetUpdatesTest.kt
@@ -1,0 +1,90 @@
+package tachiyomi.domain.updates.interactor
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.updates.model.UpdatesWithRelations
+import tachiyomi.domain.updates.repository.UpdatesRepository
+import java.time.Instant
+
+class GetUpdatesTest {
+
+    private val repository = mockk<UpdatesRepository>()
+    private val getUpdates = GetUpdates(repository)
+
+    @Test
+    fun `subscribe forwards source id and filters to repository`() {
+        val expected = emptyFlow<List<UpdatesWithRelations>>()
+        every {
+            repository.subscribeAll(
+                after = 123L,
+                limit = 500,
+                unread = true,
+                started = false,
+                bookmarked = true,
+                hideExcludedScanlators = true,
+                sourceId = 42L,
+            )
+        } returns expected
+
+        getUpdates.subscribe(
+            instant = Instant.ofEpochMilli(123L),
+            unread = true,
+            started = false,
+            bookmarked = true,
+            hideExcludedScanlators = true,
+            sourceId = 42L,
+        ) shouldBe expected
+
+        verify(exactly = 1) {
+            repository.subscribeAll(
+                after = 123L,
+                limit = 500,
+                unread = true,
+                started = false,
+                bookmarked = true,
+                hideExcludedScanlators = true,
+                sourceId = 42L,
+            )
+        }
+    }
+
+    @Test
+    fun `subscribe defaults to all sources`() {
+        val expected = emptyFlow<List<UpdatesWithRelations>>()
+        every {
+            repository.subscribeAll(
+                after = 123L,
+                limit = 500,
+                unread = null,
+                started = null,
+                bookmarked = null,
+                hideExcludedScanlators = false,
+                sourceId = null,
+            )
+        } returns expected
+
+        getUpdates.subscribe(
+            instant = Instant.ofEpochMilli(123L),
+            unread = null,
+            started = null,
+            bookmarked = null,
+            hideExcludedScanlators = false,
+        ) shouldBe expected
+
+        verify(exactly = 1) {
+            repository.subscribeAll(
+                after = 123L,
+                limit = 500,
+                unread = null,
+                started = null,
+                bookmarked = null,
+                hideExcludedScanlators = false,
+                sourceId = null,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- filter History and Updates by the currently active Komga server profile
- immediately resubscribe when the active server changes and show an empty list when no server is active
- pass an optional `sourceId` through the domain, repository, and SQLDelight query layers while preserving the existing all-sources behavior for null callers
- keep the Updates database subscription stable when only the downloaded-state filter changes
- add domain tests for explicit source filtering and null compatibility

This is a manual port of the useful history/updates portion from the old `epub-split-unrelated-leftovers-2026-07-14` stash. The old stash was not applied directly.

## Validation

- user manual testing passed
- `./gradlew.bat spotlessApply --no-daemon`
- `./gradlew.bat spotlessCheck :data:generateDebugDatabaseInterface :domain:testDebugUnitTest :app:compileDebugKotlin --no-daemon`
