### PR TITLE
修复 EPUB 云端进度重复提示与服务器时间戳偏移 / Fix EPUB remote progress prompts and timestamp offsets

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -868,6 +868,7 @@ object SettingsReaderScreen : SearchableSettings {
 
     @Composable
     private fun getEpubReaderGroup(epubReaderPreferences: EpubReaderPreferences): Preference.PreferenceGroup {
+        val syncProgressionToKomga by epubReaderPreferences.syncProgressionToKomga.collectAsState()
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_epub_reader),
             preferenceItems = persistentListOf(
@@ -880,6 +881,12 @@ object SettingsReaderScreen : SearchableSettings {
                     preference = epubReaderPreferences.syncProgressionToKomga,
                     title = stringResource(MR.strings.pref_sync_epub_progression_komga),
                     subtitle = stringResource(MR.strings.pref_sync_epub_progression_komga_summary),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = epubReaderPreferences.correctKomgaServerTimestamps,
+                    title = stringResource(MR.strings.pref_correct_komga_server_timestamps),
+                    subtitle = stringResource(MR.strings.pref_correct_komga_server_timestamps_summary),
+                    enabled = syncProgressionToKomga,
                 ),
                 Preference.PreferenceItem.ListPreference(
                     preference = epubReaderPreferences.completionThresholdPercent,

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -177,7 +177,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { KomgaEpubPublicationService() }
         addSingletonFactory { EpubPublicationResolver() }
         addSingletonFactory { EpubReaderSupportResolver() }
-        addSingletonFactory { KomgaEpubProgressSyncService(get(), get()) }
+        addSingletonFactory { KomgaEpubProgressSyncService(get(), get(), get()) }
         addSingletonFactory { KomgaEpubRemoteProgressCoordinator(get(), get(), get(), get()) }
 
         // Asynchronously init expensive components for a faster cold start

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -455,23 +455,28 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 val serverTimeOffsetMinutes = remoteCache?.serverDate?.serverTimeOffsetMinutes()
                 val persistedLocator = localProgress?.toLocatorOrNull()
                 val savedStateLocator = restoreLocator()
+                val deferCachedRemoteSelection =
+                    epubReaderPreferences.correctKomgaServerTimestamps.get() &&
+                        persistedLocator != null &&
+                        remoteProgress != null
+                val initialRemoteProgress = remoteProgress.takeUnless { deferCachedRemoteSelection }
                 val initialLocator = savedStateLocator
                     ?: if (preserveLocalProgressAfterLayoutChange) {
                         persistedLocator
                     } else {
-                        chooseMoreRecentLocator(localProgress, remoteProgress)
+                        chooseMoreRecentLocator(localProgress, initialRemoteProgress)
                     }
                 val acceptedRemoteInitially = savedStateLocator == null &&
                     !preserveLocalProgressAfterLayoutChange &&
-                    remoteProgress != null &&
+                    initialRemoteProgress != null &&
                     (
                         localProgress == null ||
-                            remoteProgress.modifiedAt.time > localProgress.updatedAt.time ||
+                            initialRemoteProgress.modifiedAt.time > localProgress.updatedAt.time ||
                             persistedLocator == null
                         )
                 if (acceptedRemoteInitially) {
-                    initiallyAcceptedRemoteLocator = remoteProgress.locator
-                    initiallyAcceptedRemoteModifiedAt = remoteProgress.modifiedAt
+                    initiallyAcceptedRemoteLocator = initialRemoteProgress.locator
+                    initiallyAcceptedRemoteModifiedAt = initialRemoteProgress.modifiedAt
                 }
 
                 logcat(LogPriority.DEBUG) {
@@ -481,6 +486,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         "localUpdated=${localProgress?.updatedAt?.time} " +
                         "remote=${remoteProgress?.locator.debugProgress()} " +
                         "remoteUpdated=${remoteProgress?.modifiedAt?.time} " +
+                        "deferredRemoteTimestampCheck=$deferCachedRemoteSelection " +
                         "selected=${initialLocator.debugProgress()}"
                 }
 
@@ -565,7 +571,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     )
                 }
 
-                if (!incognito && !preserveLocalProgressAfterLayoutChange) {
+                if (!incognito && !preserveLocalProgressAfterLayoutChange && !deferCachedRemoteSelection) {
                     val selectedRemote = remoteProgress?.takeIf {
                         localProgress == null || it.modifiedAt.time > localProgress.updatedAt.time
                     }

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -184,6 +184,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var positionsRefreshStarted = false
     private var lastPrefetchedHref: String? = null
     private var remoteProgressChecked = false
+    private var initiallyAcceptedRemoteLocator: Locator? = null
+    private var initiallyAcceptedRemoteModifiedAt: Date? = null
     private var layoutChangeRevision = 0L
     private var preserveLocalProgressAfterLayoutChange = false
     private var currentChapter: tachiyomi.domain.chapter.model.Chapter? = null
@@ -234,6 +236,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
         completeCacheStarted = false
         positionsRefreshStarted = false
         lastPrefetchedHref = null
+        initiallyAcceptedRemoteLocator = null
+        initiallyAcceptedRemoteModifiedAt = null
         layoutChangeRevision += 1
         this.preserveLocalProgressAfterLayoutChange = preserveLocalProgressAfterLayoutChange
         remoteProgressChecked = preserveLocalProgressAfterLayoutChange
@@ -457,6 +461,18 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     } else {
                         chooseMoreRecentLocator(localProgress, remoteProgress)
                     }
+                val acceptedRemoteInitially = savedStateLocator == null &&
+                    !preserveLocalProgressAfterLayoutChange &&
+                    remoteProgress != null &&
+                    (
+                        localProgress == null ||
+                            remoteProgress.modifiedAt.time > localProgress.updatedAt.time ||
+                            persistedLocator == null
+                        )
+                if (acceptedRemoteInitially) {
+                    initiallyAcceptedRemoteLocator = remoteProgress.locator
+                    initiallyAcceptedRemoteModifiedAt = remoteProgress.modifiedAt
+                }
 
                 logcat(LogPriority.DEBUG) {
                     "EPUB progress restore chapterId=${chapter.id} " +
@@ -800,6 +816,33 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
                 ?: return@launch
             val modifiedAt = remote.modifiedAt ?: return@launch
+            val acceptedRemoteLocator = initiallyAcceptedRemoteLocator
+            if (acceptedRemoteLocator != null && locator.isSamePaginationLocation(acceptedRemoteLocator)) {
+                val acceptedRemoteModifiedAt = initiallyAcceptedRemoteModifiedAt
+                val progress = currentProgress
+                if (acceptedRemoteModifiedAt != null &&
+                    progress != null &&
+                    progress.updatedAt.time == acceptedRemoteModifiedAt.time &&
+                    modifiedAt.time != acceptedRemoteModifiedAt.time
+                ) {
+                    val correctedProgress = progress.copy(
+                        updatedAt = modifiedAt,
+                        lastSyncedAt = modifiedAt,
+                    )
+                    currentProgress = correctedProgress
+                    upsertEpubProgress.await(correctedProgress)
+                    initiallyAcceptedRemoteModifiedAt = modifiedAt
+                    logcat(LogPriority.DEBUG) {
+                        "Corrected accepted initial EPUB remote timestamp chapterId=$chapterId " +
+                            "raw=${acceptedRemoteModifiedAt.time} corrected=${modifiedAt.time}"
+                    }
+                }
+                logcat(LogPriority.DEBUG) {
+                    "Ignoring already accepted initial EPUB remote progress chapterId=$chapterId " +
+                        "remote=${locator.debugProgress()} current=${latestLocator.debugProgress()}"
+                }
+                return@launch
+            }
             val localUpdatedAt = currentProgress?.updatedAt?.time
             if (localUpdatedAt != null && modifiedAt.time <= localUpdatedAt) {
                 logcat(LogPriority.DEBUG) {

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -32,6 +32,8 @@ class KomgaEpubProgressSyncService(
     private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory,
 ) {
 
+    private val recentPushes = ConcurrentHashMap<ProgressionKey, RecentPush>()
+
     suspend fun pullProgression(
         sourceId: Long,
         bookUrl: String,
@@ -125,9 +127,12 @@ class KomgaEpubProgressSyncService(
         val storedOffsetMinutes = offsetPreference.get()
         val key = ProgressionKey(sourceId, normalizedBookUrl)
         val now = System.currentTimeMillis()
-        val recentPush = recentPushes[key]
+        val observedRecentPush = recentPushes[key]
+        val recentPush = observedRecentPush
             ?.takeIf { now - it.recordedAtMillis <= RECENT_PUSH_EVIDENCE_TTL_MS }
-            .also { if (it == null) recentPushes.remove(key) }
+        if (observedRecentPush != null && recentPush == null) {
+            recentPushes.remove(key, observedRecentPush)
+        }
 
         val pushedOffsetMinutes = recentPush?.let {
             inferWholeHourOffsetMinutes(rawModifiedAt.time - it.modifiedAtMillis)
@@ -256,7 +261,5 @@ class KomgaEpubProgressSyncService(
         const val OFFSET_EVIDENCE_TOLERANCE_MS = 5 * MINUTE_MS
         const val RECENT_PUSH_EVIDENCE_TTL_MS = 5 * MINUTE_MS
         const val MAX_CORRECTION_HOURS = 24L
-
-        val recentPushes = ConcurrentHashMap<ProgressionKey, RecentPush>()
     }
 }

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -4,7 +4,9 @@ import android.os.Build
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.await
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
+import logcat.LogPriority
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -13,16 +15,21 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.readium.r2.shared.publication.Locator
 import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.source.service.SourceManager
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Date
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.abs
+import kotlin.math.roundToLong
 
 class KomgaEpubProgressSyncService(
     private val basePreferences: BasePreferences,
     private val sourceManager: SourceManager,
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory,
 ) {
 
     suspend fun pullProgression(
@@ -43,9 +50,17 @@ class KomgaEpubProgressSyncService(
 
                 val json = JSONObject(body)
                 val locator = json.optJSONObject("locator")?.let(Locator::fromJSON)
-                val modifiedAt = json.optString("modified")
+                val rawModifiedAt = json.optString("modified")
                     .takeIf(String::isNotBlank)
                     ?.let(::parseDate)
+                val modifiedAt = rawModifiedAt?.let {
+                    correctRemoteModifiedAt(
+                        sourceId = sourceId,
+                        normalizedBookUrl = normalizedBookUrl,
+                        rawModifiedAt = it,
+                        serverDate = serverDate,
+                    )
+                }
                 val progression = if (locator != null && modifiedAt != null) {
                     RemoteProgression(locator = locator, modifiedAt = modifiedAt)
                 } else {
@@ -86,7 +101,79 @@ class KomgaEpubProgressSyncService(
 
         source.client.newCall(request).await().use { response ->
             response.requireSuccess("push")
+            if (scopedPreferenceStoreFactory.epubReaderPreferences(sourceId)
+                    .correctKomgaServerTimestamps.get()
+            ) {
+                recentPushes[ProgressionKey(sourceId, normalizedBookUrl)] = RecentPush(
+                    modifiedAtMillis = modifiedAt.time,
+                    recordedAtMillis = System.currentTimeMillis(),
+                )
+            }
         }
+    }
+
+    private fun correctRemoteModifiedAt(
+        sourceId: Long,
+        normalizedBookUrl: String,
+        rawModifiedAt: Date,
+        serverDate: Date?,
+    ): Date {
+        val preferences = scopedPreferenceStoreFactory.epubReaderPreferences(sourceId)
+        if (!preferences.correctKomgaServerTimestamps.get()) return rawModifiedAt
+
+        val offsetPreference = preferences.komgaServerTimestampOffsetMinutes(sourceId)
+        val storedOffsetMinutes = offsetPreference.get()
+        val key = ProgressionKey(sourceId, normalizedBookUrl)
+        val now = System.currentTimeMillis()
+        val recentPush = recentPushes[key]
+            ?.takeIf { now - it.recordedAtMillis <= RECENT_PUSH_EVIDENCE_TTL_MS }
+            .also { if (it == null) recentPushes.remove(key) }
+
+        val pushedOffsetMinutes = recentPush?.let {
+            inferWholeHourOffsetMinutes(rawModifiedAt.time - it.modifiedAtMillis)
+        }
+        val serverOffsetMinutes = serverDate
+            ?.takeIf { rawModifiedAt.time - it.time >= MIN_FUTURE_DRIFT_MS }
+            ?.let { inferWholeHourOffsetMinutes(rawModifiedAt.time - it.time) }
+        val inferredOffsetMinutes = pushedOffsetMinutes ?: serverOffsetMinutes
+
+        val remoteMatchesRecentPush = recentPush != null &&
+            abs(rawModifiedAt.time - recentPush.modifiedAtMillis) <= OFFSET_EVIDENCE_TOLERANCE_MS
+        val appliedOffsetMinutes = when {
+            inferredOffsetMinutes != null -> inferredOffsetMinutes
+            remoteMatchesRecentPush -> 0L
+            else -> storedOffsetMinutes
+        }
+
+        if (appliedOffsetMinutes != storedOffsetMinutes) {
+            offsetPreference.set(appliedOffsetMinutes)
+        }
+        if (appliedOffsetMinutes == 0L) {
+            if (storedOffsetMinutes != 0L && remoteMatchesRecentPush) {
+                logcat(LogPriority.DEBUG) {
+                    "Cleared stale Komga timestamp correction sourceId=$sourceId " +
+                        "storedOffsetMinutes=$storedOffsetMinutes"
+                }
+            }
+            return rawModifiedAt
+        }
+
+        val corrected = Date(rawModifiedAt.time - appliedOffsetMinutes * MINUTE_MS)
+        logcat(LogPriority.DEBUG) {
+            "Corrected Komga progression timestamp sourceId=$sourceId " +
+                "raw=${rawModifiedAt.time} serverDate=${serverDate?.time} " +
+                "recentPush=${recentPush?.modifiedAtMillis} " +
+                "offsetMinutes=$appliedOffsetMinutes corrected=${corrected.time}"
+        }
+        return corrected
+    }
+
+    private fun inferWholeHourOffsetMinutes(differenceMillis: Long): Long? {
+        val roundedHours = (differenceMillis.toDouble() / HOUR_MS).roundToLong()
+        if (roundedHours == 0L || abs(roundedHours) > MAX_CORRECTION_HOURS) return null
+        val roundedDifference = roundedHours * HOUR_MS
+        if (abs(differenceMillis - roundedDifference) > OFFSET_EVIDENCE_TOLERANCE_MS) return null
+        return roundedHours * MINUTES_PER_HOUR
     }
 
     private fun normalizeBookUrl(bookUrl: String): String = bookUrl.substringBefore('#').removeSuffix("/")
@@ -150,7 +237,26 @@ class KomgaEpubProgressSyncService(
         val modifiedAt: Date,
     )
 
+    private data class ProgressionKey(
+        val sourceId: Long,
+        val bookUrl: String,
+    )
+
+    private data class RecentPush(
+        val modifiedAtMillis: Long,
+        val recordedAtMillis: Long,
+    )
+
     private companion object {
         const val MAX_ERROR_BODY_LENGTH = 512
+        const val MINUTE_MS = 60_000L
+        const val HOUR_MS = 60 * MINUTE_MS
+        const val MINUTES_PER_HOUR = 60L
+        const val MIN_FUTURE_DRIFT_MS = 30 * MINUTE_MS
+        const val OFFSET_EVIDENCE_TOLERANCE_MS = 5 * MINUTE_MS
+        const val RECENT_PUSH_EVIDENCE_TTL_MS = 5 * MINUTE_MS
+        const val MAX_CORRECTION_HOURS = 24L
+
+        val recentPushes = ConcurrentHashMap<ProgressionKey, RecentPush>()
     }
 }

--- a/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
@@ -4,13 +4,19 @@ import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 
 class EpubReaderPreferences(
-    preferenceStore: PreferenceStore,
+    private val preferenceStore: PreferenceStore,
 ) {
 
     val preferLocalFile: Preference<Boolean> = preferenceStore.getBoolean("epub_reader_prefer_local_file", true)
 
     val syncProgressionToKomga: Preference<Boolean> =
         preferenceStore.getBoolean("epub_reader_sync_progression_komga", true)
+
+    val correctKomgaServerTimestamps: Preference<Boolean> =
+        preferenceStore.getBoolean("epub_reader_correct_komga_server_timestamps", false)
+
+    fun komgaServerTimestampOffsetMinutes(sourceId: Long): Preference<Long> =
+        preferenceStore.getLong("epub_reader_komga_server_timestamp_offset_minutes_$sourceId", 0L)
 
     val completionThresholdPercent: Preference<Int> =
         preferenceStore.getInt("epub_reader_completion_threshold_percent", 98)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -953,6 +953,8 @@
     <string name="pref_prefer_local_epub_file_summary">Use the downloaded file when both local and remote copies are available</string>
     <string name="pref_sync_epub_progression_komga">Sync reading progress to Komga</string>
     <string name="pref_sync_epub_progression_komga_summary">Sync locator-based reading progress with Komga</string>
+    <string name="pref_correct_komga_server_timestamps">Correct server timestamps</string>
+    <string name="pref_correct_komga_server_timestamps_summary">Use the HTTP server time and recent progress updates to detect and correct abnormal whole-hour offsets. Enable only for affected Komga servers.</string>
     <string name="pref_epub_layout_mode">Layout mode</string>
     <string name="pref_epub_page_direction">Page direction</string>
     <string name="pref_epub_typography_and_appearance">Typography &amp; appearance</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -593,6 +593,8 @@
     <string name="pref_prefer_local_epub_file_summary">当本地和远程副本同时存在时，优先打开已下载文件</string>
     <string name="pref_sync_epub_progression_komga">将阅读进度同步到 Komga</string>
     <string name="pref_sync_epub_progression_komga_summary">将基于 Locator 的阅读位置与 Komga 保持同步</string>
+    <string name="pref_correct_komga_server_timestamps">修正服务器时间戳</string>
+    <string name="pref_correct_komga_server_timestamps_summary">使用 HTTP 服务器时间和最近的进度更新，识别并修正异常的整小时偏移。请仅对受影响的 Komga 服务器开启。</string>
     <string name="pref_epub_layout_mode">布局模式</string>
     <string name="pref_epub_page_direction">翻页方向</string>
     <string name="pref_epub_typography_and_appearance">排版与外观</string>


### PR DESCRIPTION
## 中文

### 修改内容

- 修复首次打开已有 Komga 云端阅读记录的 EPUB 时，已经跳转到云端位置后仍重复显示进度冲突提示的问题。
- 新增“修正服务器时间戳”设置，默认关闭，可针对受影响的 Komga 服务器手动启用。
- 启用后结合 HTTP 服务器时间与最近一次成功上报的进度时间，识别并修正异常的整小时偏移。
- 按服务器分别保存已识别的偏移，并在确认服务器恢复正常后自动清除过期修正。
- 同步修正尚未被后续阅读操作覆盖的本地进度时间，避免错误时间持续影响本地与云端进度选择。
- 补充中英文设置说明。

### 原因

Readium 在首屏完成排版后可能规范化 Locator，同一阅读位置的分页字段会发生变化；同时，部分 Komga 部署返回的 progression `modified` 可能存在时区转换造成的整小时偏移。两者会导致同一云端位置被误判为新的冲突进度，或让错误时间戳长期占据最新进度。

### 用户影响

开启受影响书籍时不再重复询问已经采用的云端进度。对于存在时间戳偏移的 Komga 服务器，用户可以显式开启客户端修正，无需等待服务端补丁部署。

## English

### Changes

- Prevent duplicate remote-progress prompts after an EPUB has already opened at the accepted Komga locator.
- Add an opt-in “Correct server timestamps” setting, disabled by default.
- Detect abnormal whole-hour offsets using the HTTP server date and recent successful progress uploads.
- Persist detected corrections per server and clear stale corrections when the server is confirmed healthy.
- Repair local progress timestamps that were copied from the accepted remote record and have not been superseded by later reading activity.
- Add English and Simplified Chinese preference text.

### Root cause

Readium may normalize locator pagination fields after the first layout pass, while some Komga deployments can return progression `modified` values shifted by a timezone conversion. These changes could make an already accepted locator appear to be a newer conflicting position or keep an invalid future timestamp authoritative.

### User impact

Books no longer prompt for a remote position that was already applied. Users of affected Komga servers can enable a client-side timestamp correction without depending on a server-side fix.

## Checks

- `./gradlew.bat :app:compileDebugKotlin --no-daemon`
- `./gradlew.bat spotlessCheck --no-daemon`
- `git diff --check`
