### PR TITLE
feat(epub): 首屏优先、书籍缓存与分页进度增强 / First-screen loading, book cache, and pagination progress

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -23,18 +23,22 @@ import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
 import koharia.data.epub.EpubBookmarkRepositoryImpl
 import koharia.data.epub.EpubPaginationCacheRepositoryImpl
 import koharia.data.epub.EpubProgressRepositoryImpl
+import koharia.data.epub.EpubRemoteProgressCacheRepositoryImpl
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
 import koharia.domain.epub.interactor.AddEpubBookmark
 import koharia.domain.epub.interactor.DeleteEpubBookmark
 import koharia.domain.epub.interactor.GetEpubBookmarks
 import koharia.domain.epub.interactor.GetEpubPaginationCache
 import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
 import koharia.domain.epub.interactor.UpdateEpubBookmarkNote
 import koharia.domain.epub.interactor.UpsertEpubPaginationCache
 import koharia.domain.epub.interactor.UpsertEpubProgress
+import koharia.domain.epub.interactor.UpsertEpubRemoteProgressCache
 import koharia.domain.epub.repository.EpubBookmarkRepository
 import koharia.domain.epub.repository.EpubPaginationCacheRepository
 import koharia.domain.epub.repository.EpubProgressRepository
+import koharia.domain.epub.repository.EpubRemoteProgressCacheRepository
 import koharia.domain.upcoming.interactor.GetUpcomingManga
 import tachiyomi.data.category.CategoryRepositoryImpl
 import tachiyomi.data.chapter.ChapterRepositoryImpl
