### PR TITLE
feat(telemetry): configure Firebase reporting / 配置 Firebase 遥测

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,13 +1,13 @@
 {
   "project_info": {
-    "project_number": "82031285239",
-    "project_id": "mihonapp",
-    "storage_bucket": "mihonapp.appspot.com"
+    "project_number": "917147318869",
+    "project_id": "koharia-a3e1f",
+    "storage_bucket": "koharia-a3e1f.firebasestorage.app"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:82031285239:android:336ed6dceef55c357594f2",
+        "mobilesdk_app_id": "1:917147318869:android:c40a67c21495580378b2dc",
         "android_client_info": {
           "package_name": "app.koharia"
         }
@@ -15,7 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyDTvOxBQnuXADx5isKxoynPG0nlAO8bQbk"
+          "current_key": "AIzaSyBE9gLI8vxKFaiDAbo91PUhe85cLmufyDA"
         }
       ],
       "services": {
@@ -26,15 +26,15 @@
     },
     {
       "client_info": {
-        "mobilesdk_app_id": "1:82031285239:android:b7440cbdd0d33c9d7594f2",
+        "mobilesdk_app_id": "1:917147318869:android:ae64af663147c12378b2dc",
         "android_client_info": {
-          "package_name": "app.koharia.debug"
+          "package_name": "app.koharia.dev"
         }
       },
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyDTvOxBQnuXADx5isKxoynPG0nlAO8bQbk"
+          "current_key": "AIzaSyBE9gLI8vxKFaiDAbo91PUhe85cLmufyDA"
         }
       ],
       "services": {

--- a/telemetry/src/firebase/kotlin/koharia/telemetry/TelemetryImplementation.kt
+++ b/telemetry/src/firebase/kotlin/koharia/telemetry/TelemetryImplementation.kt
@@ -9,7 +9,7 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 
-object TelemetryConfig {
+internal object TelemetryImplementation {
     private var analytics: FirebaseAnalytics? = null
     private var crashlytics: FirebaseCrashlytics? = null
 
@@ -62,4 +62,4 @@ object TelemetryConfig {
 
 private val KOHARIA_PACKAGES = hashSetOf("app.koharia", "app.koharia.debug")
 private const val KOHARIA_CERTIFICATE_FINGERPRINT =
-    "9A:DD:65:5A:78:E9:6C:4E:C7:A5:3E:F8:9D:CC:B5:57:CB:5D:76:74:89:FA:C5:E7:85:D6:71:A5:A7:5D:4D:A2"
+    "14:DF:E0:17:E6:58:61:EC:5F:9D:7B:A1:26:B8:C8:A2:45:9F:8B:3B:6C:06:4E:B7:F8:DE:28:04:04:A6:DB:52"

--- a/telemetry/src/main/kotlin/koharia/telemetry/TelemetryConfig.kt
+++ b/telemetry/src/main/kotlin/koharia/telemetry/TelemetryConfig.kt
@@ -1,0 +1,11 @@
+package koharia.telemetry
+
+import android.content.Context
+
+object TelemetryConfig {
+    fun init(context: Context) = TelemetryImplementation.init(context)
+
+    fun setAnalyticsEnabled(enabled: Boolean) = TelemetryImplementation.setAnalyticsEnabled(enabled)
+
+    fun setCrashlyticsEnabled(enabled: Boolean) = TelemetryImplementation.setCrashlyticsEnabled(enabled)
+}

--- a/telemetry/src/noop/kotlin/koharia/telemetry/TelemetryImplementation.kt
+++ b/telemetry/src/noop/kotlin/koharia/telemetry/TelemetryImplementation.kt
@@ -3,7 +3,7 @@ package koharia.telemetry
 import android.content.Context
 
 @Suppress("UNUSED_PARAMETER")
-object TelemetryConfig {
+internal object TelemetryImplementation {
     fun init(context: Context) = Unit
 
     fun setAnalyticsEnabled(enabled: Boolean) = Unit


### PR DESCRIPTION
## Summary / 概述

Configure the application to use its Firebase project for Analytics and Crashlytics.

为应用配置自有 Firebase 项目，用于 Analytics 和 Crashlytics。

## Changes / 变更

- Replace the Google Services configuration with the project-specific Android clients.
  替换为项目专用的 Google Services Android 客户端配置。
- Update the production telemetry signing gate for the release application.
  更新 release 应用的 telemetry 签名校验。
- Expose a stable telemetry facade from the standard source set while keeping Firebase and no-op implementations build-selectable.
  将稳定的 telemetry 门面放入标准源集，同时保留 Firebase/no-op 实现按构建开关切换。

## Scope / 范围

This PR only covers Firebase configuration and telemetry integration.
本 PR 仅包含 Firebase 配置与 telemetry 集成。