### PR TITLE
build: 升级 AGP 9.3 并清理构建告警 / Upgrade AGP 9.3 and clean up build warnings

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,12 +70,12 @@ android {
     }
 
     buildTypes {
-        val debug by getting {
+        val debug = getByName("debug") {
             applicationIdSuffix = ".dev"
             versionNameSuffix = "-${getLatestCommitCount()}"
             isPseudoLocalesEnabled = true
         }
-        val release by getting {
+        val release = getByName("release") {
             isMinifyEnabled = Config.enableCodeShrink
             isShrinkResources = Config.enableCodeShrink
             if (hasReleaseKeystore) {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesDisplay.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaNotesDisplay.kt
@@ -13,11 +13,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichText
 
 private val FADE_TIME = tween<Float>(500)
 
+@OptIn(ExperimentalRichTextApi::class)
 @Composable
 fun MangaNotesDisplay(
     content: String,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -7,6 +7,9 @@ import eu.kanade.tachiyomi.source.model.Page
 import koharia.source.komga.DownloadDirectoryMode
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.drop
@@ -46,6 +49,8 @@ class DownloadManager(
     private val downloadPreferences: DownloadPreferences = Injekt.get(),
     private val komgaServerPreferences: KomgaServerPreferences = Injekt.get(),
 ) {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /**
      * Downloader whose only task is to download chapters.
@@ -300,7 +305,7 @@ class DownloadManager(
      * @param source the source of the chapters.
      */
     fun deleteChapters(chapters: List<Chapter>, manga: Manga, source: Source) {
-        launchIO {
+        scope.launchIO {
             val filteredChapters = getChaptersToDelete(chapters, manga)
             if (filteredChapters.isEmpty()) {
                 return@launchIO
@@ -334,7 +339,7 @@ class DownloadManager(
      * @param removeQueued whether to also remove queued downloads.
      */
     fun deleteManga(manga: Manga, source: Source, removeQueued: Boolean = true) {
-        launchIO {
+        scope.launchIO {
             if (removeQueued) {
                 downloader.removeFromQueue(manga)
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -46,7 +46,6 @@ import okhttp3.Response
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.launchIO
-import tachiyomi.core.common.util.lang.launchNow
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.ImageUtil
 import tachiyomi.core.common.util.system.logcat
@@ -122,9 +121,7 @@ class Downloader(
     var isPaused: Boolean = false
 
     init {
-        launchNow {
-            restorePersistedQueueIfNeeded()
-        }
+        restorePersistedQueueIfNeeded()
     }
 
     /**
@@ -703,14 +700,12 @@ class Downloader(
                     }
 
                     cache.addChapter(resolvedFinalFileName, mangaDir, download.manga)
-                    (download.source as? KomgaSource)?.let { komgaSource ->
-                        mangaDir.findFile(resolvedFinalFileName)?.let { finalizedFile ->
-                            komgaSharedDownloadIndexManager.indexDownloadedChapter(
-                                download.chapter,
-                                komgaSource,
-                                finalizedFile,
-                            )
-                        }
+                    mangaDir.findFile(resolvedFinalFileName)?.let { finalizedFile ->
+                        komgaSharedDownloadIndexManager.indexDownloadedChapter(
+                            download.chapter,
+                            source,
+                            finalizedFile,
+                        )
                     }
                     DiskUtil.createNoMediaFile(mangaDir, context)
                     download.status = Download.State.DOWNLOADED

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -121,7 +121,9 @@ class Downloader(
     var isPaused: Boolean = false
 
     init {
-        restorePersistedQueueIfNeeded()
+        scope.launch {
+            restorePersistedQueueIfNeeded()
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -31,7 +31,6 @@ import eu.kanade.tachiyomi.util.system.notify
 import tachiyomi.core.common.Constants
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.library.model.LibraryManga
 import tachiyomi.domain.manga.model.Manga
@@ -166,7 +165,7 @@ class LibraryUpdateNotifier(
      *
      * @param updates a list of manga with new updates.
      */
-    fun showUpdateNotifications(updates: List<Pair<Manga, Array<Chapter>>>) {
+    suspend fun showUpdateNotifications(updates: List<Pair<Manga, Array<Chapter>>>) {
         // Parent group notification
         context.notify(
             Notifications.ID_NEW_CHAPTERS,
@@ -209,16 +208,14 @@ class LibraryUpdateNotifier(
 
         // Per-manga notification
         if (!securityPreferences.hideNotificationContent.get()) {
-            launchUI {
-                context.notify(
-                    updates.map { (manga, chapters) ->
-                        NotificationManagerCompat.NotificationWithIdAndTag(
-                            manga.id.hashCode(),
-                            createNewChaptersNotification(manga, chapters),
-                        )
-                    },
-                )
-            }
+            context.notify(
+                updates.map { (manga, chapters) ->
+                    NotificationManagerCompat.NotificationWithIdAndTag(
+                        manga.id.hashCode(),
+                        createNewChaptersNotification(manga, chapters),
+                    )
+                },
+            )
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -17,9 +17,12 @@ import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import koharia.epub.EpubReaderLauncher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.Constants
-import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
@@ -47,6 +50,7 @@ class NotificationReceiver : BroadcastReceiver() {
     private val getChapter: GetChapter by injectLazy()
     private val updateChapter: UpdateChapter by injectLazy()
     private val downloadManager: DownloadManager by injectLazy()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
@@ -79,21 +83,16 @@ class NotificationReceiver : BroadcastReceiver() {
             // Cancel downloading app update
             ACTION_CANCEL_APP_UPDATE_DOWNLOAD -> cancelDownloadAppUpdate(context)
             // Open reader activity
-            ACTION_OPEN_CHAPTER -> {
-                val pendingResult = goAsync()
-                launchIO {
-                    try {
-                        openChapter(
-                            context,
-                            intent.getLongExtra(EXTRA_MANGA_ID, -1),
-                            intent.getLongExtra(EXTRA_CHAPTER_ID, -1),
-                        )
-                    } catch (error: Exception) {
-                        logcat(LogPriority.ERROR, error) { "Failed to open EPUB chapter from notification" }
-                        withUIContext { context.toast(MR.strings.chapter_error) }
-                    } finally {
-                        pendingResult.finish()
-                    }
+            ACTION_OPEN_CHAPTER -> launchAsync {
+                try {
+                    openChapter(
+                        context,
+                        intent.getLongExtra(EXTRA_MANGA_ID, -1),
+                        intent.getLongExtra(EXTRA_CHAPTER_ID, -1),
+                    )
+                } catch (error: Exception) {
+                    logcat(LogPriority.ERROR, error) { "Failed to open EPUB chapter from notification" }
+                    withUIContext { context.toast(MR.strings.chapter_error) }
                 }
             }
             // Mark updated manga chapters as read
@@ -209,7 +208,7 @@ class NotificationReceiver : BroadcastReceiver() {
         val downloadPreferences: DownloadPreferences = Injekt.get()
         val sourceManager: SourceManager = Injekt.get()
 
-        launchIO {
+        launchAsync {
             val toUpdate = chapterUrls.mapNotNull { getChapter.await(it, mangaId) }
                 .map {
                     val chapter = it.copy(read = true)
@@ -235,10 +234,21 @@ class NotificationReceiver : BroadcastReceiver() {
      * @param mangaId id of manga
      */
     private fun downloadChapters(chapterUrls: Array<String>, mangaId: Long) {
-        launchIO {
-            val manga = getManga.await(mangaId) ?: return@launchIO
+        launchAsync {
+            val manga = getManga.await(mangaId) ?: return@launchAsync
             val chapters = chapterUrls.mapNotNull { getChapter.await(it, mangaId) }
             downloadManager.downloadChapters(manga, chapters)
+        }
+    }
+
+    private fun launchAsync(block: suspend CoroutineScope.() -> Unit) {
+        val pendingResult = goAsync()
+        scope.launch {
+            try {
+                block()
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
 import logcat.LogPriority
@@ -26,6 +27,8 @@ import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.math.min
+
+private val pageListCacheWriteScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
 /**
  * Loader used to load chapters from an online source.
@@ -150,7 +153,7 @@ internal class HttpPageLoader(
 
         // Cache current page list progress for online chapters to allow a faster reopen
         chapter.pages?.let { pages ->
-            launchIO {
+            pageListCacheWriteScope.launch {
                 try {
                     // Convert to pages without reader information
                     val pagesToSave = pages.map { Page(it.index, it.url, it.imageUrl) }

--- a/app/src/main/java/koharia/epub/EpubNavigationSheet.kt
+++ b/app/src/main/java/koharia/epub/EpubNavigationSheet.kt
@@ -204,20 +204,16 @@ private fun BookmarkTab(
                 progressionText,
                 bookmark.note?.takeIf(String::isNotBlank),
             ).joinToString(" | ").takeIf(String::isNotBlank)
-            val dismissState = rememberSwipeToDismissBoxState(
-                confirmValueChange = { value ->
-                    if (value != SwipeToDismissBoxValue.Settled) {
-                        onDelete(bookmark)
-                        true
-                    } else {
-                        false
-                    }
-                },
-            )
+            val dismissState = rememberSwipeToDismissBoxState()
             Column {
                 SwipeToDismissBox(
                     state = dismissState,
                     enableDismissFromStartToEnd = false,
+                    onDismiss = { direction ->
+                        if (direction == SwipeToDismissBoxValue.EndToStart) {
+                            onDelete(bookmark)
+                        }
+                    },
                     backgroundContent = {
                         Row(
                             modifier = Modifier

--- a/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
@@ -325,8 +325,8 @@ class EpubCacheManager(
             continuation.invokeOnCancellation { cancel() }
             enqueue(
                 object : Callback {
-                    override fun onFailure(call: Call, error: IOException) {
-                        val token = continuation.tryResumeWithException(error) ?: return
+                    override fun onFailure(call: Call, e: IOException) {
+                        val token = continuation.tryResumeWithException(e) ?: return
                         continuation.completeResume(token)
                     }
 

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -1221,13 +1221,17 @@ private fun SpacingPresetSection(
                 EpubLayoutPreferences.SpacingMode.RELAXED -> stringResource(MR.strings.pref_epub_spacing_relaxed)
                 EpubLayoutPreferences.SpacingMode.STANDARD -> stringResource(MR.strings.pref_epub_spacing_standard)
                 EpubLayoutPreferences.SpacingMode.COMPACT -> stringResource(MR.strings.pref_epub_spacing_compact)
-                else -> error("Only visual spacing presets are rendered here")
+                EpubLayoutPreferences.SpacingMode.NONE,
+                EpubLayoutPreferences.SpacingMode.CUSTOM,
+                -> error("Only visual spacing presets are rendered here")
             }
             val icon = when (mode) {
                 EpubLayoutPreferences.SpacingMode.RELAXED -> Icons.Outlined.DensityLarge
                 EpubLayoutPreferences.SpacingMode.STANDARD -> Icons.Outlined.DensityMedium
                 EpubLayoutPreferences.SpacingMode.COMPACT -> Icons.Outlined.DensitySmall
-                else -> error("Only visual spacing presets are rendered here")
+                EpubLayoutPreferences.SpacingMode.NONE,
+                EpubLayoutPreferences.SpacingMode.CUSTOM,
+                -> error("Only visual spacing presets are rendered here")
             }
             Surface(
                 onClick = { preferences.applySpacingMode(mode) },

--- a/app/src/main/java/koharia/feature/support/SupportUsScreen.kt
+++ b/app/src/main/java/koharia/feature/support/SupportUsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
@@ -21,10 +20,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -108,35 +109,29 @@ class SupportUsScreen : Screen() {
 
     @Composable
     private fun MihonSupportLinks() {
-        val uriHandler = LocalUriHandler.current
         val primary = MaterialTheme.colorScheme.primary
         val annotated = buildAnnotatedString {
             append(stringResource(MR.strings.supportUsScreen_mihonSupportPrefix))
 
-            pushStringAnnotation(tag = "URL", annotation = Constants.URL_DONATE_PATREON)
-            withStyle(SpanStyle(color = primary, textDecoration = TextDecoration.Underline)) {
-                append("Patreon")
+            withLink(LinkAnnotation.Url(Constants.URL_DONATE_PATREON)) {
+                withStyle(SpanStyle(color = primary, textDecoration = TextDecoration.Underline)) {
+                    append("Patreon")
+                }
             }
-            pop()
 
             append(stringResource(MR.strings.supportUsScreen_mihonSupportSeparator))
 
-            pushStringAnnotation(tag = "URL", annotation = Constants.URL_DONATE_OPENCOLLECTIVE)
-            withStyle(SpanStyle(color = primary, textDecoration = TextDecoration.Underline)) {
-                append("OpenCollective")
+            withLink(LinkAnnotation.Url(Constants.URL_DONATE_OPENCOLLECTIVE)) {
+                withStyle(SpanStyle(color = primary, textDecoration = TextDecoration.Underline)) {
+                    append("OpenCollective")
+                }
             }
-            pop()
         }
 
-        ClickableText(
+        Text(
             text = annotated,
             style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.onSurface),
             modifier = Modifier.padding(horizontal = MaterialTheme.padding.medium),
-            onClick = { offset ->
-                annotated.getStringAnnotations(tag = "URL", start = offset, end = offset)
-                    .firstOrNull()
-                    ?.let { uriHandler.openUri(it.item) }
-            },
         )
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,6 @@ org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/build-logic/gradle.properties
+++ b/gradle/build-logic/gradle.properties
@@ -6,3 +6,6 @@ org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.parallel=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "14.2.0"
 android-desugar = "2.1.5"
-android-gradle = "9.2.1"
+android-gradle = "9.3.0"
 androidx-activity-compose = "1.13.0"
 androidx-annotation = "1.10.0"
 androidx-appCompat = "1.7.1"


### PR DESCRIPTION
## 中文

### 修改内容

- 将 Android Gradle Plugin 升级至 9.3.0，并同步主构建与独立 build-logic 的并行 Tooling API 配置。
- 更新应用构建类型 DSL，兼容 Gradle 10 后续版本。
- 清理 Kotlin、Compose 与协程相关构建告警，包括富文本实验 API、通知与下载任务作用域、冗余类型转换和分支。
- 将支持页面链接迁移到 Compose `LinkAnnotation`。
- 将 EPUB 书签滑动删除迁移到新版 `SwipeToDismissBox(onDismiss)`，使用方向受限的动态 anchors。

### 影响

- Debug Kotlin 构建不再产生本次列出的源码和 Gradle DSL 告警。
- 异步广播任务具备完整的 `goAsync()` 生命周期，下载、通知和页面缓存任务不再依赖 delicate `GlobalScope` 包装器。
- EPUB 书签仍支持从右向左滑动删除，并与新版 Material3 API 保持兼容。

## English

### Changes

- Upgrade Android Gradle Plugin to 9.3.0 and synchronize parallel Tooling API settings across the main build and included build logic.
- Update application build-type DSL for future Gradle 10 compatibility.
- Clean up Kotlin, Compose, and coroutine build warnings, including rich-text opt-in, scoped notification/download work, redundant casts, and exhaustive branches.
- Migrate support links to Compose `LinkAnnotation`.
- Migrate EPUB bookmark swipe-to-delete to the current `SwipeToDismissBox(onDismiss)` API with direction-restricted dynamic anchors.

### Impact

- Debug Kotlin builds no longer emit the addressed source and Gradle DSL warnings.
- Asynchronous broadcast work now follows the complete `goAsync()` lifecycle, while download, notification, and page-cache tasks no longer rely on delicate `GlobalScope` wrappers.
- EPUB bookmarks retain right-to-left swipe deletion with current Material3 behavior.

## Checks

- `./gradlew.bat :app:compileDebugKotlin --warning-mode all --no-daemon`
- `./gradlew.bat spotlessCheck --no-daemon`
- Manual Android Studio build