@@ -170,6 +174,9 @@ class DomainModule : InjektModule {
         addSingletonFactory<EpubProgressRepository> { EpubProgressRepositoryImpl(get()) }
         addFactory { GetEpubProgress(get()) }
         addFactory { UpsertEpubProgress(get()) }
+        addSingletonFactory<EpubRemoteProgressCacheRepository> { EpubRemoteProgressCacheRepositoryImpl(get()) }
+        addFactory { GetEpubRemoteProgressCache(get()) }
+        addFactory { UpsertEpubRemoteProgressCache(get()) }
         addSingletonFactory<EpubPaginationCacheRepository> { EpubPaginationCacheRepositoryImpl(get()) }
         addFactory { GetEpubPaginationCache(get()) }
         addFactory { UpsertEpubPaginationCache(get()) }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -60,6 +60,8 @@ import eu.kanade.tachiyomi.data.export.LibraryExporter
 import eu.kanade.tachiyomi.data.export.LibraryExporter.ExportOptions
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.toast
+import koharia.epub.cache.EpubCacheManager
+import koharia.epub.cache.EpubCachePreferences
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.Dispatchers
@@ -113,8 +115,67 @@ object SettingsDataScreen : SearchableSettings {
             Preference.PreferenceItem.InfoPreference(stringResource(MR.strings.pref_storage_location_info)),
 
             getBackupAndRestoreGroup(backupPreferences = backupPreferences),
+            getBookCacheGroup(),
             getDataGroup(),
             getExportGroup(),
+        )
+    }
+
+    @Composable
+    private fun getBookCacheGroup(): Preference.PreferenceGroup {
+        val context = LocalContext.current
+        val scope = rememberCoroutineScope()
+        val preferences = remember { Injekt.get<EpubCachePreferences>() }
+        val cacheManager = remember { Injekt.get<EpubCacheManager>() }
+        val cacheSizeMb by preferences.cacheSizeMb.collectAsState()
+        var cacheUsage by remember { mutableStateOf(Formatter.formatFileSize(context, 0)) }
+        var refreshKey by remember { mutableIntStateOf(0) }
+        val cacheSizeRange =
+            EpubCachePreferences.MIN_CACHE_SIZE_MB..EpubCachePreferences.MAX_CACHE_SIZE_MB step
+                EpubCachePreferences.CACHE_SIZE_STEP_MB
+
+        LaunchedEffect(refreshKey, cacheSizeMb) {
+            cacheUsage = withIOContext { cacheManager.readableSize() }
+        }
+
+        return Preference.PreferenceGroup(
+            title = stringResource(MR.strings.pref_book_cache),
+            preferenceItems = persistentListOf(
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = preferences.cacheWholeBook,
+                    title = stringResource(MR.strings.pref_cache_whole_book),
+                    subtitle = stringResource(MR.strings.pref_cache_whole_book_summary),
+                ),
+                Preference.PreferenceItem.SliderPreference(
+                    value = cacheSizeMb,
+                    valueRange = cacheSizeRange,
+                    steps = 30,
+                    title = stringResource(MR.strings.pref_book_cache_size),
+                    valueString = stringResource(MR.strings.cache_size_megabytes, cacheSizeMb),
+                    subtitle = stringResource(MR.strings.used_cache, cacheUsage),
+                    onValueChanged = { value ->
+                        preferences.cacheSizeMb.set(value)
+                        scope.launch {
+                            cacheManager.trimToSize()
+                            refreshKey++
+                        }
+                    },
+                ),
+                Preference.PreferenceItem.TextPreference(
+                    title = stringResource(MR.strings.pref_clear_book_cache),
+                    subtitle = stringResource(MR.strings.used_cache, cacheUsage),
+                    onClick = {
+                        scope.launch {
+                            val deleted = cacheManager.clear()
+                            context.toast(context.stringResource(MR.strings.cache_deleted, deleted))
+                            refreshKey++
+                        }
+                    },
+                ),
+                Preference.PreferenceItem.InfoPreference(
+                    stringResource(MR.strings.pref_book_cache_info),
+                ),
+            ),
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalCacheCleaner.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalCacheCleaner.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.text.format.Formatter
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.network.NetworkHelper
+import koharia.epub.cache.EpubCacheManager
 import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
 import tachiyomi.domain.manga.model.Manga
 
@@ -13,6 +14,7 @@ class LocalCacheCleaner(
     private val coverCache: CoverCache,
     private val downloadCache: DownloadCache,
     private val networkHelper: NetworkHelper,
+    private val epubCacheManager: EpubCacheManager,
 ) {
 
     fun temporaryCacheReadableSize(): String {
@@ -31,7 +33,7 @@ class LocalCacheCleaner(
         return coverCache.clear()
     }
 
-    fun clearAllTemporaryCache(): Int {
+    suspend fun clearAllTemporaryCache(): Int {
         var deleted = 0
         deleted += clearChapterCache()
         deleted += networkHelper.clearDiskCache()
@@ -39,6 +41,7 @@ class LocalCacheCleaner(
         deleted += downloadCache.clearDiskCache()
         deleted += LocalTempCacheDirectoryProvider.clearCoilDiskCache(context)
         deleted += LocalTempCacheDirectoryProvider.clearSharedImageCache(context)
+        deleted += epubCacheManager.clear()
         return deleted
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -153,6 +153,7 @@ class DownloadCache(
         mangaTitle: String,
         sourceId: Long,
         skipCache: Boolean,
+        allowSharedLookup: Boolean = true,
     ): Boolean {
         if (skipCache) {
             val source = sourceManager.getOrStub(sourceId)
@@ -173,7 +174,9 @@ class DownloadCache(
             }
         }
 
-        if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared) {
+        if (allowSharedLookup &&
+            komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared
+        ) {
             val source = sourceManager.getOrStub(sourceId)
             return provider.findChapterDir(chapterName, chapterScanlator, chapterUrl, mangaTitle, source) != null
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -259,8 +259,17 @@ class DownloadManager(
         mangaTitle: String,
         sourceId: Long,
         skipCache: Boolean = false,
+        allowSharedLookup: Boolean = true,
     ): Boolean {
-        return cache.isChapterDownloaded(chapterName, chapterScanlator, chapterUrl, mangaTitle, sourceId, skipCache)
+        return cache.isChapterDownloaded(
+            chapterName,
+            chapterScanlator,
+            chapterUrl,
+            mangaTitle,
+            sourceId,
+            skipCache,
+            allowSharedLookup,
+        )
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -22,7 +22,10 @@ import eu.kanade.tachiyomi.data.track.TrackerManager
 import eu.kanade.tachiyomi.network.JavaScriptEngine
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.source.AndroidSourceManager
+import koharia.epub.cache.EpubCacheManager
+import koharia.epub.cache.EpubCachePreferences
 import koharia.epub.progress.KomgaEpubProgressSyncService
+import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
 import koharia.epub.service.EpubPublicationResolver
 import koharia.epub.service.EpubReaderSupportResolver
 import koharia.epub.service.KomgaEpubPublicationService
@@ -45,6 +48,7 @@ import tachiyomi.data.DateColumnAdapter
 import tachiyomi.data.Epub_bookmark
 import tachiyomi.data.Epub_pagination_cache
 import tachiyomi.data.Epub_progress
+import tachiyomi.data.Epub_remote_progress_cache
 import tachiyomi.data.History
 import tachiyomi.data.Mangas
 import tachiyomi.data.MemoColumnAdapter
@@ -93,6 +97,11 @@ class AppModule(val app: Application) : InjektModule {
                     updated_atAdapter = DateColumnAdapter,
                     last_synced_atAdapter = DateColumnAdapter,
                 ),
+                epub_remote_progress_cacheAdapter = Epub_remote_progress_cache.Adapter(
+                    modified_atAdapter = DateColumnAdapter,
+                    checked_atAdapter = DateColumnAdapter,
+                    server_dateAdapter = DateColumnAdapter,
+                ),
                 epub_bookmarkAdapter = Epub_bookmark.Adapter(
                     created_atAdapter = DateColumnAdapter,
                 ),
@@ -139,7 +148,9 @@ class AppModule(val app: Application) : InjektModule {
 
         addSingletonFactory { ChapterCache(app, get()) }
         addSingletonFactory { CoverCache(app) }
-        addSingletonFactory { LocalCacheCleaner(app, get(), get(), get(), get()) }
+        addSingletonFactory { EpubCachePreferences(get()) }
+        addSingletonFactory { EpubCacheManager(app, get()) }
+        addSingletonFactory { LocalCacheCleaner(app, get(), get(), get(), get(), get()) }
 
         addSingletonFactory { NetworkHelper(app, get()) }
         addSingletonFactory { JavaScriptEngine(app) }
@@ -167,6 +178,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { EpubPublicationResolver() }
         addSingletonFactory { EpubReaderSupportResolver() }
         addSingletonFactory { KomgaEpubProgressSyncService(get(), get()) }
+        addSingletonFactory { KomgaEpubRemoteProgressCoordinator(get(), get(), get(), get()) }
 
         // Asynchronously init expensive components for a faster cold start
         ContextCompat.getMainExecutor(app).execute {

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -66,6 +66,7 @@ class PreferenceModule(val app: Application) : InjektModule {
                 downloadProvider = get(),
                 downloadCache = get(),
                 komgaSharedDownloadIndexManager = get(),
+                epubCacheManager = get(),
             )
         }
         addSingletonFactory {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -46,11 +46,13 @@ import eu.kanade.tachiyomi.util.removeCovers
 import eu.kanade.tachiyomi.util.system.toast
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
 import koharia.domain.epub.interactor.GetEpubProgress
-import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
+import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -95,6 +97,9 @@ import uy.kohesive.injekt.api.get
 import kotlin.math.floor
 import kotlin.math.roundToInt
 
+private const val KOMGA_DETAILS_REFRESH_INTERVAL_MS = 5 * 60 * 1_000L
+private const val EPUB_REMOTE_PROGRESS_DELAY_MS = 1_000L
+
 class MangaScreenModel(
     private val context: Context,
     private val lifecycle: Lifecycle,
@@ -126,6 +131,8 @@ class MangaScreenModel(
     private val filterChaptersForDownload: FilterChaptersForDownload = Injekt.get(),
     private val komgaProgressSyncService: KomgaProgressSyncService = Injekt.get(),
     private val getEpubProgress: GetEpubProgress = Injekt.get(),
+    private val getEpubRemoteProgressCache: GetEpubRemoteProgressCache = Injekt.get(),
+    private val epubRemoteProgressCoordinator: KomgaEpubRemoteProgressCoordinator = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -188,7 +195,12 @@ class MangaScreenModel(
                     updateSuccessState {
                         it.copy(
                             manga = manga,
-                            chapters = chapters.toChapterListItems(manga, epubProgresses.associateBy { it.chapterId }),
+                            chapters = chapters.toChapterListItems(
+                                manga,
+                                epubProgresses.mapNotNull { progress ->
+                                    progress.progression?.let { progress.chapterId to it }
+                                }.toMap(),
+                            ),
                         )
                     }
                 }
@@ -219,18 +231,63 @@ class MangaScreenModel(
         observeDownloads()
 
         screenModelScope.launchIO {
-            val manga = getMangaAndChapters.awaitManga(mangaId)
-            val epubProgresses = getEpubProgress.awaitByMangaId(mangaId)
+            val mangaDeferred = async { getMangaAndChapters.awaitManga(mangaId) }
+            val chaptersDeferred = async {
+                getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true)
+            }
+            val localProgressDeferred = async { getEpubProgress.awaitByMangaId(mangaId) }
+            val remoteProgressDeferred = async {
+                runCatching {
+                    getEpubRemoteProgressCache.awaitByMangaId(mangaId)
+                }.onFailure { error ->
+                    logcat(LogPriority.WARN, error) {
+                        "Failed to load cached EPUB remote progress for mangaId=$mangaId"
+                    }
+                }.getOrDefault(emptyList())
+            }
+            val availableScanlatorsDeferred = async { getAvailableScanlators.await(mangaId) }
+            val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
+
+            val manga = mangaDeferred.await()
+            val localEpubProgresses = localProgressDeferred.await()
                 .associateBy { it.chapterId }
-            val chapters = getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true)
-                .toChapterListItems(manga, epubProgresses)
+            val cachedRemoteProgresses = remoteProgressDeferred.await()
+                .associateBy { it.chapterId }
+            val epubProgresses = (localEpubProgresses.keys + cachedRemoteProgresses.keys)
+                .associateWith { chapterId ->
+                    val local = localEpubProgresses[chapterId]
+                    val remote = cachedRemoteProgresses[chapterId]
+                    val remoteModifiedAt = remote?.modifiedAt
+                    if (remoteModifiedAt != null &&
+                        (local == null || remoteModifiedAt.time > local.updatedAt.time)
+                    ) {
+                        remote.progression
+                    } else {
+                        local?.progression
+                    }
+                }
+                .mapNotNull { (chapterId, progression) ->
+                    progression?.let { chapterId to it }
+                }
+                .toMap()
+            val chapterModels = chaptersDeferred.await()
+            val chapters = chapterModels.toChapterListItems(
+                manga = manga,
+                epubProgresses = epubProgresses,
+                allowSharedDownloadLookup = false,
+            )
             val source = Injekt.get<SourceManager>().getOrStub(manga.source)
 
             if (!manga.favorite) {
                 setMangaDefaultChapterFlags.await(manga)
             }
 
-            val shouldRefreshKomga = source.isKomgaSource()
+            val shouldRefreshKomga = source.isKomgaSource() &&
+                (
+                    !manga.initialized ||
+                        manga.lastUpdate <= 0L ||
+                        System.currentTimeMillis() - manga.lastUpdate >= KOMGA_DETAILS_REFRESH_INTERVAL_MS
+                    )
             val needRefreshInfo = !manga.initialized || shouldRefreshKomga
             val needRefreshChapter = chapters.isEmpty() || shouldRefreshKomga
 
@@ -241,12 +298,29 @@ class MangaScreenModel(
                     source = source,
                     isFromSource = isFromSource,
                     chapters = chapters,
-                    availableScanlators = getAvailableScanlators.await(mangaId),
-                    excludedScanlators = getExcludedScanlators.await(mangaId),
+                    availableScanlators = availableScanlatorsDeferred.await(),
+                    excludedScanlators = excludedScanlatorsDeferred.await(),
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters.get(),
                 )
+            }
+
+            launch {
+                val resolvedChapters = chapterModels.toChapterListItems(manga, epubProgresses)
+                    .associateBy { it.chapter.id }
+                updateSuccessState { current ->
+                    current.copy(
+                        chapters = current.chapters.map { item ->
+                            resolvedChapters[item.chapter.id]?.let { resolved ->
+                                item.copy(
+                                    downloadState = resolved.downloadState,
+                                    downloadProgress = resolved.downloadProgress,
+                                )
+                            } ?: item
+                        },
+                    )
+                }
             }
 
             // Start observe tracking since it only needs mangaId
@@ -264,6 +338,9 @@ class MangaScreenModel(
             // Initial loading finished
             updateSuccessState { it.copy(isRefreshingData = false) }
 
+            successState?.let { current ->
+                syncEpubProgressInBackground(source, current.chapters.map { it.chapter })
+            }
             syncKomgaProgressInBackground(source)
         }
     }
@@ -278,6 +355,58 @@ class MangaScreenModel(
             fetchFromSourceTasks.awaitAll()
             updateSuccessState { it.copy(isRefreshingData = false) }
             successState?.let { syncKomgaProgressInBackground(it.source) }
+            successState?.let { state ->
+                syncEpubProgressInBackground(
+                    source = state.source,
+                    chapters = state.chapters.map { it.chapter },
+                    force = manualFetch,
+                )
+            }
+        }
+    }
+
+    private fun syncEpubProgressInBackground(
+        source: Source,
+        chapters: List<Chapter>,
+        force: Boolean = false,
+    ) {
+        if (!source.isKomgaSource()) return
+        screenModelScope.launchIO {
+            if (!force) delay(EPUB_REMOTE_PROGRESS_DELAY_MS)
+            val remote = runCatching {
+                epubRemoteProgressCoordinator.syncManga(
+                    mangaId = mangaId,
+                    sourceId = source.id,
+                    chapters = chapters,
+                    force = force,
+                )
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to refresh EPUB remote progress for mangaId=$mangaId"
+                }
+            }.getOrDefault(emptyList()).associateBy { it.chapterId }
+            val local = getEpubProgress.awaitByMangaId(mangaId).associateBy { it.chapterId }
+            updateSuccessState { state ->
+                state.copy(
+                    chapters = state.chapters.map { item ->
+                        val localProgress = local[item.chapter.id]
+                        val remoteProgress = remote[item.chapter.id]
+                        val remoteModifiedAt = remoteProgress?.modifiedAt
+                        val progression = if (remoteModifiedAt != null &&
+                            (localProgress == null || remoteModifiedAt.time > localProgress.updatedAt.time)
+                        ) {
+                            remoteProgress.progression
+                        } else {
+                            localProgress?.progression
+                        }
+                        item.copy(
+                            epubProgressPercent = progression?.let {
+                                (it.coerceIn(0.0, 1.0) * 100).roundToInt()
+                            },
+                        )
+                    },
+                )
+            }
         }
     }
 
@@ -569,7 +698,8 @@ class MangaScreenModel(
 
     private fun List<Chapter>.toChapterListItems(
         manga: Manga,
-        epubProgresses: Map<Long, EpubProgress> = emptyMap(),
+        epubProgresses: Map<Long, Double> = emptyMap(),
+        allowSharedDownloadLookup: Boolean = true,
     ): List<ChapterList.Item> {
         return map { chapter ->
             val activeDownload = downloadManager.getQueuedDownloadOrNull(chapter.id)
@@ -579,6 +709,7 @@ class MangaScreenModel(
                 chapter.url,
                 manga.title,
                 manga.source,
+                allowSharedLookup = allowSharedDownloadLookup,
             )
             val downloadState = when {
                 activeDownload != null -> activeDownload.status
@@ -591,7 +722,6 @@ class MangaScreenModel(
                 downloadState = downloadState,
                 downloadProgress = activeDownload?.progress ?: 0,
                 epubProgressPercent = epubProgresses[chapter.id]
-                    ?.progression
                     ?.let { progression ->
                         (progression.coerceIn(0.0, 1.0) * 100)
                             .roundToInt()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -47,6 +47,8 @@ import eu.kanade.tachiyomi.util.system.toast
 import koharia.domain.chapter.interactor.FilterChaptersForDownload
 import koharia.domain.epub.interactor.GetEpubProgress
 import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.model.EpubRemoteProgressCache
 import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -99,6 +101,29 @@ import kotlin.math.roundToInt
 
 private const val KOMGA_DETAILS_REFRESH_INTERVAL_MS = 5 * 60 * 1_000L
 private const val EPUB_REMOTE_PROGRESS_DELAY_MS = 1_000L
+
+private fun mergeEpubProgressions(
+    localProgresses: List<EpubProgress>,
+    remoteProgresses: List<EpubRemoteProgressCache>,
+): Map<Long, Double> {
+    val localByChapter = localProgresses.associateBy(EpubProgress::chapterId)
+    val remoteByChapter = remoteProgresses.associateBy(EpubRemoteProgressCache::chapterId)
+    return (localByChapter.keys + remoteByChapter.keys)
+        .mapNotNull { chapterId ->
+            val local = localByChapter[chapterId]
+            val remote = remoteByChapter[chapterId]
+            val remoteModifiedAt = remote?.modifiedAt
+            val progression = if (remoteModifiedAt != null &&
+                (local == null || remoteModifiedAt.time > local.updatedAt.time)
+            ) {
+                remote.progression
+            } else {
+                local?.progression
+            }
+            progression?.let { chapterId to it }
+        }
+        .toMap()
+}
 
 class MangaScreenModel(
     private val context: Context,
@@ -184,22 +209,21 @@ class MangaScreenModel(
             combine(
                 getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
                 getEpubProgress.subscribeByMangaId(mangaId),
+                getEpubRemoteProgressCache.subscribeByMangaId(mangaId),
                 downloadCache.changes,
                 downloadManager.queueState,
-            ) { mangaAndChapters, epubProgresses, _, _ ->
-                mangaAndChapters to epubProgresses
+            ) { mangaAndChapters, localProgresses, remoteProgresses, _, _ ->
+                Triple(mangaAndChapters, localProgresses, remoteProgresses)
             }
                 .flowWithLifecycle(lifecycle)
-                .collectLatest { (mangaAndChapters, epubProgresses) ->
+                .collectLatest { (mangaAndChapters, localProgresses, remoteProgresses) ->
                     val (manga, chapters) = mangaAndChapters
                     updateSuccessState {
                         it.copy(
                             manga = manga,
                             chapters = chapters.toChapterListItems(
                                 manga,
-                                epubProgresses.mapNotNull { progress ->
-                                    progress.progression?.let { progress.chapterId to it }
-                                }.toMap(),
+                                mergeEpubProgressions(localProgresses, remoteProgresses),
                             ),
                         )
                     }
@@ -249,27 +273,10 @@ class MangaScreenModel(
             val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
 
             val manga = mangaDeferred.await()
-            val localEpubProgresses = localProgressDeferred.await()
-                .associateBy { it.chapterId }
-            val cachedRemoteProgresses = remoteProgressDeferred.await()
-                .associateBy { it.chapterId }
-            val epubProgresses = (localEpubProgresses.keys + cachedRemoteProgresses.keys)
-                .associateWith { chapterId ->
-                    val local = localEpubProgresses[chapterId]
-                    val remote = cachedRemoteProgresses[chapterId]
-                    val remoteModifiedAt = remote?.modifiedAt
-                    if (remoteModifiedAt != null &&
-                        (local == null || remoteModifiedAt.time > local.updatedAt.time)
-                    ) {
-                        remote.progression
-                    } else {
-                        local?.progression
-                    }
-                }
-                .mapNotNull { (chapterId, progression) ->
-                    progression?.let { chapterId to it }
-                }
-                .toMap()
+            val epubProgresses = mergeEpubProgressions(
+                localProgresses = localProgressDeferred.await(),
+                remoteProgresses = remoteProgressDeferred.await(),
+            )
             val chapterModels = chaptersDeferred.await()
             val chapters = chapterModels.toChapterListItems(
                 manga = manga,

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -84,7 +84,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val session = sessionRepository.get(chapterId)
+        val session = sessionRepository.getForPagination(chapterId)
         val firstMissingLink = session?.publication?.readingOrder?.firstOrNull { link ->
             pageCounts.keys.none { cachedHref -> cachedHref.isSameResourceHref(link.href.toString()) }
         } ?: session?.publication?.readingOrder?.firstOrNull()
@@ -204,7 +204,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
         )
     }
 
-    private fun readingOrder() = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+    private fun readingOrder() = sessionRepository.getForPagination(chapterId)?.publication?.readingOrder.orEmpty()
 
     private fun navigatorFragment(): EpubNavigatorFragment? {
         if (!isAdded) return null

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -75,12 +75,14 @@ import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.setComposeContent
+import koharia.epub.service.EpubReaderSupportResolution
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -116,12 +118,32 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         private const val READER_EDGE_PADDING_DP = 8
         private const val PAGINATION_SETTINGS_DEBOUNCE_MS = 250L
         private const val PAGINATION_VIEWPORT_DEBOUNCE_MS = 250L
+        private const val PROGRESSION_SEEK_DEBOUNCE_MS = 100L
 
-        fun newIntent(context: Context, mangaId: Long?, chapterId: Long?, sourceId: Long? = null): Intent {
+        fun newIntent(
+            context: Context,
+            mangaId: Long?,
+            chapterId: Long?,
+            sourceId: Long? = null,
+            resolution: EpubReaderSupportResolution? = null,
+        ): Intent {
             return Intent(context, EpubReaderActivity::class.java).apply {
                 putExtra("manga", mangaId)
                 putExtra("chapter", chapterId)
                 sourceId?.let { putExtra("source", it) }
+                resolution?.let {
+                    putExtra("epub_resolution_chapter", it.chapterId)
+                    putExtra("epub_resolution_source", it.sourceId)
+                    putExtra("epub_resolution_local_uri", it.localUri)
+                    putExtra("epub_resolution_remote_url", it.remoteBookUrl)
+                    putExtra("epub_resolution_open_source", it.preferredOpenSource?.name)
+                    putExtra("epub_resolution_publication_key", it.publicationKey)
+                    putExtra("epub_resolution_file_name", it.bookFileName)
+                    it.bookSizeBytes?.let { size -> putExtra("epub_resolution_file_size", size) }
+                    putExtra("epub_resolution_manual_download", it.isManualDownload)
+                    putExtra("epub_resolution_complete_cache", it.isCompleteCache)
+                    putExtra("epub_resolution_divina", it.isDivinaCompatible)
+                }
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             }
         }
@@ -169,6 +191,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private var paginationViewport: EpubPaginationViewport? = null
     private var paginationViewportJob: Job? = null
     private var paginationJob: Job? = null
+    private var progressionSeekJob: Job? = null
+    private var progressionSeekGeneration = 0L
     private var currentPublisherStyles: Boolean? = null
     private var readerFragment: EpubReaderFragment? = null
 
@@ -396,8 +420,29 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                                     }
                                 },
                                 onProgressionChange = { progression ->
-                                    viewModel.locatorAtProgression(progression)?.let { locator ->
-                                        epubReaderFragment()?.goTo(locator)
+                                    val generation = ++progressionSeekGeneration
+                                    progressionSeekJob?.cancel()
+                                    progressionSeekJob = lifecycleScope.launch {
+                                        delay(PROGRESSION_SEEK_DEBOUNCE_MS)
+                                        val locator = viewModel.locatorAtProgression(progression)
+                                        if (generation != progressionSeekGeneration) return@launch
+                                        if (locator == null) {
+                                            logcat(LogPriority.WARN) {
+                                                "EPUB progression seek unresolved generation=$generation " +
+                                                    "target=$progression"
+                                            }
+                                            viewModel.restoreCurrentProgressDisplay()
+                                            return@launch
+                                        }
+                                        viewModel.previewProgressionSeek(progression, locator)
+                                        val accepted = epubReaderFragment()?.goTo(locator) == true
+                                        logcat(LogPriority.DEBUG) {
+                                            "EPUB progression seek submitted generation=$generation " +
+                                                "target=$progression href=${locator.href} accepted=$accepted"
+                                        }
+                                        if (!accepted && generation == progressionSeekGeneration) {
+                                            viewModel.restoreCurrentProgressDisplay()
+                                        }
                                     }
                                 },
                                 onPreviousChapter = {
@@ -614,6 +659,45 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 )
             }
 
+            state.remoteProgressConflict?.let { conflict ->
+                AlertDialog(
+                    onDismissRequest = viewModel::dismissRemoteProgressConflict,
+                    title = { Text(stringResource(MR.strings.epub_reader_remote_progress_title)) },
+                    text = {
+                        Text(
+                            buildString {
+                                append(
+                                    stringResource(
+                                        MR.strings.epub_reader_remote_progress_message,
+                                        conflict.progressionPercent ?: 0,
+                                    ),
+                                )
+                                conflict.sectionTitle?.takeIf { it.isNotBlank() }?.let {
+                                    append("\n")
+                                    append(it)
+                                }
+                            },
+                        )
+                    },
+                    dismissButton = {
+                        TextButton(onClick = viewModel::dismissRemoteProgressConflict) {
+                            Text(stringResource(MR.strings.epub_reader_keep_local_progress))
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(
+                            onClick = {
+                                viewModel.acceptRemoteProgress()?.let { locator ->
+                                    epubReaderFragment()?.goTo(locator)
+                                }
+                            },
+                        ) {
+                            Text(stringResource(MR.strings.epub_reader_jump_remote_progress))
+                        }
+                    },
+                )
+            }
+
             if (showBookInfoDialog) {
                 EpubBookInfoDialog(
                     state = state,
@@ -664,12 +748,26 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             .distinctUntilChanged()
             .onEach(::updateSystemBars)
             .launchIn(lifecycleScope)
+
+        viewModel.state
+            .map { it.paginationSourceVersion }
+            .distinctUntilChanged()
+            .drop(1)
+            .onEach {
+                if (viewModel.state.value.isReady) {
+                    epubReaderFragment()?.stopPagination()
+                    applyCurrentReadiumPreferences()
+                }
+            }
+            .launchIn(lifecycleScope)
     }
 
     override fun onPause() {
         isReaderResumed = false
         paginationViewportJob?.cancel()
         paginationJob?.cancel()
+        progressionSeekGeneration += 1
+        progressionSeekJob?.cancel()
         epubReaderFragment()?.stopPagination()
         lifecycleScope.launchNonCancellable {
             viewModel.saveCurrentProgress()
@@ -757,6 +855,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
+        viewModel.onFirstContentDisplayed()
         viewModel.updateVisualPage(pageIndex, totalPages, locator)
     }
 
@@ -919,6 +1018,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                     "EPUB pagination settings changed values=$values phase=${state.paginationPhase} " +
                         "pages=${state.currentVisualPage}/${state.totalVisualPages}"
                 }
+                viewModel.onLayoutPreferencesChanged()
                 paginationJob?.cancel()
                 viewModel.invalidatePaginationDisplay()
                 epubReaderFragment()?.stopPagination()
@@ -983,7 +1083,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             viewModel.setPublisherStylesOverride(enabled)
         }
         lifecycleScope.launch {
-            viewModel.init(state.mangaId, state.chapterId)
+            viewModel.init(
+                mangaId = state.mangaId,
+                chapterId = state.chapterId,
+                preserveLocalProgressAfterLayoutChange = true,
+            )
         }
     }
 

--- a/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.Intent
 import eu.kanade.tachiyomi.ui.reader.ReaderActivity
 import koharia.epub.service.EpubReaderSupportResolver
-import koharia.epub.settings.EpubReaderPreferences
-import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import logcat.LogPriority
@@ -17,9 +15,7 @@ import uy.kohesive.injekt.api.get
 
 class EpubReaderLauncher @JvmOverloads constructor(
     private val supportResolver: EpubReaderSupportResolver = Injekt.get(),
-    private val epubReaderPreferences: EpubReaderPreferences = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
-    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) {
 
     fun launch(
@@ -50,32 +46,27 @@ class EpubReaderLauncher @JvmOverloads constructor(
         chapterId: Long,
         forcePages: Boolean = false,
     ): Intent {
-        val sourceId = withIOContext { getManga.await(mangaId)?.source }
-        val scopedPreferences = sourceId
-            ?.takeIf { it > 0L }
-            ?.let(scopedPreferenceStoreFactory::epubReaderPreferences)
-            ?: epubReaderPreferences
-
         if (forcePages) {
+            val sourceId = withIOContext { getManga.await(mangaId)?.source }
             return ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
         }
 
         return withIOContext {
             runCatching {
-                if (supportResolver.resolve(
-                        mangaId = mangaId,
-                        chapterId = chapterId,
-                        preferLocalFile = scopedPreferences.preferLocalFile.get(),
-                    ).isNativeSupported
-                ) {
-                    EpubReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
+                val resolution = supportResolver.resolve(
+                    mangaId = mangaId,
+                    chapterId = chapterId,
+                )
+                if (resolution.isNativeSupported) {
+                    EpubReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId, resolution)
                 } else {
-                    ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
+                    ReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId)
                 }
             }.getOrElse { error ->
                 logcat(LogPriority.WARN, error) {
                     "EpubReaderLauncher failed to resolve reader type for chapterId=$chapterId"
                 }
+                val sourceId = getManga.await(mangaId)?.source
                 ReaderActivity.newIntent(context, mangaId, chapterId, sourceId)
             }
         }

--- a/app/src/main/java/koharia/epub/EpubReaderUiState.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderUiState.kt
@@ -27,6 +27,7 @@ data class EpubReaderUiState(
     val totalVisualPages: Int? = null,
     val paginationPhase: EpubPaginationPhase = EpubPaginationPhase.CALCULATING,
     val paginationGeneration: Long = 0,
+    val paginationSourceVersion: Long = 0,
     val sessionToken: Long = 0,
     val isLoading: Boolean = false,
     val isReady: Boolean = false,
@@ -43,4 +44,13 @@ data class EpubReaderUiState(
     val searchResults: List<EpubSearchResult> = emptyList(),
     val isSearchLoading: Boolean = false,
     val searchErrorMessage: String? = null,
+    val remoteProgressConflict: EpubRemoteProgressConflict? = null,
+)
+
+@Immutable
+data class EpubRemoteProgressConflict(
+    val locatorJson: String,
+    val progressionPercent: Int?,
+    val sectionTitle: String?,
+    val modifiedAtMillis: Long,
 )

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -17,17 +17,22 @@ import koharia.domain.epub.interactor.UpsertEpubProgress
 import koharia.domain.epub.model.EpubBookmark
 import koharia.domain.epub.model.EpubPaginationCache
 import koharia.domain.epub.model.EpubProgress
+import koharia.epub.cache.EpubCacheManager
+import koharia.epub.cache.EpubCachePolicy
+import koharia.epub.cache.EpubCachePreferences
 import koharia.epub.locator.toPersistentLocator
 import koharia.epub.model.EpubOpenRequest
 import koharia.epub.model.EpubSearchResult
 import koharia.epub.model.EpubTocEntry
 import koharia.epub.progress.KomgaEpubProgressSyncService
+import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
 import koharia.epub.service.EpubPublicationResolver
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.epub.settings.EpubSessionPreferenceStore
 import koharia.komga.api.dto.isDivinaCompatibleEpub
 import koharia.komga.api.dto.isEpub
+import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CoroutineScope
@@ -50,6 +55,7 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Layout
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.services.locateProgression
 import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.publication.services.search.SearchIterator
 import org.readium.r2.shared.publication.services.search.isSearchable
@@ -73,6 +79,7 @@ import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.io.File
 import java.util.Date
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -98,6 +105,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private val getEpubPaginationCache: GetEpubPaginationCache = Injekt.get(),
     private val upsertEpubPaginationCache: UpsertEpubPaginationCache = Injekt.get(),
     private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
+    private val epubRemoteProgressCoordinator: KomgaEpubRemoteProgressCoordinator = Injekt.get(),
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
+    private val epubCachePreferences: EpubCachePreferences = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val upsertHistory: UpsertHistory = Injekt.get(),
     private val getEpubBookmarks: GetEpubBookmarks = Injekt.get(),
@@ -166,6 +176,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var paginationLayoutJson: String? = null
     private var isRtlLayout = false
     private var currentPublicationKey: String? = null
+    private var leasedCacheFile: File? = null
+    private var leasedPublicationKey: String? = null
+    private var completeCacheStarted = false
+    private var positionsRefreshStarted = false
+    private var lastPrefetchedHref: String? = null
+    private var remoteProgressChecked = false
+    private var layoutChangeRevision = 0L
+    private var preserveLocalProgressAfterLayoutChange = false
+    private var currentChapter: tachiyomi.domain.chapter.model.Chapter? = null
     private var currentChapterUrl: String? = null
     private var currentChapterRead = false
     private var currentChapterBookmark = false
@@ -207,7 +226,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
     suspend fun init(
         mangaId: Long,
         chapterId: Long,
+        preserveLocalProgressAfterLayoutChange: Boolean = false,
     ): Result<Unit> {
+        releaseCacheLeases()
+        completeCacheStarted = false
+        positionsRefreshStarted = false
+        lastPrefetchedHref = null
+        layoutChangeRevision += 1
+        this.preserveLocalProgressAfterLayoutChange = preserveLocalProgressAfterLayoutChange
+        remoteProgressChecked = preserveLocalProgressAfterLayoutChange
         this.mangaId = mangaId
         this.chapterId = chapterId
         mutableState.update {
@@ -229,6 +256,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
             runCatching {
                 val manga = checkNotNull(getManga.await(mangaId)) { "Manga not found" }
                 val chapter = checkNotNull(getChapter.await(chapterId)) { "Chapter not found" }
+                currentChapter = chapter
                 val source = sourceManager.get(manga.source) as? KomgaSource
                     ?: error(application.stringResource(MR.strings.source_unsupported))
 
@@ -251,42 +279,100 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 val nextBookChapterId = chapterIndex.takeIf { it >= 0 }
                     ?.let { chapters.getOrNull(it + 1)?.id }
 
-                val localFile = downloadProvider.findChapterDir(
-                    chapterName = chapter.name,
-                    chapterScanlator = chapter.scanlator,
-                    chapterUrl = chapter.url,
-                    mangaTitle = manga.title,
-                    source = source,
-                )
-                val localUri = localFile
+                val hasLauncherResolution =
+                    savedState.get<Long>("epub_resolution_chapter") == chapter.id &&
+                        savedState.get<Long>("epub_resolution_source") == source.id
+                val resolvedLocalUri = savedState.get<String>("epub_resolution_local_uri")
+                val resolvedRemoteBookUrl = savedState.get<String>("epub_resolution_remote_url")
+                val resolvedOpenSource = savedState.get<String>("epub_resolution_open_source")
+                    ?.let { value -> runCatching { EpubOpenRequest.OpenSource.valueOf(value) }.getOrNull() }
+                val resolvedPublicationKey = savedState.get<String>("epub_resolution_publication_key")
+                val resolvedCompleteCache =
+                    savedState.get<Boolean>("epub_resolution_complete_cache") == true
+
+                val downloadedFile = if (hasLauncherResolution) {
+                    null
+                } else {
+                    downloadProvider.findChapterDir(
+                        chapterName = chapter.name,
+                        chapterScanlator = chapter.scanlator,
+                        chapterUrl = chapter.url,
+                        mangaTitle = manga.title,
+                        source = source,
+                    )
+                }
+                val downloadedUri = downloadedFile
                     ?.takeIf { it.extension.equals("epub", ignoreCase = true) }
                     ?.uri
                     ?.toString()
 
-                val bookDetails = runCatching { source.getBookDetails(chapter.url) }
-                    .getOrNull()
-                    ?.takeIf { it.isEpub }
-                val remoteBookUrl = bookDetails
-                    ?.let { chapter.url.substringBefore('#').removeSuffix("/") }
-                val canOpenAsPages = bookDetails?.media?.let { media ->
-                    media.isDivinaCompatibleEpub && media.pagesCount > 0
-                } == true
+                val memoFingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
+                val memoIsEpub = KomgaChapterMemo.isEpub(chapter.memo)
+                val memoBookUrl = memoFingerprint?.bookUrl
+                    ?: chapter.url.substringBefore('#').removeSuffix("/")
+                val remotePublicationKey = EpubCachePolicy.publicationKey(
+                    fileHash = memoFingerprint?.fileHash,
+                    fileLastModified = KomgaChapterMemo.fileLastModified(chapter.memo),
+                    sizeBytes = memoFingerprint?.sizeBytes ?: 0L,
+                    fallback = "book:${chapter.id}:${chapter.url}",
+                )
+                val cachedBookFile = epubCacheManager.completeBookFile(source.id, remotePublicationKey)
+                val cachedBookUri = cachedBookFile?.toURI()?.toString()
+                val reusableResolvedLocalUri = resolvedLocalUri
+                    .takeUnless { resolvedCompleteCache && cachedBookFile == null }
+                val preferredLocalUri = reusableResolvedLocalUri ?: downloadedUri ?: cachedBookUri
+                val needsRemoteDetails = !hasLauncherResolution &&
+                    (preferredLocalUri == null || memoIsEpub == null)
+                val bookDetails = if (needsRemoteDetails) {
+                    runCatching { source.getBookDetails(chapter.url) }
+                        .getOrNull()
+                        ?.takeIf { it.isEpub }
+                } else {
+                    null
+                }
+                val remoteBookUrl = when {
+                    hasLauncherResolution -> resolvedRemoteBookUrl
+                    bookDetails != null -> chapter.url.substringBefore('#').removeSuffix("/")
+                    memoIsEpub == true || preferredLocalUri != null -> memoBookUrl
+                    else -> null
+                }
+                val canOpenAsPages = if (hasLauncherResolution) {
+                    savedState.get<Boolean>("epub_resolution_divina") == true
+                } else {
+                    bookDetails?.media?.let { media ->
+                        media.isDivinaCompatibleEpub && media.pagesCount > 0
+                    } == true
+                }
 
-                check(localUri != null || remoteBookUrl != null) {
+                check(preferredLocalUri != null || remoteBookUrl != null) {
                     application.stringResource(MR.strings.epub_reader_unsupported_book)
                 }
 
                 val primarySource = when {
-                    epubReaderPreferences.preferLocalFile.get() && localUri != null ->
+                    hasLauncherResolution && resolvedOpenSource == EpubOpenRequest.OpenSource.LOCAL &&
+                        preferredLocalUri != null -> EpubOpenRequest.OpenSource.LOCAL
+                    hasLauncherResolution && resolvedOpenSource == EpubOpenRequest.OpenSource.REMOTE &&
+                        remoteBookUrl != null -> EpubOpenRequest.OpenSource.REMOTE
+                    preferredLocalUri != null ->
                         EpubOpenRequest.OpenSource.LOCAL
                     remoteBookUrl != null ->
                         EpubOpenRequest.OpenSource.REMOTE
                     else ->
                         EpubOpenRequest.OpenSource.LOCAL
                 }
-                val bookFileName = localFile?.name ?: bookDetails?.name
-                val bookSizeBytes = localFile?.length()?.takeIf { size -> size > 0L }
+                val localUri = preferredLocalUri
+                val bookFileName = savedState.get<String>("epub_resolution_file_name")
+                    ?.takeIf { hasLauncherResolution }
+                    ?: downloadedFile?.name
+                    ?: cachedBookFile?.name
+                    ?: bookDetails?.name
+                    ?: KomgaChapterMemo.fileName(chapter.memo)
+                val bookSizeBytes = savedState.get<Long>("epub_resolution_file_size")
+                    ?.takeIf { hasLauncherResolution && it > 0L }
+                    ?: downloadedFile?.length()?.takeIf { size -> size > 0L }
+                    ?: cachedBookFile?.length()?.takeIf { size -> size > 0L }
                     ?: bookDetails?.sizeBytes?.takeIf { size -> size > 0L }
+                    ?: memoFingerprint?.sizeBytes?.takeIf { size -> size > 0L }
                 mutableState.update {
                     it.copy(
                         mangaTitle = manga.title,
@@ -304,13 +390,25 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
                 currentBookUrl = remoteBookUrl
                 currentPublicationKey = when {
-                    primarySource == EpubOpenRequest.OpenSource.LOCAL && localFile != null ->
-                        "local:$localUri:${localFile.lastModified()}:${localFile.length()}"
+                    hasLauncherResolution && !resolvedPublicationKey.isNullOrBlank() -> resolvedPublicationKey
+                    primarySource == EpubOpenRequest.OpenSource.LOCAL && downloadedFile != null ->
+                        "local:$localUri:${downloadedFile.lastModified()}:${downloadedFile.length()}"
+                    primarySource == EpubOpenRequest.OpenSource.LOCAL && cachedBookFile != null ->
+                        remotePublicationKey
                     primarySource == EpubOpenRequest.OpenSource.LOCAL ->
                         "local:$localUri"
                     !bookDetails?.fileHash.isNullOrBlank() -> "komga:${bookDetails.fileHash}"
-                    bookDetails != null -> "komga:${bookDetails.fileLastModified}:${bookDetails.sizeBytes}"
-                    else -> "book:${chapter.id}:${chapter.url}"
+                    bookDetails != null && bookDetails.fileLastModified.isNotBlank() ->
+                        "komga:${bookDetails.fileLastModified}:${bookDetails.sizeBytes}"
+                    else -> remotePublicationKey
+                }
+                epubCacheManager.acquirePublication(source.id, checkNotNull(currentPublicationKey))
+                leasedPublicationKey = currentPublicationKey
+                cachedBookFile?.takeIf {
+                    primarySource == EpubOpenRequest.OpenSource.LOCAL && localUri == cachedBookUri
+                }?.let {
+                    epubCacheManager.acquire(it)
+                    leasedCacheFile = it
                 }
 
                 val incognito = isIncognito()
@@ -325,25 +423,38 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         }
                         .getOrNull()
                 }
-                val remotePull = if (incognito || remoteBookUrl == null ||
+                val remoteCache = if (incognito || remoteBookUrl == null ||
                     !epubReaderPreferences.syncProgressionToKomga.get()
                 ) {
                     null
                 } else {
-                    runCatching { komgaEpubProgressSyncService.pullProgression(source.id, remoteBookUrl) }
+                    runCatching { epubRemoteProgressCoordinator.get(chapter.id) }
                         .onFailure { error ->
                             logcat(LogPriority.WARN, error) {
-                                "Failed to pull Komga EPUB progression for chapterId=${chapter.id}"
+                                "Failed to load cached Komga EPUB progression for chapterId=${chapter.id}"
                             }
                         }
                         .getOrNull()
                 }
-                val remoteProgress = remotePull?.progression
-                val serverTimeOffsetMinutes = remotePull?.serverDate?.serverTimeOffsetMinutes()
+                val remoteProgress = remoteCache?.let { cache ->
+                    val locator = cache.locatorJson
+                        ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
+                    val modifiedAt = cache.modifiedAt
+                    if (locator != null && modifiedAt != null) {
+                        KomgaEpubProgressSyncService.RemoteProgression(locator, modifiedAt)
+                    } else {
+                        null
+                    }
+                }
+                val serverTimeOffsetMinutes = remoteCache?.serverDate?.serverTimeOffsetMinutes()
                 val persistedLocator = localProgress?.toLocatorOrNull()
                 val savedStateLocator = restoreLocator()
                 val initialLocator = savedStateLocator
-                    ?: chooseMoreRecentLocator(localProgress, remoteProgress)
+                    ?: if (preserveLocalProgressAfterLayoutChange) {
+                        persistedLocator
+                    } else {
+                        chooseMoreRecentLocator(localProgress, remoteProgress)
+                    }
 
                 logcat(LogPriority.DEBUG) {
                     "EPUB progress restore chapterId=${chapter.id} " +
@@ -370,18 +481,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         localUri = localUri,
                         openSource = primarySource,
                         publisherStylesOverride = publisherStylesOverride,
+                        publicationKey = checkNotNull(currentPublicationKey),
+                        persistCache = !incognito,
                     ),
                     initialLocator = initialLocator,
                 )
                 sessionRepository.put(session)
-                publicationPositions = session.publication.positions()
-                publicationPositionByHref = buildMap {
-                    publicationPositions.forEachIndexed { index, locator ->
-                        locator.href.toString().hrefCandidates().forEach { href ->
-                            putIfAbsent(href, index + 1)
-                        }
-                    }
-                }
+                applyPublicationPositions(session.positionsController.currentPositions())
                 resetVisualPagination()
                 val initialPosition = initialLocator.positionIn(publicationPositions)
                 val initialProgression = initialLocator?.totalProgressionValue()
@@ -441,7 +547,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     )
                 }
 
-                if (!incognito) {
+                if (!incognito && !preserveLocalProgressAfterLayoutChange) {
                     val selectedRemote = remoteProgress?.takeIf {
                         localProgress == null || it.modifiedAt.time > localProgress.updatedAt.time
                     }
@@ -501,12 +607,14 @@ class EpubReaderViewModel @JvmOverloads constructor(
             ?.publication
             ?.toPersistentLocator(locator)
             ?: locator
+        val visualPagePair = visualPagePairForLocator(persistentLocator)
+        visualPagePair?.first?.let { visualPageNumber = it }
         latestLocator = persistentLocator
         val newLocatorJson = persistentLocator.toJSON().toString()
         locatorJson = newLocatorJson
         logcat(LogPriority.DEBUG) {
             "EPUB locator update chapterId=$chapterId navigatorHref=${locator.href} " +
-                persistentLocator.debugProgress()
+                "${persistentLocator.debugProgress()} visual=${visualPagePair?.first}/${visualPagePair?.second}"
         }
         mutableState.update {
             it.copy(
@@ -516,6 +624,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     ?: persistentLocator.positionIn(publicationPositions).toProgression(publicationPositions.size),
                 progressionPercent = persistentLocator.progressionPercent(),
                 currentPosition = persistentLocator.positionIn(publicationPositions),
+                currentVisualPage = visualPagePair?.first ?: it.currentVisualPage,
+                totalVisualPages = visualPagePair?.second ?: it.totalVisualPages,
+                paginationPhase = if (visualPagePair != null) {
+                    EpubPaginationPhase.READY
+                } else {
+                    it.paginationPhase
+                },
                 currentBookmarkId = findBookmarkForLocator(it.bookmarks, persistentLocator)?.id,
             )
         }
@@ -532,7 +647,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         lastVisualPageIndex = pageIndex
         lastVisualTotalPages = totalPages
 
-        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        val readingOrder = paginationReadingOrder()
         val exactPage = exactVisualPage(href, pageIndex, readingOrder, bookVisualPageCounts)
         val exactTotalPages = bookVisualPageCounts.values.sum()
             .takeIf { bookVisualPageCounts.size == readingOrder.size && it > 0 }
@@ -540,8 +655,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
             val currentPage = exactPage.coerceIn(1, exactTotalPages)
             visualPageNumber = currentPage
             val previousState = mutableState.value
-            if (previousState.paginationPhase != EpubPaginationPhase.READY ||
-                previousState.totalVisualPages != exactTotalPages
+            if (previousState.currentVisualPage != currentPage ||
+                previousState.totalVisualPages != exactTotalPages ||
+                previousState.paginationPhase != EpubPaginationPhase.READY
             ) {
                 logcat(LogPriority.DEBUG) {
                     "EPUB pagination visual page resolved chapterId=$chapterId " +
@@ -559,6 +675,166 @@ class EpubReaderViewModel @JvmOverloads constructor(
             }
             return
         }
+    }
+
+    fun onFirstContentDisplayed() {
+        refreshRemoteProgressAfterDisplay()
+        refreshPositionsAfterDisplay()
+        prefetchNextResourceIfNeeded()
+        if (completeCacheStarted || isIncognito() || state.value.isUsingLocalFile) return
+        if (!epubCachePreferences.cacheWholeBook.get()) return
+        val source = sourceManager.get(currentSourceId) as? KomgaSource ?: return
+        val bookUrl = currentBookUrl ?: return
+        val publicationKey = currentPublicationKey ?: return
+        val requestedChapterId = chapterId
+        completeCacheStarted = true
+        viewModelScope.launch {
+            val cachedFile = epubCacheManager.cacheCompleteBook(
+                source = source,
+                bookUrl = bookUrl,
+                publicationKey = publicationKey,
+                acquireLease = true,
+            ) ?: return@launch
+            if (chapterId != requestedChapterId || currentPublicationKey != publicationKey) {
+                epubCacheManager.release(cachedFile)
+                return@launch
+            }
+            val cachedUri = cachedFile.toURI().toString()
+            runCatching {
+                withIOContext {
+                    publicationResolver.open(
+                        request = EpubOpenRequest(
+                            mangaId = mangaId,
+                            chapterId = chapterId,
+                            sourceId = currentSourceId,
+                            title = mutableState.value.chapterTitle.orEmpty(),
+                            bookUrl = bookUrl,
+                            localUri = cachedUri,
+                            openSource = EpubOpenRequest.OpenSource.LOCAL,
+                            publisherStylesOverride = publisherStylesOverride,
+                            publicationKey = publicationKey,
+                            persistCache = !isIncognito(),
+                        ),
+                        initialLocator = null,
+                    )
+                }
+            }.onSuccess { paginationSession ->
+                if (chapterId != requestedChapterId || currentPublicationKey != publicationKey) {
+                    paginationSession.close()
+                    epubCacheManager.release(cachedFile)
+                    return@onSuccess
+                }
+                sessionRepository.putForPagination(paginationSession)
+                leasedCacheFile?.let(epubCacheManager::release)
+                leasedCacheFile = cachedFile
+                invalidatePaginationDisplay()
+                mutableState.update {
+                    it.copy(
+                        localEpubUri = cachedUri,
+                        bookSizeBytes = cachedFile.length(),
+                        paginationSourceVersion = it.paginationSourceVersion + 1,
+                    )
+                }
+            }.onFailure { error ->
+                epubCacheManager.release(cachedFile)
+                logcat(LogPriority.WARN, error) {
+                    "Failed to open cached EPUB for local pagination chapterId=$chapterId"
+                }
+            }
+        }
+    }
+
+    private fun refreshPositionsAfterDisplay() {
+        if (positionsRefreshStarted) return
+        val session = sessionRepository.get(chapterId) ?: return
+        positionsRefreshStarted = true
+        viewModelScope.launch {
+            runCatching { session.positionsController.refresh() }
+                .onSuccess(::applyPublicationPositions)
+                .onFailure { error ->
+                    logcat(LogPriority.WARN, error) {
+                        "Failed to refresh EPUB positions for chapterId=$chapterId"
+                    }
+                }
+        }
+    }
+
+    private fun prefetchNextResourceIfNeeded() {
+        if (isIncognito() || state.value.isUsingLocalFile || epubCachePreferences.cacheWholeBook.get()) return
+        val session = sessionRepository.get(chapterId) ?: return
+        val href = latestLocator?.href?.toString()?.normalizedResourceHref().orEmpty()
+        if (lastPrefetchedHref == href) return
+        lastPrefetchedHref = href
+        viewModelScope.launch {
+            runCatching { session.prefetchNextResource(latestLocator) }
+                .onFailure { error ->
+                    logcat(LogPriority.WARN, error) {
+                        "Failed to prefetch next EPUB resource chapterId=$chapterId href=$href"
+                    }
+                }
+        }
+    }
+
+    private fun refreshRemoteProgressAfterDisplay() {
+        if (remoteProgressChecked || isIncognito() || !epubReaderPreferences.syncProgressionToKomga.get()) return
+        val chapter = currentChapter ?: return
+        val sourceId = currentSourceId.takeIf { it > 0L } ?: return
+        val checkLayoutRevision = layoutChangeRevision
+        remoteProgressChecked = true
+        viewModelScope.launch {
+            val remote = runCatching {
+                epubRemoteProgressCoordinator.refreshChapter(mangaId, chapter, sourceId)
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to refresh EPUB remote progress for chapterId=$chapterId"
+                }
+            }.getOrNull() ?: return@launch
+            val locator = remote.locatorJson
+                ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
+                ?: return@launch
+            val modifiedAt = remote.modifiedAt ?: return@launch
+            if (preserveLocalProgressAfterLayoutChange || checkLayoutRevision != layoutChangeRevision) {
+                logcat(LogPriority.DEBUG) {
+                    "Ignoring EPUB remote progress conflict after local layout change " +
+                        "chapterId=$chapterId remoteModified=${modifiedAt.time}"
+                }
+                return@launch
+            }
+            if (locator.isSamePaginationLocation(latestLocator)) return@launch
+            mutableState.update {
+                it.copy(
+                    serverTimeOffsetMinutes = remote.serverDate?.serverTimeOffsetMinutes(),
+                    remoteProgressConflict = EpubRemoteProgressConflict(
+                        locatorJson = locator.toJSON().toString(),
+                        progressionPercent = locator.progressionPercent(),
+                        sectionTitle = locator.title,
+                        modifiedAtMillis = modifiedAt.time,
+                    ),
+                )
+            }
+        }
+    }
+
+    fun onLayoutPreferencesChanged() {
+        layoutChangeRevision += 1
+        preserveLocalProgressAfterLayoutChange = true
+        remoteProgressChecked = true
+        mutableState.update { state ->
+            state.copy(remoteProgressConflict = null)
+        }
+        logcat(LogPriority.DEBUG) {
+            "Keeping local EPUB progress after layout change chapterId=$chapterId revision=$layoutChangeRevision"
+        }
+    }
+
+    fun acceptRemoteProgress(): Locator? {
+        val conflict = mutableState.value.remoteProgressConflict ?: return null
+        mutableState.update { it.copy(remoteProgressConflict = null) }
+        return runCatching { Locator.fromJSON(JSONObject(conflict.locatorJson)) }.getOrNull()
+    }
+
+    fun dismissRemoteProgressConflict() {
+        mutableState.update { it.copy(remoteProgressConflict = null) }
     }
 
     fun invalidatePaginationDisplay() {
@@ -593,7 +869,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
         lastVisualTotalPages = null
 
         val publicationKey = currentPublicationKey ?: "chapter:$chapterId"
-        val publication = sessionRepository.get(chapterId)?.publication
+        val publication = sessionRepository.getForPagination(chapterId)?.publication
+        val hasLocalPaginationSource = mutableState.value.isUsingLocalFile ||
+            sessionRepository.hasDedicatedPaginationSession(chapterId)
         if (publication?.metadata?.layout == Layout.FIXED) {
             val fixedCounts = publication.readingOrder.associate { link ->
                 link.href.toString().normalizedResourceHref() to 1
@@ -646,7 +924,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         } else {
             getEpubPaginationCache.await(chapterId, publicationKey, snapshot.key)
         }
-        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        val readingOrder = publication?.readingOrder.orEmpty()
         val cachedCounts = cache?.resourcePageCountsJson
             ?.toPageCounts()
             ?.orderedFor(readingOrder)
@@ -680,13 +958,34 @@ class EpubReaderViewModel @JvmOverloads constructor(
             )
         }
 
+        if (!hasLocalPaginationSource && !isComplete) {
+            bookVisualPageCounts = emptyMap()
+            visualPageNumber = null
+            mutableState.update {
+                it.copy(
+                    currentVisualPage = null,
+                    totalVisualPages = null,
+                    paginationPhase = EpubPaginationPhase.UNAVAILABLE,
+                    paginationGeneration = generation,
+                )
+            }
+            return EpubPaginationRequest(
+                generation = generation,
+                publicationKey = publicationKey,
+                layoutKey = snapshot.key,
+                layoutSnapshotJson = snapshot.json,
+                initialPageCounts = emptyMap(),
+                shouldScan = false,
+            )
+        }
+
         return EpubPaginationRequest(
             generation = generation,
             publicationKey = publicationKey,
             layoutKey = snapshot.key,
             layoutSnapshotJson = snapshot.json,
             initialPageCounts = cachedCounts,
-            shouldScan = !isComplete,
+            shouldScan = hasLocalPaginationSource && !isComplete,
         )
     }
 
@@ -696,7 +995,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         isComplete: Boolean,
     ) {
         if (generation != paginationGeneration) return
-        val readingOrder = sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+        val readingOrder = sessionRepository.getForPagination(chapterId)?.publication?.readingOrder.orEmpty()
         if (readingOrder.isEmpty()) return
         val orderedCounts = pageCounts.orderedFor(readingOrder)
         bookVisualPageCounts = orderedCounts
@@ -710,6 +1009,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
             ?: latestLocator?.href?.toString()?.normalizedResourceHref()
         val currentPage = lastVisualPageIndex
             ?.let { exactVisualPage(href, it, readingOrder, orderedCounts) }
+            ?: pageFromLocator(latestLocator, readingOrder, orderedCounts)
         val coercedCurrentPage = currentPage?.coerceIn(1, totalPages)
         logcat(LogPriority.DEBUG) {
             "EPUB pagination scan complete chapterId=$chapterId generation=$generation " +
@@ -756,9 +1056,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         locator ?: return null
         if (pageCounts.size != readingOrder.size) return null
         val href = locator.href.toString().normalizedResourceHref()
-        val resourcePages = pageCounts.entries.firstOrNull { (candidate, _) ->
-            href.isSameResourceHref(candidate)
-        }?.value ?: return null
+        val resourcePages = pageCounts.pageCountFor(href) ?: return null
         val progression = (locator.locations.progression as? Number)?.toDouble() ?: 0.0
         var pageIndex = (progression * resourcePages).roundToInt().coerceIn(0, resourcePages - 1)
         if (isRtlLayout && pageIndex > 0) pageIndex -= 1
@@ -776,13 +1074,39 @@ class EpubReaderViewModel @JvmOverloads constructor(
         var pagesBefore = 0
         for (link in readingOrder) {
             val resourceHref = link.href.toString().normalizedResourceHref()
-            val resourcePages = pageCounts[resourceHref] ?: return null
+            val resourcePages = pageCounts.pageCountFor(resourceHref) ?: return null
             if (resourceHref.isSameResourceHref(href)) {
                 return pagesBefore + (pageIndex + 1).coerceIn(1, resourcePages)
             }
             pagesBefore += resourcePages
         }
         return null
+    }
+
+    private fun Map<String, Int>.pageCountFor(href: String): Int? {
+        return entries.firstOrNull { (candidate, count) ->
+            count > 0 && candidate.isSameResourceHref(href)
+        }?.value
+    }
+
+    private fun paginationReadingOrder(): List<Link> {
+        return sessionRepository.getForPagination(chapterId)
+            ?.publication
+            ?.readingOrder
+            .orEmpty()
+            .ifEmpty {
+                sessionRepository.get(chapterId)?.publication?.readingOrder.orEmpty()
+            }
+    }
+
+    private fun visualPagePairForLocator(locator: Locator): Pair<Int, Int>? {
+        val readingOrder = paginationReadingOrder()
+        if (readingOrder.isEmpty() || bookVisualPageCounts.size != readingOrder.size) return null
+        val totalPages = bookVisualPageCounts.values.sum().takeIf { it > 0 } ?: return null
+        val currentPage = pageFromLocator(locator, readingOrder, bookVisualPageCounts)
+            ?.coerceIn(1, totalPages)
+            ?: return null
+        return currentPage to totalPages
     }
 
     private fun resetVisualPagination() {
@@ -802,11 +1126,84 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun locatorAtPosition(index: Int): Locator? = publicationPositions.getOrNull(index)
 
-    fun locatorAtProgression(progression: Double): Locator? {
+    suspend fun locatorAtProgression(progression: Double): Locator? {
+        val target = progression.coerceIn(0.0, 1.0)
+        sessionRepository.get(chapterId)
+            ?.publication
+            ?.locateProgression(target)
+            ?.let { locator ->
+                logcat(LogPriority.DEBUG) {
+                    "EPUB progression locate chapterId=$chapterId target=$target " + locator.debugProgress()
+                }
+                return locator
+            }
         if (publicationPositions.isEmpty()) return null
-        val index = (progression.coerceIn(0.0, 1.0) * (publicationPositions.size - 1))
+        val index = (target * (publicationPositions.size - 1))
             .roundToInt()
-        return publicationPositions.getOrNull(index)
+        return publicationPositions.getOrNull(index)?.also { locator ->
+            logcat(LogPriority.DEBUG) {
+                "EPUB progression locate fallback chapterId=$chapterId target=$target index=$index " +
+                    locator.debugProgress()
+            }
+        }
+    }
+
+    fun previewProgressionSeek(requestedProgression: Double, locator: Locator) {
+        val persistentLocator = sessionRepository.get(chapterId)
+            ?.publication
+            ?.toPersistentLocator(locator)
+            ?: locator
+        val progression = persistentLocator.totalProgressionValue()
+            ?: requestedProgression.coerceIn(0.0, 1.0)
+        val visualPagePair = visualPagePairForLocator(persistentLocator)
+        visualPagePair?.first?.let { visualPageNumber = it }
+        mutableState.update {
+            it.copy(
+                progression = progression,
+                progressionPercent = (progression * 100).roundToInt().coerceIn(0, 100),
+                currentPosition = persistentLocator.positionIn(publicationPositions),
+                currentVisualPage = visualPagePair?.first,
+                totalVisualPages = visualPagePair?.second,
+                paginationPhase = if (visualPagePair != null) {
+                    EpubPaginationPhase.READY
+                } else {
+                    it.paginationPhase
+                },
+            )
+        }
+        logcat(LogPriority.DEBUG) {
+            "EPUB progression preview chapterId=$chapterId requested=$requestedProgression " +
+                "${persistentLocator.debugProgress()} visual=${visualPagePair?.first}/${visualPagePair?.second}"
+        }
+    }
+
+    fun restoreCurrentProgressDisplay() {
+        latestLocator?.let(::updateLocator)
+    }
+
+    private fun applyPublicationPositions(positions: List<Locator>) {
+        if (positions.isEmpty()) return
+        publicationPositions = positions
+        publicationPositionByHref = buildMap {
+            positions.forEachIndexed { index, locator ->
+                locator.href.toString().hrefCandidates().forEach { href ->
+                    putIfAbsent(href, index + 1)
+                }
+            }
+        }
+        latestLocator?.let { locator ->
+            val position = locator.positionIn(positions)
+            val progression = locator.totalProgressionValue()
+                ?: position.toProgression(positions.size)
+            mutableState.update {
+                it.copy(
+                    progression = progression,
+                    progressionPercent = (progression * 100).roundToInt().coerceIn(0, 100),
+                    currentPosition = position,
+                    totalPositions = positions.size.coerceAtLeast(1),
+                )
+            }
+        }
     }
 
     fun currentLocator(): Locator? = latestLocator
@@ -1024,6 +1421,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     fun releaseSession() {
         locatorPersistenceJob.cancel()
         sessionRepository.remove(chapterId)?.close()
+        releaseCacheLeases()
 
         val locator = latestLocator
         if (locator != null && !isIncognito()) {
@@ -1044,7 +1442,18 @@ class EpubReaderViewModel @JvmOverloads constructor(
     override fun onCleared() {
         searchIterator?.close()
         searchIterator = null
+        releaseCacheLeases()
         super.onCleared()
+    }
+
+    private fun releaseCacheLeases() {
+        leasedCacheFile?.let(epubCacheManager::release)
+        leasedCacheFile = null
+        leasedPublicationKey?.let { publicationKey ->
+            currentSourceId.takeIf { it > 0L }
+                ?.let { sourceId -> epubCacheManager.releasePublication(sourceId, publicationKey) }
+        }
+        leasedPublicationKey = null
     }
 
     private suspend fun refreshBookmarks() {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -27,6 +27,7 @@ import koharia.epub.model.EpubTocEntry
 import koharia.epub.progress.KomgaEpubProgressSyncService
 import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
 import koharia.epub.service.EpubPublicationResolver
+import koharia.epub.session.EpubReaderSession
 import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubReaderPreferences
 import koharia.epub.settings.EpubSessionPreferenceStore
@@ -35,6 +36,7 @@ import koharia.komga.api.dto.isEpub
 import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -689,19 +691,19 @@ class EpubReaderViewModel @JvmOverloads constructor(
         val requestedChapterId = chapterId
         completeCacheStarted = true
         viewModelScope.launch {
-            val cachedFile = epubCacheManager.cacheCompleteBook(
-                source = source,
-                bookUrl = bookUrl,
-                publicationKey = publicationKey,
-                acquireLease = true,
-            ) ?: return@launch
-            if (chapterId != requestedChapterId || currentPublicationKey != publicationKey) {
-                epubCacheManager.release(cachedFile)
-                return@launch
-            }
-            val cachedUri = cachedFile.toURI().toString()
-            runCatching {
-                withIOContext {
+            var leasedFile: File? = null
+            var pendingSession: EpubReaderSession? = null
+            try {
+                val cachedFile = epubCacheManager.cacheCompleteBook(
+                    source = source,
+                    bookUrl = bookUrl,
+                    publicationKey = publicationKey,
+                    acquireLease = true,
+                ) ?: return@launch
+                leasedFile = cachedFile
+                if (chapterId != requestedChapterId || currentPublicationKey != publicationKey) return@launch
+                val cachedUri = cachedFile.toURI().toString()
+                val paginationSession = withIOContext {
                     publicationResolver.open(
                         request = EpubOpenRequest(
                             mangaId = mangaId,
@@ -718,15 +720,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         initialLocator = null,
                     )
                 }
-            }.onSuccess { paginationSession ->
+                pendingSession = paginationSession
                 if (chapterId != requestedChapterId || currentPublicationKey != publicationKey) {
-                    paginationSession.close()
-                    epubCacheManager.release(cachedFile)
-                    return@onSuccess
+                    return@launch
                 }
                 sessionRepository.putForPagination(paginationSession)
+                pendingSession = null
                 leasedCacheFile?.let(epubCacheManager::release)
                 leasedCacheFile = cachedFile
+                leasedFile = null
                 invalidatePaginationDisplay()
                 mutableState.update {
                     it.copy(
@@ -735,11 +737,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         paginationSourceVersion = it.paginationSourceVersion + 1,
                     )
                 }
-            }.onFailure { error ->
-                epubCacheManager.release(cachedFile)
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
                 logcat(LogPriority.WARN, error) {
                     "Failed to open cached EPUB for local pagination chapterId=$chapterId"
                 }
+            } finally {
+                pendingSession?.close()
+                leasedFile?.let(epubCacheManager::release)
             }
         }
     }
@@ -780,6 +786,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         val chapter = currentChapter ?: return
         val sourceId = currentSourceId.takeIf { it > 0L } ?: return
         val checkLayoutRevision = layoutChangeRevision
+        val localLocatorAtCheck = latestLocator
         remoteProgressChecked = true
         viewModelScope.launch {
             val remote = runCatching {
@@ -793,6 +800,22 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
                 ?: return@launch
             val modifiedAt = remote.modifiedAt ?: return@launch
+            val localUpdatedAt = currentProgress?.updatedAt?.time
+            if (localUpdatedAt != null && modifiedAt.time <= localUpdatedAt) {
+                logcat(LogPriority.DEBUG) {
+                    "Ignoring stale EPUB remote progress chapterId=$chapterId " +
+                        "remoteModified=${modifiedAt.time} localUpdated=$localUpdatedAt"
+                }
+                return@launch
+            }
+            if (localLocatorAtCheck != null &&
+                !localLocatorAtCheck.isSamePaginationLocation(latestLocator)
+            ) {
+                logcat(LogPriority.DEBUG) {
+                    "Ignoring EPUB remote progress after local navigation chapterId=$chapterId"
+                }
+                return@launch
+            }
             if (preserveLocalProgressAfterLayoutChange || checkLayoutRevision != layoutChangeRevision) {
                 logcat(LogPriority.DEBUG) {
                     "Ignoring EPUB remote progress conflict after local layout change " +

--- a/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
@@ -1,0 +1,356 @@
+package koharia.epub.cache
+
+import android.app.Application
+import android.text.format.Formatter
+import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
+import tachiyomi.core.common.util.system.logcat
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+class EpubCacheManager(
+    private val application: Application,
+    private val preferences: EpubCachePreferences,
+) {
+    data class ResourceEntry(
+        val bytes: ByteArray,
+        val mediaType: String?,
+    )
+
+    private data class CacheCandidate(
+        val files: List<File>,
+        val lastModified: Long,
+    )
+
+    private val root = LocalTempCacheDirectoryProvider.epubCacheDir(application)
+    private val resourcesDir = File(root, "resources").apply { mkdirs() }
+    private val booksDir = File(root, "books").apply { mkdirs() }
+    private val ioMutex = Mutex()
+    private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val transferMutexes = ConcurrentHashMap<String, Mutex>()
+    private val transferClients = ConcurrentHashMap<Long, OkHttpClient>()
+    private val leasedFiles = Collections.synchronizedSet(mutableSetOf<String>())
+    private val leasedPublicationDirs = Collections.synchronizedSet(mutableSetOf<String>())
+    private val pendingDeleteFiles = Collections.synchronizedSet(mutableSetOf<String>())
+    private val pendingDeleteDirs = Collections.synchronizedSet(mutableSetOf<String>())
+    private val activePartialFiles = Collections.synchronizedSet(mutableSetOf<String>())
+    private val clearGeneration = AtomicLong(0L)
+    private var scheduledTrimJob: Job? = null
+
+    fun completeBookFile(sourceId: Long, publicationKey: String): File? {
+        val file = completeBookTarget(sourceId, publicationKey)
+        return file.takeIf { it.isFile && it.length() > 0L }
+            ?.also(::touch)
+    }
+
+    fun acquire(file: File) {
+        leasedFiles += file.absolutePath
+        touch(file)
+    }
+
+    fun release(file: File) {
+        leasedFiles -= file.absolutePath
+        touch(file)
+        if (pendingDeleteFiles.remove(file.absolutePath)) {
+            cleanupScope.launch {
+                ioMutex.withLock { file.delete() }
+            }
+        }
+    }
+
+    fun acquirePublication(sourceId: Long, publicationKey: String) {
+        val directory = resourcePublicationDir(sourceId, publicationKey)
+        leasedPublicationDirs += directory.absolutePath
+        touch(directory)
+    }
+
+    fun releasePublication(sourceId: Long, publicationKey: String) {
+        val directory = resourcePublicationDir(sourceId, publicationKey)
+        leasedPublicationDirs -= directory.absolutePath
+        touch(directory)
+        if (pendingDeleteDirs.remove(directory.absolutePath)) {
+            cleanupScope.launch {
+                ioMutex.withLock { directory.deleteRecursively() }
+            }
+        }
+    }
+
+    suspend fun cacheCompleteBook(
+        source: KomgaSource,
+        bookUrl: String,
+        publicationKey: String,
+        acquireLease: Boolean = false,
+    ): File? = withContext(Dispatchers.IO) {
+        val transferKey = "${source.id}|$publicationKey"
+        val transferMutex = transferMutexes.getOrPut(transferKey) { Mutex() }
+        transferMutex.withLock {
+            completeBookFile(source.id, publicationKey)?.let { file ->
+                if (acquireLease) acquire(file)
+                return@withLock file
+            }
+            val generationAtStart = clearGeneration.get()
+            val target = completeBookTarget(source.id, publicationKey)
+            target.parentFile?.mkdirs()
+            val temporary = File(target.parentFile, "${target.name}.part")
+            activePartialFiles += temporary.absolutePath
+            try {
+                val existingBytes = temporary.length().takeIf { it > 0L } ?: 0L
+                val call = completeBookTransferClient(source).newCall(
+                    source.rawFileRequest(bookUrl, existingBytes.takeIf { it > 0L }),
+                )
+                runCatching {
+                    call.execute().use { response ->
+                        check(response.isSuccessful) { "HTTP ${response.code}" }
+                        val append = EpubCachePolicy.shouldAppendPartial(
+                            existingBytes = existingBytes,
+                            responseCode = response.code,
+                            contentRange = response.header("Content-Range"),
+                        )
+                        if (response.code == 206 && existingBytes > 0L && !append) {
+                            temporary.delete()
+                            error("Invalid EPUB cache Content-Range ${response.header("Content-Range")}")
+                        }
+                        if (!append && temporary.exists()) temporary.delete()
+                        FileOutputStream(temporary, append).use { output ->
+                            response.body.byteStream().use { input -> input.copyTo(output) }
+                        }
+                    }
+                    check(temporary.length() > 0L) { "Empty EPUB cache response" }
+                    if (generationAtStart != clearGeneration.get()) {
+                        temporary.delete()
+                        return@runCatching null
+                    }
+                    ioMutex.withLock {
+                        moveAtomically(temporary, target)
+                        touch(target)
+                        if (acquireLease) acquire(target)
+                        trimToSizeLocked()
+                    }
+                    target
+                }.onFailure { error ->
+                    logcat(LogPriority.WARN, error) {
+                        "Failed to cache complete EPUB sourceId=${source.id} bookUrl=$bookUrl"
+                    }
+                }.getOrNull()
+            } finally {
+                activePartialFiles -= temporary.absolutePath
+                transferMutexes.remove(transferKey, transferMutex)
+            }
+        }
+    }
+
+    suspend fun getResource(
+        sourceId: Long,
+        publicationKey: String,
+        url: String,
+    ): ResourceEntry? = withContext(Dispatchers.IO) {
+        val directory = resourcePublicationDir(sourceId, publicationKey)
+        val base = url.sha256()
+        val body = File(directory, "$base.body")
+        val metadata = File(directory, "$base.meta")
+        if (!body.isFile || !metadata.isFile) return@withContext null
+        runCatching {
+            val lines = metadata.readLines()
+            if (lines.firstOrNull() != url) return@runCatching null
+            touch(directory)
+            touch(body)
+            touch(metadata)
+            ResourceEntry(
+                bytes = body.readBytes(),
+                mediaType = lines.getOrNull(1)?.ifBlank { null },
+            )
+        }.getOrNull()
+    }
+
+    suspend fun putResource(
+        sourceId: Long,
+        publicationKey: String,
+        url: String,
+        mediaType: String?,
+        bytes: ByteArray,
+    ) = withContext(Dispatchers.IO) {
+        if (bytes.isEmpty() || bytes.size > MAX_RESOURCE_BYTES) return@withContext
+        ioMutex.withLock {
+            val directory = resourcePublicationDir(sourceId, publicationKey).apply { mkdirs() }
+            val base = url.sha256()
+            val body = File(directory, "$base.body")
+            val metadata = File(directory, "$base.meta")
+            val temporaryBody = File(directory, "$base.body.tmp")
+            val temporaryMetadata = File(directory, "$base.meta.tmp")
+            runCatching {
+                temporaryBody.writeBytes(bytes)
+                temporaryMetadata.writeText("$url\n${mediaType.orEmpty()}\n")
+                moveAtomically(temporaryBody, body)
+                moveAtomically(temporaryMetadata, metadata)
+                touch(directory)
+                touch(body)
+                touch(metadata)
+            }.onFailure { error ->
+                temporaryBody.delete()
+                temporaryMetadata.delete()
+                logcat(LogPriority.WARN, error) { "Failed to cache EPUB resource url=$url" }
+            }
+        }
+        scheduleTrim()
+    }
+
+    suspend fun trimToSize() = withContext(Dispatchers.IO) {
+        ioMutex.withLock { trimToSizeLocked() }
+    }
+
+    suspend fun clear(): Int = withContext(Dispatchers.IO) {
+        ioMutex.withLock {
+            clearGeneration.incrementAndGet()
+            leasedFiles.forEach(pendingDeleteFiles::add)
+            leasedPublicationDirs.forEach(pendingDeleteDirs::add)
+            cacheFiles()
+                .filterNot(::isProtected)
+                .count { it.delete() }
+                .also { deleteEmptyDirectories() }
+        }
+    }
+
+    suspend fun clearServer(sourceId: Long): Int = withContext(Dispatchers.IO) {
+        ioMutex.withLock {
+            clearGeneration.incrementAndGet()
+            val sourceBookDir = File(booksDir, sourceId.toString())
+            val sourceResourceDir = File(resourcesDir, sourceId.toString())
+            leasedFiles.filter { path -> File(path).startsWith(sourceBookDir) }
+                .forEach(pendingDeleteFiles::add)
+            leasedPublicationDirs.filter { path -> File(path).startsWith(sourceResourceDir) }
+                .forEach(pendingDeleteDirs::add)
+            (sourceBookDir.walkTopDown() + sourceResourceDir.walkTopDown())
+                .filter { it.isFile && !isProtected(it) }
+                .count { it.delete() }
+                .also { deleteEmptyDirectories() }
+        }
+    }
+
+    fun sizeBytes(): Long = cacheFiles().sumOf(File::length)
+
+    fun readableSize(): String = Formatter.formatFileSize(application, sizeBytes())
+
+    private fun trimToSizeLocked() {
+        var size = sizeBytes()
+        val limit = preferences.cacheSizeMb.get()
+            .coerceIn(EpubCachePreferences.MIN_CACHE_SIZE_MB, EpubCachePreferences.MAX_CACHE_SIZE_MB)
+            .toLong() * BYTES_PER_MB
+        if (size <= limit) return
+
+        val resources = resourcesDir.walkTopDown()
+            .filter { it.isFile && it.name.endsWith(".body") && !isProtected(it) }
+            .map { body ->
+                val metadata = File(body.parentFile, "${body.name.removeSuffix(".body")}.meta")
+                CacheCandidate(
+                    files = listOf(body, metadata).filter(File::isFile),
+                    lastModified = maxOf(body.lastModified(), metadata.lastModified()),
+                )
+            }
+            .sortedBy(CacheCandidate::lastModified)
+            .toList()
+        val books = booksDir.walkTopDown()
+            .filter {
+                it.isFile &&
+                    !isProtected(it)
+            }
+            .map { file -> CacheCandidate(listOf(file), file.lastModified()) }
+            .sortedBy(CacheCandidate::lastModified)
+            .toList()
+        for (candidate in resources + books) {
+            if (size <= limit) break
+            val deletedSize = candidate.files.sumOf { file ->
+                val length = file.length()
+                if (file.delete()) length else 0L
+            }
+            size -= deletedSize
+        }
+        deleteEmptyDirectories()
+    }
+
+    @Synchronized
+    private fun scheduleTrim() {
+        if (scheduledTrimJob?.isActive == true) return
+        scheduledTrimJob = cleanupScope.launch {
+            delay(TRIM_DEBOUNCE_MS)
+            ioMutex.withLock { trimToSizeLocked() }
+        }
+    }
+
+    private fun completeBookTarget(sourceId: Long, publicationKey: String): File =
+        File(File(booksDir, sourceId.toString()), "${publicationKey.sha256()}.epub")
+
+    private fun completeBookTransferClient(source: KomgaSource): OkHttpClient =
+        transferClients.getOrPut(source.id) {
+            source.client.newBuilder()
+                .dispatcher(
+                    Dispatcher().apply {
+                        maxRequests = 1
+                        maxRequestsPerHost = 1
+                    },
+                )
+                .build()
+        }
+
+    private fun resourcePublicationDir(sourceId: Long, publicationKey: String): File =
+        File(File(resourcesDir, sourceId.toString()), publicationKey.sha256())
+
+    private fun cacheFiles(): List<File> =
+        root.walkTopDown().filter(File::isFile).toList()
+
+    private fun isProtected(file: File): Boolean {
+        if (file.absolutePath in leasedFiles || file.absolutePath in activePartialFiles) return true
+        return leasedPublicationDirs.any { directory -> file.startsWith(File(directory)) }
+    }
+
+    private fun deleteEmptyDirectories() {
+        root.walkBottomUp()
+            .filter { it.isDirectory && it != root && it.listFiles().orEmpty().isEmpty() }
+            .forEach(File::delete)
+    }
+
+    private fun moveAtomically(source: File, target: File) {
+        target.parentFile?.mkdirs()
+        runCatching {
+            Files.move(
+                source.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        }.getOrElse {
+            Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun touch(file: File) {
+        if (file.exists()) file.setLastModified(System.currentTimeMillis())
+    }
+
+    private fun String.sha256(): String = MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray())
+        .joinToString("") { byte -> "%02x".format(byte) }
+
+    companion object {
+        const val MAX_RESOURCE_BYTES = 64 * 1024 * 1024
+        private const val BYTES_PER_MB = 1024L * 1024L
+        private const val TRIM_DEBOUNCE_MS = 1_500L
+    }
+}

--- a/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
@@ -3,26 +3,31 @@ package koharia.epub.cache
 import android.app.Application
 import android.text.format.Formatter
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
+import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
+import okhttp3.Response
 import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
 import tachiyomi.core.common.util.system.logcat
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
-import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
@@ -47,11 +52,11 @@ class EpubCacheManager(
     private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val transferMutexes = ConcurrentHashMap<String, Mutex>()
     private val transferClients = ConcurrentHashMap<Long, OkHttpClient>()
-    private val leasedFiles = Collections.synchronizedSet(mutableSetOf<String>())
-    private val leasedPublicationDirs = Collections.synchronizedSet(mutableSetOf<String>())
-    private val pendingDeleteFiles = Collections.synchronizedSet(mutableSetOf<String>())
-    private val pendingDeleteDirs = Collections.synchronizedSet(mutableSetOf<String>())
-    private val activePartialFiles = Collections.synchronizedSet(mutableSetOf<String>())
+    private val leasedFiles = ConcurrentHashMap.newKeySet<String>()
+    private val leasedPublicationDirs = ConcurrentHashMap.newKeySet<String>()
+    private val pendingDeleteFiles = ConcurrentHashMap.newKeySet<String>()
+    private val pendingDeleteDirs = ConcurrentHashMap.newKeySet<String>()
+    private val activePartialFiles = ConcurrentHashMap.newKeySet<String>()
     private val clearGeneration = AtomicLong(0L)
     private var scheduledTrimJob: Job? = null
 
@@ -74,6 +79,7 @@ class EpubCacheManager(
                 ioMutex.withLock { file.delete() }
             }
         }
+        scheduleTrim()
     }
 
     fun acquirePublication(sourceId: Long, publicationKey: String) {
@@ -91,6 +97,7 @@ class EpubCacheManager(
                 ioMutex.withLock { directory.deleteRecursively() }
             }
         }
+        scheduleTrim()
     }
 
     suspend fun cacheCompleteBook(
@@ -116,8 +123,8 @@ class EpubCacheManager(
                 val call = completeBookTransferClient(source).newCall(
                     source.rawFileRequest(bookUrl, existingBytes.takeIf { it > 0L }),
                 )
-                runCatching {
-                    call.execute().use { response ->
+                try {
+                    call.executeCancellable { response ->
                         check(response.isSuccessful) { "HTTP ${response.code}" }
                         val append = EpubCachePolicy.shouldAppendPartial(
                             existingBytes = existingBytes,
@@ -136,20 +143,24 @@ class EpubCacheManager(
                     check(temporary.length() > 0L) { "Empty EPUB cache response" }
                     if (generationAtStart != clearGeneration.get()) {
                         temporary.delete()
-                        return@runCatching null
+                        null
+                    } else {
+                        ioMutex.withLock {
+                            moveAtomically(temporary, target)
+                            touch(target)
+                            if (acquireLease) acquire(target)
+                            trimToSizeLocked()
+                        }
+                        target
                     }
-                    ioMutex.withLock {
-                        moveAtomically(temporary, target)
-                        touch(target)
-                        if (acquireLease) acquire(target)
-                        trimToSizeLocked()
-                    }
-                    target
-                }.onFailure { error ->
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (error: Exception) {
                     logcat(LogPriority.WARN, error) {
                         "Failed to cache complete EPUB sourceId=${source.id} bookUrl=$bookUrl"
                     }
-                }.getOrNull()
+                    null
+                }
             } finally {
                 activePartialFiles -= temporary.absolutePath
                 transferMutexes.remove(transferKey, transferMutex)
@@ -307,6 +318,33 @@ class EpubCacheManager(
                     },
                 )
                 .build()
+        }
+
+    private suspend fun <T> Call.executeCancellable(block: (Response) -> T): T =
+        suspendCancellableCoroutine { continuation ->
+            continuation.invokeOnCancellation { cancel() }
+            enqueue(
+                object : Callback {
+                    override fun onFailure(call: Call, error: IOException) {
+                        val token = continuation.tryResumeWithException(error) ?: return
+                        continuation.completeResume(token)
+                    }
+
+                    override fun onResponse(call: Call, response: Response) {
+                        val result = runCatching { response.use(block) }
+                        result.fold(
+                            onSuccess = { value ->
+                                val token = continuation.tryResume(value) ?: return@fold
+                                continuation.completeResume(token)
+                            },
+                            onFailure = { error ->
+                                val token = continuation.tryResumeWithException(error) ?: return@fold
+                                continuation.completeResume(token)
+                            },
+                        )
+                    }
+                },
+            )
         }
 
     private fun resourcePublicationDir(sourceId: Long, publicationKey: String): File =

--- a/app/src/main/java/koharia/epub/cache/EpubCachePolicy.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCachePolicy.kt
@@ -1,0 +1,44 @@
+package koharia.epub.cache
+
+internal object EpubCachePolicy {
+
+    enum class OpenSource {
+        MANUAL_DOWNLOAD,
+        COMPLETE_CACHE,
+        REMOTE,
+    }
+
+    fun selectOpenSource(
+        manualDownloadUri: String?,
+        completeCacheUri: String?,
+        remoteUrl: String?,
+    ): OpenSource? = when {
+        manualDownloadUri != null -> OpenSource.MANUAL_DOWNLOAD
+        completeCacheUri != null -> OpenSource.COMPLETE_CACHE
+        remoteUrl != null -> OpenSource.REMOTE
+        else -> null
+    }
+
+    fun publicationKey(
+        fileHash: String?,
+        fileLastModified: String?,
+        sizeBytes: Long,
+        fallback: String,
+    ): String = when {
+        !fileHash.isNullOrBlank() -> "komga:$fileHash"
+        !fileLastModified.isNullOrBlank() && sizeBytes > 0L ->
+            "komga:$fileLastModified:$sizeBytes"
+        else -> fallback
+    }
+
+    fun shouldAppendPartial(
+        existingBytes: Long,
+        responseCode: Int,
+        contentRange: String?,
+    ): Boolean {
+        if (existingBytes <= 0L || responseCode != 206) return false
+        return contentRange
+            ?.trim()
+            ?.startsWith("bytes $existingBytes-", ignoreCase = true) == true
+    }
+}

--- a/app/src/main/java/koharia/epub/cache/EpubCachePreferences.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCachePreferences.kt
@@ -1,0 +1,21 @@
+package koharia.epub.cache
+
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class EpubCachePreferences(
+    preferenceStore: PreferenceStore,
+) {
+    val cacheWholeBook: Preference<Boolean> =
+        preferenceStore.getBoolean("epub_cache_whole_book", true)
+
+    val cacheSizeMb: Preference<Int> =
+        preferenceStore.getInt("epub_book_cache_size_mb", DEFAULT_CACHE_SIZE_MB)
+
+    companion object {
+        const val DEFAULT_CACHE_SIZE_MB = 512
+        const val MIN_CACHE_SIZE_MB = 128
+        const val MAX_CACHE_SIZE_MB = 4096
+        const val CACHE_SIZE_STEP_MB = 128
+    }
+}

--- a/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
+++ b/app/src/main/java/koharia/epub/model/EpubOpenRequest.kt
@@ -9,6 +9,8 @@ data class EpubOpenRequest(
     val localUri: String?,
     val openSource: OpenSource,
     val publisherStylesOverride: Boolean? = null,
+    val publicationKey: String = "chapter:$chapterId",
+    val persistCache: Boolean = true,
 ) {
     enum class OpenSource {
         LOCAL,

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubRemoteProgressCoordinator.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubRemoteProgressCoordinator.kt
@@ -25,6 +25,7 @@ class KomgaEpubRemoteProgressCoordinator(
         sourceId: Long,
         chapters: List<Chapter>,
         force: Boolean = false,
+        includeUnknownChapters: Boolean = false,
     ): List<EpubRemoteProgressCache> = coroutineScope {
         if (scopedPreferenceStoreFactory.basePreferences(sourceId).incognitoMode.get()) {
             return@coroutineScope emptyList()
@@ -33,7 +34,9 @@ class KomgaEpubRemoteProgressCoordinator(
         val now = System.currentTimeMillis()
         val semaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
         chapters.filter { chapter ->
-            KomgaChapterMemo.isEpub(chapter.memo) == true || existing.containsKey(chapter.id)
+            KomgaChapterMemo.isEpub(chapter.memo) == true ||
+                existing.containsKey(chapter.id) ||
+                includeUnknownChapters
         }.map { chapter ->
             async {
                 semaphore.withPermit {
@@ -70,7 +73,13 @@ class KomgaEpubRemoteProgressCoordinator(
         mangaId: Long,
         chapter: Chapter,
         sourceId: Long,
-    ): EpubRemoteProgressCache? = syncManga(mangaId, sourceId, listOf(chapter), force = true).firstOrNull()
+    ): EpubRemoteProgressCache? = syncManga(
+        mangaId = mangaId,
+        sourceId = sourceId,
+        chapters = listOf(chapter),
+        force = true,
+        includeUnknownChapters = true,
+    ).firstOrNull()
 
     private fun Locator.totalProgression(): Double? =
         (locations.totalProgression as? Number)?.toDouble()

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubRemoteProgressCoordinator.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubRemoteProgressCoordinator.kt
@@ -1,0 +1,85 @@
+package koharia.epub.progress
+
+import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
+import koharia.domain.epub.interactor.UpsertEpubRemoteProgressCache
+import koharia.domain.epub.model.EpubRemoteProgressCache
+import koharia.komga.download.KomgaChapterMemo
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import org.readium.r2.shared.publication.Locator
+import tachiyomi.domain.chapter.model.Chapter
+import java.util.Date
+
+class KomgaEpubRemoteProgressCoordinator(
+    private val syncService: KomgaEpubProgressSyncService,
+    private val getCache: GetEpubRemoteProgressCache,
+    private val upsertCache: UpsertEpubRemoteProgressCache,
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory,
+) {
+    suspend fun syncManga(
+        mangaId: Long,
+        sourceId: Long,
+        chapters: List<Chapter>,
+        force: Boolean = false,
+    ): List<EpubRemoteProgressCache> = coroutineScope {
+        if (scopedPreferenceStoreFactory.basePreferences(sourceId).incognitoMode.get()) {
+            return@coroutineScope emptyList()
+        }
+        val existing = getCache.awaitByMangaId(mangaId).associateBy { it.chapterId }
+        val now = System.currentTimeMillis()
+        val semaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
+        chapters.filter { chapter ->
+            KomgaChapterMemo.isEpub(chapter.memo) == true || existing.containsKey(chapter.id)
+        }.map { chapter ->
+            async {
+                semaphore.withPermit {
+                    val cached = existing[chapter.id]
+                    if (!force && cached != null && now - cached.checkedAt.time < CACHE_TTL_MS) {
+                        return@withPermit cached
+                    }
+                    val bookUrl = KomgaChapterMemo.readFingerprint(chapter.memo)?.bookUrl
+                        ?: chapter.url.substringBefore('#').removeSuffix("/")
+                    runCatching { syncService.pullProgression(sourceId, bookUrl) }
+                        .map { result ->
+                            val remote = result.progression
+                            EpubRemoteProgressCache(
+                                chapterId = chapter.id,
+                                mangaId = mangaId,
+                                bookUrl = bookUrl,
+                                locatorJson = remote?.locator?.toJSON()?.toString(),
+                                progression = remote?.locator?.totalProgression(),
+                                positionIndex = remote?.locator?.positionIndex(),
+                                modifiedAt = remote?.modifiedAt,
+                                checkedAt = Date(),
+                                serverDate = result.serverDate,
+                            ).also { upsertCache.await(it) }
+                        }
+                        .getOrElse { cached }
+                }
+            }
+        }.awaitAll().filterNotNull()
+    }
+
+    suspend fun get(chapterId: Long): EpubRemoteProgressCache? = getCache.await(chapterId)
+
+    suspend fun refreshChapter(
+        mangaId: Long,
+        chapter: Chapter,
+        sourceId: Long,
+    ): EpubRemoteProgressCache? = syncManga(mangaId, sourceId, listOf(chapter), force = true).firstOrNull()
+
+    private fun Locator.totalProgression(): Double? =
+        (locations.totalProgression as? Number)?.toDouble()
+
+    private fun Locator.positionIndex(): Long? =
+        (locations.position as? Number)?.toLong()
+
+    private companion object {
+        const val MAX_CONCURRENT_REQUESTS = 2
+        const val CACHE_TTL_MS = 60_000L
+    }
+}

--- a/app/src/main/java/koharia/epub/service/EpubPublicationPositions.kt
+++ b/app/src/main/java/koharia/epub/service/EpubPublicationPositions.kt
@@ -1,0 +1,67 @@
+package koharia.epub.service
+
+import koharia.epub.session.EpubPositionsController
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.InternalReadiumApi
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.CacheService
+import org.readium.r2.shared.publication.services.ContentProtectionService
+import org.readium.r2.shared.publication.services.CoverService
+import org.readium.r2.shared.publication.services.LocatorService
+import org.readium.r2.shared.publication.services.PositionsService
+import org.readium.r2.shared.publication.services.cacheServiceFactory
+import org.readium.r2.shared.publication.services.content.ContentService
+import org.readium.r2.shared.publication.services.content.contentServiceFactory
+import org.readium.r2.shared.publication.services.contentProtectionServiceFactory
+import org.readium.r2.shared.publication.services.coverServiceFactory
+import org.readium.r2.shared.publication.services.locatorServiceFactory
+import org.readium.r2.shared.publication.services.positionsServiceFactory
+import org.readium.r2.shared.publication.services.search.SearchService
+import org.readium.r2.shared.publication.services.search.searchServiceFactory
+
+internal data class EpubPublicationWithPositions(
+    val publication: Publication,
+    val controller: EpubPositionsController,
+)
+
+@OptIn(InternalReadiumApi::class, ExperimentalReadiumApi::class)
+internal fun Publication.withEpubPositionsController(
+    initialPositions: List<Locator> = emptyList(),
+): EpubPublicationWithPositions {
+    val original = this
+    val controller = EpubPositionsController(
+        readingOrder = readingOrder,
+        delegate = findService(PositionsService::class),
+        initialPositions = initialPositions,
+    )
+    val servicesBuilder = Publication.ServicesBuilder().apply {
+        original.findService(CacheService::class)?.let { service ->
+            cacheServiceFactory = { service }
+        }
+        original.findService(ContentService::class)?.let { service ->
+            contentServiceFactory = { service }
+        }
+        original.findService(ContentProtectionService::class)?.let { service ->
+            contentProtectionServiceFactory = { service }
+        }
+        original.findService(CoverService::class)?.let { service ->
+            coverServiceFactory = { service }
+        }
+        original.findService(LocatorService::class)?.let { service ->
+            locatorServiceFactory = { service }
+        }
+        positionsServiceFactory = { controller }
+        original.findService(SearchService::class)?.let { service ->
+            searchServiceFactory = { service }
+        }
+    }
+    return EpubPublicationWithPositions(
+        publication = Publication(
+            manifest = manifest,
+            container = container,
+            servicesBuilder = servicesBuilder,
+        ),
+        controller = controller,
+    )
+}

--- a/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
@@ -3,9 +3,12 @@ package koharia.epub.service
 import android.app.Application
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.util.system.isOnline
+import koharia.epub.cache.EpubCacheManager
+import koharia.epub.cache.EpubCachePolicy
 import koharia.epub.model.EpubOpenRequest
 import koharia.komga.api.dto.isDivinaCompatibleEpub
 import koharia.komga.api.dto.isEpub
+import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaSource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
@@ -23,12 +26,12 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
     private val downloadProvider: DownloadProvider = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChapter: GetChapter = Injekt.get(),
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
 ) {
 
     suspend fun resolve(
         mangaId: Long,
         chapterId: Long,
-        preferLocalFile: Boolean,
     ): EpubReaderSupportResolution = withIOContext {
         val manga = getManga.await(mangaId) ?: return@withIOContext EpubReaderSupportResolution(
             mangaId = mangaId,
@@ -51,7 +54,7 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
                 unsupportedReason = EpubReaderSupportResolution.UnsupportedReason.SOURCE_UNSUPPORTED,
             )
 
-        val localUri = downloadProvider.findChapterDir(
+        val downloadedFile = downloadProvider.findChapterDir(
             chapterName = chapter.name,
             chapterScanlator = chapter.scanlator,
             chapterUrl = chapter.url,
@@ -59,25 +62,52 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             source = source,
         )
             ?.takeIf { it.extension.equals("epub", ignoreCase = true) }
-            ?.uri
-            ?.toString()
+        val downloadedUri = downloadedFile?.uri?.toString()
 
-        val remoteLookup = if (localUri != null && !application.isOnline()) {
+        val memoFingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
+        val memoIsEpub = KomgaChapterMemo.isEpub(chapter.memo)
+        val memoBookUrl = memoFingerprint?.bookUrl
+            ?: chapter.url.substringBefore('#').removeSuffix("/")
+        val remotePublicationKey = EpubCachePolicy.publicationKey(
+            fileHash = memoFingerprint?.fileHash,
+            fileLastModified = KomgaChapterMemo.fileLastModified(chapter.memo),
+            sizeBytes = memoFingerprint?.sizeBytes ?: 0L,
+            fallback = "book:${chapter.id}:${chapter.url}",
+        )
+        val cachedBookFile = epubCacheManager.completeBookFile(source.id, remotePublicationKey)
+        val cachedBookUri = cachedBookFile?.toURI()?.toString()
+        val selectedSource = EpubCachePolicy.selectOpenSource(downloadedUri, cachedBookUri, memoBookUrl)
+        val localUri = when (selectedSource) {
+            EpubCachePolicy.OpenSource.MANUAL_DOWNLOAD -> downloadedUri
+            EpubCachePolicy.OpenSource.COMPLETE_CACHE -> cachedBookUri
+            else -> null
+        }
+
+        val remoteLookup = if (memoIsEpub == true || localUri != null || !application.isOnline()) {
             Result.success(null)
         } else {
             runCatching { source.getBookDetails(chapter.url) }
         }
         val remoteBook = remoteLookup.getOrNull()
-        val remoteBookUrl = remoteBook
-            ?.takeIf { it.isEpub }
-            ?.let { chapter.url.substringBefore('#').removeSuffix("/") }
+        val resolvedRemotePublicationKey = remoteBook?.let { book ->
+            EpubCachePolicy.publicationKey(
+                fileHash = book.fileHash,
+                fileLastModified = book.fileLastModified,
+                sizeBytes = book.sizeBytes,
+                fallback = remotePublicationKey,
+            )
+        } ?: remotePublicationKey
+        val remoteBookUrl = when {
+            remoteBook?.isEpub == true -> chapter.url.substringBefore('#').removeSuffix("/")
+            memoIsEpub == true || localUri != null -> memoBookUrl
+            else -> null
+        }
 
         val isDivinaCompatible = remoteBook?.media?.isDivinaCompatibleEpub == true
 
         val preferredOpenSource = when {
-            preferLocalFile && localUri != null -> EpubOpenRequest.OpenSource.LOCAL
-            remoteBookUrl != null -> EpubOpenRequest.OpenSource.REMOTE
             localUri != null -> EpubOpenRequest.OpenSource.LOCAL
+            remoteBookUrl != null -> EpubOpenRequest.OpenSource.REMOTE
             else -> null
         }
 
@@ -100,6 +130,21 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             preferredOpenSource = preferredOpenSource,
             unsupportedReason = unsupportedReason,
             metadataError = remoteLookup.exceptionOrNull(),
+            publicationKey = when {
+                downloadedFile != null ->
+                    "local:$downloadedUri:${downloadedFile.lastModified()}:${downloadedFile.length()}"
+                else -> resolvedRemotePublicationKey
+            },
+            bookFileName = downloadedFile?.name
+                ?: cachedBookFile?.name
+                ?: remoteBook?.name
+                ?: KomgaChapterMemo.fileName(chapter.memo),
+            bookSizeBytes = downloadedFile?.length()?.takeIf { it > 0L }
+                ?: cachedBookFile?.length()?.takeIf { it > 0L }
+                ?: remoteBook?.sizeBytes?.takeIf { it > 0L }
+                ?: memoFingerprint?.sizeBytes?.takeIf { it > 0L },
+            isManualDownload = downloadedFile != null,
+            isCompleteCache = downloadedFile == null && cachedBookFile != null,
         )
     }
 }
@@ -117,6 +162,11 @@ data class EpubReaderSupportResolution(
     val preferredOpenSource: EpubOpenRequest.OpenSource? = null,
     val unsupportedReason: UnsupportedReason? = null,
     val metadataError: Throwable? = null,
+    val publicationKey: String? = null,
+    val bookFileName: String? = null,
+    val bookSizeBytes: Long? = null,
+    val isManualDownload: Boolean = false,
+    val isCompleteCache: Boolean = false,
 ) {
 
     val isNativeSupported: Boolean
@@ -132,6 +182,7 @@ data class EpubReaderSupportResolution(
             bookUrl = remoteBookUrl,
             localUri = localUri,
             openSource = openSource,
+            publicationKey = publicationKey ?: "chapter:$chapterId",
         )
     }
 

--- a/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
@@ -1,13 +1,13 @@
 package koharia.epub.service
 
 import android.app.Application
-import android.os.SystemClock
 import koharia.epub.model.EpubOpenRequest
+import koharia.epub.session.EpubPositionsController
 import koharia.epub.session.EpubReaderSession
 import logcat.LogPriority
+import org.json.JSONObject
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
 import org.readium.r2.shared.publication.Locator
-import org.readium.r2.shared.publication.services.positions
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.FileExtension
 import org.readium.r2.shared.util.asset.AssetRetriever
@@ -28,6 +28,7 @@ import org.readium.r2.streamer.parser.DefaultPublicationParser
 import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.net.URI
 
 class KomgaEpubPublicationService(
     private val application: Application = Injekt.get(),
@@ -45,8 +46,14 @@ class KomgaEpubPublicationService(
         logcat(LogPriority.DEBUG) {
             "EPUB remote open start chapterId=${request.chapterId} manifestUrl=$manifestUrl"
         }
-        val httpClient = httpClientFactory.create(request.sourceId, request.publisherStylesOverride)
+        val httpClient = httpClientFactory.create(
+            sourceId = request.sourceId,
+            publisherStylesOverride = request.publisherStylesOverride,
+            publicationKey = request.publicationKey,
+            persistCache = request.persistCache,
+        )
         val assetRetriever = AssetRetriever(application.contentResolver, httpClient)
+        var cachedPositions: List<Locator> = emptyList()
         val publicationOpener = PublicationOpener(
             DefaultPublicationParser(application, httpClient, assetRetriever, null),
         )
@@ -54,6 +61,12 @@ class KomgaEpubPublicationService(
             .getOrElse {
                 throw IllegalStateException("Failed to fetch Komga EPUB manifest: ${it.message}")
             }
+        cachedPositions = findPositionsUrl(manifestJson, manifestUrl.toString(), bookUrl)
+            ?.let { positionsUrl ->
+                httpClientFactory.cachedResource(request.sourceId, request.publicationKey, positionsUrl)
+            }
+            ?.toLocators()
+            .orEmpty()
         val manifestResource = StringResource(
             string = manifestJson,
             source = manifestUrl,
@@ -71,24 +84,15 @@ class KomgaEpubPublicationService(
             resource = manifestResource,
         )
 
-        val publication = publicationOpener.open(manifestAsset, allowUserInteraction = false)
+        val openedPublication = publicationOpener.open(manifestAsset, allowUserInteraction = false)
             .getOrElse {
                 manifestAsset.close()
                 throw IllegalStateException(it.message)
             }
+        val publicationWithPositions = openedPublication.withEpubPositionsController(cachedPositions)
+        val publication = publicationWithPositions.publication
         logcat(LogPriority.DEBUG) {
             "EPUB remote open success chapterId=${request.chapterId} readingOrder=${publication.readingOrder.size} toc=${publication.tableOfContents.size}"
-        }
-
-        // Readium 3.3.0's EPUB navigator reads positions through runBlocking on the main thread
-        // when it publishes the first location. Remote EPUB positions can require fetching every
-        // reading-order resource, so populate the service cache while this open coroutine is still
-        // showing the reader loading state.
-        val positionsStartedAt = SystemClock.elapsedRealtime()
-        val positions = publication.positions()
-        logcat(LogPriority.DEBUG) {
-            "EPUB positions ready chapterId=${request.chapterId} count=${positions.size} " +
-                "durationMs=${SystemClock.elapsedRealtime() - positionsStartedAt}"
         }
 
         return EpubReaderSession(
@@ -97,6 +101,63 @@ class KomgaEpubPublicationService(
             publication = publication,
             navigatorFactory = EpubNavigatorFactory(publication),
             initialLocator = initialLocator,
+            positionsController = publicationWithPositions.controller,
+            prefetchNextResource = { locator ->
+                val locatorHref = locator?.href?.toString()?.resourceKey()
+                val currentIndex = publication.readingOrder.indexOfFirst { link ->
+                    val linkHref = link.href.toString().resourceKey()
+                    locatorHref != null &&
+                        (
+                            linkHref == locatorHref || linkHref.endsWith("/$locatorHref") ||
+                                locatorHref.endsWith("/$linkHref")
+                            )
+                }.takeIf { it >= 0 } ?: 0
+                publication.readingOrder.getOrNull(currentIndex + 1)
+                    ?.let(publication::get)
+                    ?.let { resource ->
+                        try {
+                            resource.read().getOrElse { ByteArray(0) }
+                        } finally {
+                            resource.close()
+                        }
+                    }
+            },
         )
     }
+
+    private fun String.resourceKey(): String =
+        substringBefore('#')
+            .substringBefore('?')
+            .trimStart('/')
+
+    private fun findPositionsUrl(manifestJson: String, manifestUrl: String, bookUrl: String): String? {
+        val links = runCatching { JSONObject(manifestJson).optJSONArray("links") }.getOrNull()
+        if (links != null) {
+            var selfUrl: String? = null
+            var positionsHref: String? = null
+            for (index in 0 until links.length()) {
+                val link = links.optJSONObject(index) ?: continue
+                val href = link.optString("href").takeIf(String::isNotBlank) ?: continue
+                val rel = link.opt("rel")?.toString().orEmpty()
+                val type = link.optString("type")
+                if (rel.contains("self")) selfUrl = href
+                if (rel.contains("positions") || type.contains("position-list")) positionsHref = href
+            }
+            positionsHref?.let { href ->
+                val base = selfUrl?.let { URI(manifestUrl).resolve(it).toString() } ?: manifestUrl
+                return runCatching { URI(base).resolve(href).toString() }.getOrNull()
+            }
+        }
+        return "$bookUrl/positions"
+    }
+
+    private fun ByteArray.toLocators(): List<Locator> = runCatching {
+        val positions = JSONObject(toString(Charsets.UTF_8)).optJSONArray("positions")
+            ?: return@runCatching emptyList()
+        buildList {
+            for (index in 0 until positions.length()) {
+                Locator.fromJSON(positions.optJSONObject(index))?.let(::add)
+            }
+        }
+    }.getOrDefault(emptyList())
 }

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -1,29 +1,52 @@
 package koharia.epub.service
 
+import koharia.epub.cache.EpubCacheManager
 import koharia.epub.injectEpubParagraphIndentStyle
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import logcat.LogPriority
+import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.http.DefaultHttpClient
 import org.readium.r2.shared.util.http.HttpClient
 import org.readium.r2.shared.util.http.HttpRequest
+import org.readium.r2.shared.util.http.HttpResponse
+import org.readium.r2.shared.util.http.HttpStatus
 import org.readium.r2.shared.util.http.HttpStreamResponse
+import org.readium.r2.shared.util.mediatype.MediaType
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.ByteArrayInputStream
+import java.net.URI
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 
 class KomgaReadiumHttpClient(
     private val sourceManager: SourceManager = Injekt.get(),
     private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
 ) {
 
     private val requestLogCount = AtomicInteger(0)
 
-    fun create(sourceId: Long, publisherStylesOverride: Boolean? = null): HttpClient {
+    suspend fun cachedResource(
+        sourceId: Long,
+        publicationKey: String,
+        url: String,
+    ): ByteArray? = epubCacheManager.getResource(sourceId, publicationKey, url)?.bytes
+
+    fun create(
+        sourceId: Long,
+        publisherStylesOverride: Boolean? = null,
+        publicationKey: String = "source:$sourceId",
+        persistCache: Boolean = true,
+    ): HttpClient {
         val client = DefaultHttpClient()
         client.callback = object : DefaultHttpClient.Callback {
             override suspend fun onStartRequest(request: HttpRequest) = Try.success(
@@ -47,12 +70,167 @@ class KomgaReadiumHttpClient(
                 },
             )
         }
-        return ParagraphIndentNormalizingHttpClient(client) {
+        val cachedClient = EpubResourceCacheHttpClient(
+            delegate = client,
+            cacheManager = epubCacheManager,
+            sourceId = sourceId,
+            publicationKey = publicationKey,
+            persistCache = persistCache,
+        )
+        return ParagraphIndentNormalizingHttpClient(cachedClient) {
             !(
                 publisherStylesOverride
                     ?: scopedPreferenceStoreFactory.epubLayoutPreferences(sourceId).publisherStyles.get()
                 )
         }
+    }
+}
+
+private class EpubResourceCacheHttpClient(
+    private val delegate: HttpClient,
+    private val cacheManager: EpubCacheManager,
+    private val sourceId: Long,
+    private val publicationKey: String,
+    private val persistCache: Boolean,
+) : HttpClient {
+
+    private val prefetchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override suspend fun stream(request: HttpRequest): org.readium.r2.shared.util.http.HttpTry<HttpStreamResponse> {
+        if (!isCacheable(request)) return delegate.stream(request)
+
+        cacheManager.getResource(sourceId, publicationKey, request.url.toString())?.let { cached ->
+            return Try.success(
+                HttpStreamResponse(
+                    response = HttpResponse(
+                        request = request,
+                        url = request.url,
+                        statusCode = HttpStatus(200),
+                        headers = emptyMap(),
+                        mediaType = cached.mediaType?.let { value -> MediaType(value) },
+                    ),
+                    body = ByteArrayInputStream(cached.bytes),
+                ),
+            )
+        }
+
+        return delegate.stream(request).map { response ->
+            if (response.response.statusCode != HttpStatus(200) ||
+                response.response.contentLength?.let { it > EpubCacheManager.MAX_RESOURCE_BYTES } == true
+            ) {
+                return@map response
+            }
+            val bytes = response.body.use { it.readBytes() }
+            if (persistCache) {
+                prefetchScope.launch {
+                    cacheManager.putResource(
+                        sourceId = sourceId,
+                        publicationKey = publicationKey,
+                        url = request.url.toString(),
+                        mediaType = response.response.mediaType?.toString(),
+                        bytes = bytes,
+                    )
+                    if (response.response.mediaType?.isHtml == true || isHtmlUrl(request.url.toString())) {
+                        prefetchDependencies(
+                            baseUrl = response.response.url.toString(),
+                            content = bytes.toString(Charsets.UTF_8),
+                        )
+                    }
+                }
+            }
+            HttpStreamResponse(response.response, ByteArrayInputStream(bytes))
+        }
+    }
+
+    private fun isCacheable(request: HttpRequest): Boolean {
+        if (!persistCache || request.method != HttpRequest.Method.GET) return false
+        if (request.headers.keys.any { it.equals("Range", ignoreCase = true) }) return false
+        val url = request.url.toString().substringBefore('?')
+        return url.contains("/manifest/epub") ||
+            url.endsWith("/positions") ||
+            url.contains("/resource/")
+    }
+
+    private suspend fun prefetchDependencies(
+        baseUrl: String,
+        content: String,
+    ) {
+        val visited = Collections.synchronizedSet(mutableSetOf<String>())
+        htmlDependency.findAll(content)
+            .map { match -> match.groupValues[2] }
+            .filter(::isFetchableReference)
+            .take(MAX_PREFETCH_DEPENDENCIES)
+            .forEach { reference ->
+                prefetchDependency(baseUrl, reference, visited, parseCssDependencies = true)
+            }
+    }
+
+    private suspend fun prefetchDependency(
+        baseUrl: String,
+        reference: String,
+        visited: MutableSet<String>,
+        parseCssDependencies: Boolean,
+    ) {
+        val resolved = runCatching { URI(baseUrl).resolve(reference).toString() }.getOrNull() ?: return
+        if (!visited.add(resolved)) return
+        val absoluteUrl = AbsoluteUrl(resolved) ?: return
+        cacheManager.getResource(sourceId, publicationKey, resolved)?.let { return }
+        delegate.stream(HttpRequest(absoluteUrl)).map { response ->
+            if (response.response.statusCode != HttpStatus(200) ||
+                response.response.contentLength?.let { it > EpubCacheManager.MAX_RESOURCE_BYTES } == true
+            ) {
+                response.body.close()
+                return@map
+            }
+            val bytes = response.body.use { it.readBytes() }
+            cacheManager.putResource(
+                sourceId = sourceId,
+                publicationKey = publicationKey,
+                url = resolved,
+                mediaType = response.response.mediaType?.toString(),
+                bytes = bytes,
+            )
+            if (parseCssDependencies &&
+                (
+                    response.response.mediaType?.toString()?.startsWith("text/css") == true ||
+                        resolved.substringBefore('?').endsWith(".css", ignoreCase = true)
+                    )
+            ) {
+                cssDependency.findAll(bytes.toString(Charsets.UTF_8))
+                    .map { match -> match.groupValues[2] }
+                    .filter(::isFetchableReference)
+                    .take(MAX_PREFETCH_DEPENDENCIES)
+                    .forEach { cssReference ->
+                        prefetchDependency(resolved, cssReference, visited, parseCssDependencies = false)
+                    }
+            }
+        }
+    }
+
+    private fun isFetchableReference(reference: String): Boolean {
+        val value = reference.trim()
+        return value.isNotBlank() &&
+            !value.startsWith("#") &&
+            !value.startsWith("data:", ignoreCase = true) &&
+            !value.startsWith("javascript:", ignoreCase = true)
+    }
+
+    private fun isHtmlUrl(url: String): Boolean {
+        val path = url.substringBefore('?')
+        return htmlExtensions.any { path.endsWith(it, ignoreCase = true) }
+    }
+
+    private companion object {
+        const val MAX_PREFETCH_DEPENDENCIES = 64
+        val htmlExtensions = listOf(".xhtml", ".html", ".htm")
+        val htmlDependency = Regex(
+            """(?:src|href)\s*=\s*([\"'])(.*?)\1""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
+        )
+        val cssDependency = Regex(
+            """url\(\s*([\"']?)(.*?)\1\s*\)""",
+            RegexOption.IGNORE_CASE,
+        )
     }
 }
 

--- a/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
@@ -3,6 +3,7 @@ package koharia.epub.service
 import android.app.Application
 import android.net.Uri
 import koharia.epub.model.EpubOpenRequest
+import koharia.epub.session.EpubPositionsController
 import koharia.epub.session.EpubReaderSession
 import logcat.LogPriority
 import org.readium.r2.navigator.epub.EpubNavigatorFactory
@@ -40,11 +41,13 @@ class LocalEpubPublicationService(
 
         val asset = assetRetriever.retrieve(url, MediaType.EPUB)
             .getOrElse { throw IllegalStateException(it.message) }
-        val publication = publicationOpener.open(asset, allowUserInteraction = false)
+        val openedPublication = publicationOpener.open(asset, allowUserInteraction = false)
             .getOrElse {
                 asset.close()
                 throw IllegalStateException(it.message)
             }
+        val publicationWithPositions = openedPublication.withEpubPositionsController()
+        val publication = publicationWithPositions.publication
         logcat(LogPriority.DEBUG) {
             "EPUB local open success chapterId=${request.chapterId} readingOrder=${publication.readingOrder.size} toc=${publication.tableOfContents.size}"
         }
@@ -55,6 +58,7 @@ class LocalEpubPublicationService(
             publication = publication,
             navigatorFactory = EpubNavigatorFactory(publication),
             initialLocator = initialLocator,
+            positionsController = publicationWithPositions.controller,
         )
     }
 }

--- a/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
+++ b/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
@@ -1,0 +1,71 @@
+package koharia.epub.session
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.services.PositionsService
+import org.readium.r2.shared.util.mediatype.MediaType
+
+class EpubPositionsController(
+    private val readingOrder: List<Link>,
+    private val delegate: PositionsService?,
+    initialPositions: List<Locator> = emptyList(),
+) : PositionsService {
+    private val refreshMutex = Mutex()
+
+    @Volatile
+    private var current: List<List<Locator>> = initialPositions
+        .groupForReadingOrder()
+        .takeIf { groups -> groups.flatten().isNotEmpty() }
+        ?: fallbackPositions()
+
+    override suspend fun positionsByReadingOrder(): List<List<Locator>> = current
+
+    suspend fun refresh(): List<Locator> = refreshMutex.withLock {
+        val refreshed = delegate?.positionsByReadingOrder()
+            ?.takeIf { groups -> groups.flatten().isNotEmpty() }
+        if (refreshed != null) current = refreshed
+        current.flatten()
+    }
+
+    fun currentPositions(): List<Locator> = current.flatten()
+
+    override fun close() {
+        delegate?.close()
+    }
+
+    private fun List<Locator>.groupForReadingOrder(): List<List<Locator>> =
+        readingOrder.map { link ->
+            val linkHref = link.href.toString().resourceKey()
+            filter { locator ->
+                val locatorHref = locator.href.toString().resourceKey()
+                linkHref == locatorHref ||
+                    linkHref.endsWith("/$locatorHref") ||
+                    locatorHref.endsWith("/$linkHref")
+            }
+        }
+
+    private fun fallbackPositions(): List<List<Locator>> {
+        val count = readingOrder.size.coerceAtLeast(1)
+        return readingOrder.mapIndexed { index, link ->
+            listOf(
+                Locator(
+                    href = link.url(),
+                    mediaType = link.mediaType ?: MediaType.XHTML,
+                    title = link.title,
+                    locations = Locator.Locations(
+                        progression = 0.0,
+                        position = index + 1,
+                        totalProgression = index.toDouble() / count,
+                    ),
+                ),
+            )
+        }
+    }
+
+    private fun String.resourceKey(): String =
+        substringBefore('#')
+            .substringBefore('?')
+            .trimStart('/')
+}

--- a/app/src/main/java/koharia/epub/session/EpubReaderSession.kt
+++ b/app/src/main/java/koharia/epub/session/EpubReaderSession.kt
@@ -10,6 +10,8 @@ data class EpubReaderSession(
     val publication: Publication,
     val navigatorFactory: EpubNavigatorFactory,
     val initialLocator: Locator?,
+    val positionsController: EpubPositionsController,
+    val prefetchNextResource: suspend (Locator?) -> Unit = {},
 ) {
     fun close() {
         publication.close()

--- a/app/src/main/java/koharia/epub/session/EpubReaderSessionRepository.kt
+++ b/app/src/main/java/koharia/epub/session/EpubReaderSessionRepository.kt
@@ -3,15 +3,32 @@ package koharia.epub.session
 class EpubReaderSessionRepository {
 
     private val sessions = mutableMapOf<Long, EpubReaderSession>()
+    private val paginationSessions = mutableMapOf<Long, EpubReaderSession>()
 
     @Synchronized
     fun get(chapterId: Long): EpubReaderSession? = sessions[chapterId]
 
     @Synchronized
+    fun getForPagination(chapterId: Long): EpubReaderSession? =
+        paginationSessions[chapterId] ?: sessions[chapterId]
+
+    @Synchronized
+    fun hasDedicatedPaginationSession(chapterId: Long): Boolean = paginationSessions.containsKey(chapterId)
+
+    @Synchronized
     fun put(session: EpubReaderSession) {
+        paginationSessions.remove(session.chapterId)?.close()
         sessions.put(session.chapterId, session)?.close()
     }
 
     @Synchronized
-    fun remove(chapterId: Long): EpubReaderSession? = sessions.remove(chapterId)
+    fun putForPagination(session: EpubReaderSession) {
+        paginationSessions.put(session.chapterId, session)?.close()
+    }
+
+    @Synchronized
+    fun remove(chapterId: Long): EpubReaderSession? {
+        paginationSessions.remove(chapterId)?.close()
+        return sessions.remove(chapterId)
+    }
 }

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -1,6 +1,7 @@
 package koharia.komga.download
 
 import koharia.komga.api.dto.BookDto
+import koharia.komga.api.dto.isEpub
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.doubleOrNull
@@ -27,6 +28,9 @@ object KomgaChapterMemo {
     const val BOOK_TITLE = "bookTitle"
     const val NUMBER_SORT = "numberSort"
     const val ISBN = "isbn"
+    const val IS_EPUB = "isEpub"
+    const val FILE_LAST_MODIFIED = "fileLastModified"
+    const val FILE_NAME = "fileName"
 
     fun buildFingerprint(baseUrl: String, book: BookDto): KomgaBookFingerprint {
         return KomgaBookFingerprint(
@@ -42,7 +46,13 @@ object KomgaChapterMemo {
     }
 
     fun buildMemo(baseUrl: String, book: BookDto): JsonObject {
-        return buildMemo(buildFingerprint(baseUrl, book))
+        val fingerprint = buildMemo(buildFingerprint(baseUrl, book))
+        return buildJsonObject {
+            fingerprint.forEach { (key, value) -> put(key, value) }
+            put(IS_EPUB, book.isEpub)
+            if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
+            if (book.name.isNotBlank()) put(FILE_NAME, book.name)
+        }
     }
 
     fun buildMemo(fingerprint: KomgaBookFingerprint): JsonObject {
@@ -97,6 +107,12 @@ object KomgaChapterMemo {
             isbn = memo.string(ISBN).orEmpty(),
         )
     }
+
+    fun isEpub(memo: JsonObject): Boolean? = memo[IS_EPUB]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
+
+    fun fileLastModified(memo: JsonObject): String? = memo.string(FILE_LAST_MODIFIED)
+
+    fun fileName(memo: JsonObject): String? = memo.string(FILE_NAME)
 
     private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull()
 

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -4,6 +4,7 @@ import androidx.core.content.edit
 import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadIndexManager
+import koharia.epub.cache.EpubCacheManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
@@ -15,6 +16,7 @@ class KomgaServerRemovalManager(
     private val downloadProvider: DownloadProvider,
     private val downloadCache: DownloadCache,
     private val komgaSharedDownloadIndexManager: KomgaSharedDownloadIndexManager,
+    private val epubCacheManager: EpubCacheManager,
 ) {
 
     suspend fun removeServer(
@@ -27,6 +29,7 @@ class KomgaServerRemovalManager(
         withContext(Dispatchers.IO) {
             clearServerSettingsIfNeeded(serverId)
             cleanupDownloads(profile, options)
+            epubCacheManager.clearServer(serverId)
             localConfigManager.clearScopeForServer(serverId)
         }
         serverPreferences.setProfiles(currentProfiles - profile)

--- a/app/src/test/java/koharia/epub/cache/EpubCachePolicyTest.kt
+++ b/app/src/test/java/koharia/epub/cache/EpubCachePolicyTest.kt
@@ -1,0 +1,48 @@
+package koharia.epub.cache
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubCachePolicyTest {
+
+    @Test
+    fun `manual download wins over complete cache and remote`() {
+        assertEquals(
+            EpubCachePolicy.OpenSource.MANUAL_DOWNLOAD,
+            EpubCachePolicy.selectOpenSource("manual.epub", "cached.epub", "https://server/book"),
+        )
+    }
+
+    @Test
+    fun `complete cache wins over remote`() {
+        assertEquals(
+            EpubCachePolicy.OpenSource.COMPLETE_CACHE,
+            EpubCachePolicy.selectOpenSource(null, "cached.epub", "https://server/book"),
+        )
+    }
+
+    @Test
+    fun `publication key prefers hash then version and size`() {
+        assertEquals(
+            "komga:hash",
+            EpubCachePolicy.publicationKey("hash", "2026-07-16", 10L, "fallback"),
+        )
+        assertEquals(
+            "komga:2026-07-16:10",
+            EpubCachePolicy.publicationKey(null, "2026-07-16", 10L, "fallback"),
+        )
+        assertEquals(
+            "fallback",
+            EpubCachePolicy.publicationKey(null, null, 10L, "fallback"),
+        )
+    }
+
+    @Test
+    fun `resume only appends a matching partial response`() {
+        assertTrue(EpubCachePolicy.shouldAppendPartial(128L, 206, "bytes 128-255/256"))
+        assertFalse(EpubCachePolicy.shouldAppendPartial(128L, 200, null))
+        assertFalse(EpubCachePolicy.shouldAppendPartial(128L, 206, "bytes 0-255/256"))
+    }
+}

--- a/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
@@ -11,6 +11,7 @@ object LocalTempCacheDirectoryProvider {
     private const val NETWORK_CACHE_DIR = "network_cache"
     private const val CHAPTER_CACHE_DIR = "chapter_disk_cache"
     private const val METADATA_CACHE_DIR = "komga_metadata_cache"
+    private const val EPUB_CACHE_DIR = "epub_cache"
     private const val DOWNLOAD_INDEX_FILE = "dl_index_cache_v4"
     private const val COIL_DISK_CACHE_DIR = "coil3_disk_cache"
     private const val SHARED_IMAGE_DIR = "shared_image"
@@ -20,6 +21,8 @@ object LocalTempCacheDirectoryProvider {
     fun chapterCacheDir(context: Context): File = prepareDirectory(context, CHAPTER_CACHE_DIR)
 
     fun metadataCacheDir(context: Context): File = prepareDirectory(context, METADATA_CACHE_DIR)
+
+    fun epubCacheDir(context: Context): File = prepareDirectory(context, EPUB_CACHE_DIR)
 
     fun downloadIndexCacheFile(context: Context): File = prepareFile(context, DOWNLOAD_INDEX_FILE)
 
@@ -93,12 +96,14 @@ object LocalTempCacheDirectoryProvider {
         return listOf(
             chapterCacheDir(context),
             metadataCacheDir(context),
+            epubCacheDir(context),
             networkCacheDir(context),
             downloadIndexCacheFile(context),
             coilDiskCacheDir(context),
             sharedImageDir(context),
             legacyDirectory(context, CHAPTER_CACHE_DIR),
             legacyDirectory(context, METADATA_CACHE_DIR),
+            legacyDirectory(context, EPUB_CACHE_DIR),
             legacyDirectory(context, NETWORK_CACHE_DIR),
             legacyFile(context, DOWNLOAD_INDEX_FILE),
             legacyDirectory(context, COIL_DISK_CACHE_DIR),

--- a/data/src/main/java/koharia/data/epub/EpubRemoteProgressCacheRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubRemoteProgressCacheRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package koharia.data.epub
+
+import app.cash.sqldelight.async.coroutines.awaitAsList
+import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
+import koharia.domain.epub.model.EpubRemoteProgressCache
+import koharia.domain.epub.repository.EpubRemoteProgressCacheRepository
+import tachiyomi.data.Database
+import java.util.Date
+
+class EpubRemoteProgressCacheRepositoryImpl(
+    private val database: Database,
+) : EpubRemoteProgressCacheRepository {
+    override suspend fun getByChapterId(chapterId: Long): EpubRemoteProgressCache? =
+        database.epub_remote_progress_cacheQueries.getByChapterId(chapterId, ::map).awaitAsOneOrNull()
+
+    override suspend fun getByMangaId(mangaId: Long): List<EpubRemoteProgressCache> =
+        database.epub_remote_progress_cacheQueries.getByMangaId(mangaId, ::map).awaitAsList()
+
+    override suspend fun upsert(cache: EpubRemoteProgressCache) {
+        database.epub_remote_progress_cacheQueries.upsert(
+            chapterId = cache.chapterId,
+            mangaId = cache.mangaId,
+            bookUrl = cache.bookUrl,
+            locatorJson = cache.locatorJson,
+            progression = cache.progression,
+            positionIndex = cache.positionIndex,
+            modifiedAt = cache.modifiedAt,
+            checkedAt = cache.checkedAt,
+            serverDate = cache.serverDate,
+        )
+    }
+
+    private fun map(
+        chapterId: Long,
+        mangaId: Long,
+        bookUrl: String,
+        locatorJson: String?,
+        progression: Double?,
+        positionIndex: Long?,
+        modifiedAt: Date?,
+        checkedAt: Date,
+        serverDate: Date?,
+    ) = EpubRemoteProgressCache(
+        chapterId = chapterId,
+        mangaId = mangaId,
+        bookUrl = bookUrl,
+        locatorJson = locatorJson,
+        progression = progression,
+        positionIndex = positionIndex,
+        modifiedAt = modifiedAt,
+        checkedAt = checkedAt,
+        serverDate = serverDate,
+    )
+}

--- a/data/src/main/java/koharia/data/epub/EpubRemoteProgressCacheRepositoryImpl.kt
+++ b/data/src/main/java/koharia/data/epub/EpubRemoteProgressCacheRepositoryImpl.kt
@@ -4,7 +4,9 @@ import app.cash.sqldelight.async.coroutines.awaitAsList
 import app.cash.sqldelight.async.coroutines.awaitAsOneOrNull
 import koharia.domain.epub.model.EpubRemoteProgressCache
 import koharia.domain.epub.repository.EpubRemoteProgressCacheRepository
+import kotlinx.coroutines.flow.Flow
 import tachiyomi.data.Database
+import tachiyomi.data.subscribeToList
 import java.util.Date
 
 class EpubRemoteProgressCacheRepositoryImpl(
@@ -15,6 +17,9 @@ class EpubRemoteProgressCacheRepositoryImpl(
 
     override suspend fun getByMangaId(mangaId: Long): List<EpubRemoteProgressCache> =
         database.epub_remote_progress_cacheQueries.getByMangaId(mangaId, ::map).awaitAsList()
+
+    override fun subscribeByMangaId(mangaId: Long): Flow<List<EpubRemoteProgressCache>> =
+        database.epub_remote_progress_cacheQueries.getByMangaId(mangaId, ::map).subscribeToList()
 
     override suspend fun upsert(cache: EpubRemoteProgressCache) {
         database.epub_remote_progress_cacheQueries.upsert(

--- a/data/src/main/sqldelight/tachiyomi/data/epub_remote_progress_cache.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/epub_remote_progress_cache.sq
@@ -1,0 +1,46 @@
+import java.util.Date;
+
+CREATE TABLE epub_remote_progress_cache(
+    chapter_id INTEGER NOT NULL PRIMARY KEY,
+    manga_id INTEGER NOT NULL,
+    book_url TEXT NOT NULL,
+    locator_json TEXT,
+    progression REAL,
+    position_index INTEGER,
+    modified_at INTEGER AS Date,
+    checked_at INTEGER AS Date NOT NULL,
+    server_date INTEGER AS Date,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX epub_remote_progress_cache_manga_id_index
+ON epub_remote_progress_cache(manga_id);
+
+getByChapterId:
+SELECT * FROM epub_remote_progress_cache WHERE chapter_id = :chapterId;
+
+getByMangaId:
+SELECT * FROM epub_remote_progress_cache WHERE manga_id = :mangaId;
+
+upsert:
+INSERT INTO epub_remote_progress_cache(
+    chapter_id, manga_id, book_url, locator_json, progression, position_index,
+    modified_at, checked_at, server_date
+)
+VALUES (
+    :chapterId, :mangaId, :bookUrl, :locatorJson, :progression, :positionIndex,
+    :modifiedAt, :checkedAt, :serverDate
+)
+ON CONFLICT(chapter_id) DO UPDATE SET
+    manga_id = :mangaId,
+    book_url = :bookUrl,
+    locator_json = :locatorJson,
+    progression = :progression,
+    position_index = :positionIndex,
+    modified_at = :modifiedAt,
+    checked_at = :checkedAt,
+    server_date = :serverDate;
+
+deleteByChapterId:
+DELETE FROM epub_remote_progress_cache WHERE chapter_id = :chapterId;

--- a/data/src/main/sqldelight/tachiyomi/migrations/16.sqm
+++ b/data/src/main/sqldelight/tachiyomi/migrations/16.sqm
@@ -1,0 +1,16 @@
+CREATE TABLE epub_remote_progress_cache(
+    chapter_id INTEGER NOT NULL PRIMARY KEY,
+    manga_id INTEGER NOT NULL,
+    book_url TEXT NOT NULL,
+    locator_json TEXT,
+    progression REAL,
+    position_index INTEGER,
+    modified_at INTEGER,
+    checked_at INTEGER NOT NULL,
+    server_date INTEGER,
+    FOREIGN KEY(chapter_id) REFERENCES chapters (_id) ON DELETE CASCADE,
+    FOREIGN KEY(manga_id) REFERENCES mangas (_id) ON DELETE CASCADE
+);
+
+CREATE INDEX epub_remote_progress_cache_manga_id_index
+ON epub_remote_progress_cache(manga_id);

--- a/domain/src/main/java/koharia/domain/epub/interactor/GetEpubRemoteProgressCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/GetEpubRemoteProgressCache.kt
@@ -1,0 +1,10 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.repository.EpubRemoteProgressCacheRepository
+
+class GetEpubRemoteProgressCache(
+    private val repository: EpubRemoteProgressCacheRepository,
+) {
+    suspend fun await(chapterId: Long) = repository.getByChapterId(chapterId)
+    suspend fun awaitByMangaId(mangaId: Long) = repository.getByMangaId(mangaId)
+}

--- a/domain/src/main/java/koharia/domain/epub/interactor/GetEpubRemoteProgressCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/GetEpubRemoteProgressCache.kt
@@ -7,4 +7,5 @@ class GetEpubRemoteProgressCache(
 ) {
     suspend fun await(chapterId: Long) = repository.getByChapterId(chapterId)
     suspend fun awaitByMangaId(mangaId: Long) = repository.getByMangaId(mangaId)
+    fun subscribeByMangaId(mangaId: Long) = repository.subscribeByMangaId(mangaId)
 }

--- a/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubRemoteProgressCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/interactor/UpsertEpubRemoteProgressCache.kt
@@ -1,0 +1,10 @@
+package koharia.domain.epub.interactor
+
+import koharia.domain.epub.model.EpubRemoteProgressCache
+import koharia.domain.epub.repository.EpubRemoteProgressCacheRepository
+
+class UpsertEpubRemoteProgressCache(
+    private val repository: EpubRemoteProgressCacheRepository,
+) {
+    suspend fun await(cache: EpubRemoteProgressCache) = repository.upsert(cache)
+}

--- a/domain/src/main/java/koharia/domain/epub/model/EpubRemoteProgressCache.kt
+++ b/domain/src/main/java/koharia/domain/epub/model/EpubRemoteProgressCache.kt
@@ -1,0 +1,15 @@
+package koharia.domain.epub.model
+
+import java.util.Date
+
+data class EpubRemoteProgressCache(
+    val chapterId: Long,
+    val mangaId: Long,
+    val bookUrl: String,
+    val locatorJson: String?,
+    val progression: Double?,
+    val positionIndex: Long?,
+    val modifiedAt: Date?,
+    val checkedAt: Date,
+    val serverDate: Date?,
+)

--- a/domain/src/main/java/koharia/domain/epub/repository/EpubRemoteProgressCacheRepository.kt
+++ b/domain/src/main/java/koharia/domain/epub/repository/EpubRemoteProgressCacheRepository.kt
@@ -1,9 +1,11 @@
 package koharia.domain.epub.repository
 
 import koharia.domain.epub.model.EpubRemoteProgressCache
+import kotlinx.coroutines.flow.Flow
 
 interface EpubRemoteProgressCacheRepository {
     suspend fun getByChapterId(chapterId: Long): EpubRemoteProgressCache?
     suspend fun getByMangaId(mangaId: Long): List<EpubRemoteProgressCache>
+    fun subscribeByMangaId(mangaId: Long): Flow<List<EpubRemoteProgressCache>>
     suspend fun upsert(cache: EpubRemoteProgressCache)
 }

--- a/domain/src/main/java/koharia/domain/epub/repository/EpubRemoteProgressCacheRepository.kt
+++ b/domain/src/main/java/koharia/domain/epub/repository/EpubRemoteProgressCacheRepository.kt
@@ -1,0 +1,9 @@
+package koharia.domain.epub.repository
+
+import koharia.domain.epub.model.EpubRemoteProgressCache
+
+interface EpubRemoteProgressCacheRepository {
+    suspend fun getByChapterId(chapterId: Long): EpubRemoteProgressCache?
+    suspend fun getByMangaId(mangaId: Long): List<EpubRemoteProgressCache>
+    suspend fun upsert(cache: EpubRemoteProgressCache)
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1307,4 +1307,15 @@
     <string name="epub_reader_font_size_input_range">Enter a font size from 13 to 32</string>
     <string name="epub_reader_reading_mode_settings">Reading mode</string>
     <string name="epub_reader_show_reading_progress">Show reading progress</string>
+    <string name="pref_book_cache">Book cache</string>
+    <string name="pref_cache_whole_book">Cache the whole book</string>
+    <string name="pref_cache_whole_book_summary">Cache the complete EPUB after the first page is shown. When disabled, only the current and next sections are cached.</string>
+    <string name="pref_book_cache_size">Book cache limit</string>
+    <string name="cache_size_megabytes">%1$d MB</string>
+    <string name="pref_clear_book_cache">Clear book cache</string>
+    <string name="pref_book_cache_info">Book cache is managed separately from downloads. Clearing it does not remove offline downloads, reading progress, or bookmarks.</string>
+    <string name="epub_reader_remote_progress_title">Server reading progress</string>
+    <string name="epub_reader_remote_progress_message">The server has a different saved position (%1$d%%). Jump to it?</string>
+    <string name="epub_reader_keep_local_progress">Keep current position</string>
+    <string name="epub_reader_jump_remote_progress">Jump to server position</string>
 </resources>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -1168,4 +1168,15 @@
     <string name="epub_reader_font_size_input_range">请输入 13 至 32 之间的字号</string>
     <string name="epub_reader_reading_mode_settings">阅读模式</string>
     <string name="epub_reader_show_reading_progress">显示阅读进度</string>
+    <string name="pref_book_cache">书籍缓存</string>
+    <string name="pref_cache_whole_book">完整缓存整本书</string>
+    <string name="pref_cache_whole_book_summary">显示首个页面后缓存完整 EPUB；关闭时仅缓存当前章节和下一章节。</string>
+    <string name="pref_book_cache_size">书籍缓存上限</string>
+    <string name="cache_size_megabytes">%1$d MB</string>
+    <string name="pref_clear_book_cache">清除书籍缓存</string>
+    <string name="pref_book_cache_info">书籍缓存与下载相互独立。清除缓存不会删除离线下载、阅读进度或书签。</string>
+    <string name="epub_reader_remote_progress_title">服务器阅读进度</string>
+    <string name="epub_reader_remote_progress_message">服务器保存了不同的阅读位置（%1$d%%），是否跳转？</string>
+    <string name="epub_reader_keep_local_progress">保留当前位置</string>
+    <string name="epub_reader_jump_remote_progress">跳转至服务器进度</string>
 </resources>


### PR DESCRIPTION
## 中文

### 概要

本次更新为 EPUB 阅读器增加首屏优先的加载流程、独立书籍缓存体系、云端进度缓存和更稳定的分页进度体验。阅读器会优先展示正文，并将完整缓存、资源预取、云端复核和视觉分页放在后续阶段完成。

### 功能变化

- 优化 EPUB 打开优先级：手动下载文件、完整书籍缓存、按需资源缓存、Komga 远程资源依次作为数据源。
- 新增独立的“书籍缓存”体系，与用户主动下载完全分离，不改变书籍的下载状态。
- 支持后台完整缓存 EPUB，并提供临时文件、续传、原子完成标记、阅读会话占用保护和 LRU 容量管理。
- 支持按需缓存 WebPub manifest、positions、XHTML、CSS、图片和字体，并预取下一阅读资源。
- 在“数据与存储”中新增完整缓存开关、缓存容量、占用空间和清除书籍缓存选项。
- 隐私模式下仅使用内存数据，不写入书籍缓存或远程进度缓存。
- 详情页优先显示本地数据和缓存进度，再在后台刷新 Komga 数据及下载状态。
- 新增 EPUB 云端进度本地缓存，在阅读会话中复用服务器 Locator，并支持本地与服务器位置选择。
- 排版设置变化时保留当前本地阅读位置，后台重新计算视觉页数，期间继续显示稳定的百分比进度。
- 优化 Readium positions 管理，使正文显示、进度定位和后台 positions 更新相互独立。
- 改进进度条拖动定位，只处理最新跳转目标，并同步更新百分比、position、当前视觉页和总页数。
- 统一本地 EPUB 路径与 Komga 资源 URL 的页数匹配，支持缓存页数在远程与本地阅读数据源之间复用。
- 完整分页缓存可用时立即恢复当前页与总页数；缓存无效或排版变化时使用百分比并异步重算。

## English

### Summary

This update adds a first-screen-first loading flow, an independent managed book cache, cached cloud progress, and a more stable pagination experience for the EPUB reader. Reading content is prioritized while full-book caching, resource prefetching, cloud reconciliation, and visual pagination continue afterward.

### Functional changes

- Prioritizes EPUB data sources in this order: manual downloads, complete book cache, on-demand resource cache, and Komga remote resources.
- Adds a managed “Book cache” that is fully separate from user-initiated downloads and never changes download status.
- Supports background full-EPUB caching with partial transfers, resume support, atomic completion markers, active-reading leases, and LRU capacity management.
- Caches WebPub manifests, positions, XHTML, CSS, images, and fonts on demand, with prefetching for the next reading resource.
- Adds full-book caching, cache capacity, storage usage, and clear-book-cache controls under Data & Storage.
- Keeps book and remote-progress caches memory-only in incognito mode.
- Shows local details and cached progress first, then refreshes Komga metadata and download state in the background.
- Adds a local EPUB remote-progress cache for reusing server Locators and choosing between local and server reading positions.
- Preserves the local reading position when layout preferences change, recalculates visual pages in the background, and keeps percentage progress available during recalculation.
- Improves Readium positions management so content display, progression lookup, and background positions updates remain independent.
- Improves progress-slider navigation by accepting only the latest target and synchronizing percentage, position, current visual page, and total pages.
- Matches local EPUB resource paths and Komga resource URLs consistently so pagination data can be reused across local and remote sources.
- Restores current and total visual pages immediately when a complete pagination cache is available, and falls back to percentage progress while invalidated layouts are recalculated.
