### PR TITLE
feat(manga): 漫画首屏优先与双向按页缓存 / Prioritize manga first-screen loading with bidirectional page caching

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -6,6 +6,7 @@ import com.jakewharton.disklrucache.DiskLruCache
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.saveTo
+import koharia.komga.download.KomgaChapterMemo
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
 import okhttp3.Response
@@ -75,13 +76,22 @@ class ChapterCache(
      * @param chapter the chapter.
      * @return the list of pages.
      */
-    fun getPageListFromCache(chapter: Chapter): List<Page> {
+    fun getPageListFromCache(chapter: Chapter): List<Page>? {
         // Get the key for the chapter.
         val key = DiskUtil.hashKeyForDisk(getKey(chapter))
 
-        // Convert JSON string to list of objects. Throws an exception if snapshot is null
-        return diskCache.get(key).use {
-            json.decodeFromString(it.getString(0))
+        val snapshot = try {
+            diskCache.get(key)
+        } catch (_: IOException) {
+            null
+        } ?: return null
+
+        return try {
+            snapshot.use { json.decodeFromString(it.getString(0)) }
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to read cached page list; discarding it" }
+            runCatching { diskCache.remove(key) }
+            null
         }
     }
 
@@ -117,6 +127,14 @@ class ChapterCache(
             // Ignore.
         } finally {
             editor?.abortUnlessCommitted()
+        }
+    }
+
+    fun removePageListFromCache(chapter: Chapter) {
+        runCatching {
+            diskCache.remove(DiskUtil.hashKeyForDisk(getKey(chapter)))
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) { "Failed to remove cached page list" }
         }
     }
 
@@ -208,7 +226,15 @@ class ChapterCache(
     }
 
     private fun getKey(chapter: Chapter): String {
-        return "${chapter.mangaId}${chapter.url}"
+        val publicationVersion = KomgaChapterMemo.publicationVersion(chapter.memo)
+        return buildString {
+            append(chapter.mangaId)
+            append(chapter.url)
+            publicationVersion?.let {
+                append("|publication=")
+                append(it)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -10,6 +10,7 @@ import koharia.source.komga.KomgaSource
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import logcat.LogPriority
+import okhttp3.CacheControl
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.MediaType.Companion.toMediaType
@@ -121,6 +122,32 @@ class KomgaApi(
                             isEpub = book.media?.mediaProfile == "EPUB",
                         )
                     }
+            }
+        }
+
+    suspend fun getBookProgress(bookUrl: String): BookProgressSnapshot? =
+        withIOContext {
+            val source = resolveSourceForUrl(bookUrl) ?: return@withIOContext null
+            with(json) {
+                val request = GET(bookUrl, source.currentHeaders())
+                    .newBuilder()
+                    .cacheControl(CacheControl.FORCE_NETWORK)
+                    .build()
+                val book = source.client.newCall(request)
+                    .awaitSuccess()
+                    .parseAs<BookDto>()
+                BookProgressSnapshot(
+                    url = bookUrl,
+                    pageIndex = book.readProgress?.page?.let { (it - 1).coerceAtLeast(0) },
+                    totalPages = book.media?.pagesCount ?: 0,
+                    completed = book.readProgress?.completed ?: false,
+                    readDate = book.readProgress?.readDate,
+                    isEpub = book.media?.mediaProfile == "EPUB",
+                    fileHash = book.fileHash,
+                    fileLastModified = book.fileLastModified,
+                    sizeBytes = book.sizeBytes,
+                    fileName = book.name,
+                )
             }
         }
 
@@ -237,5 +264,18 @@ class KomgaApi(
         val url: String,
         val readProgress: BookReadProgressDto?,
         val isEpub: Boolean = false,
+    )
+
+    data class BookProgressSnapshot(
+        val url: String,
+        val pageIndex: Int?,
+        val totalPages: Int,
+        val completed: Boolean,
+        val readDate: String?,
+        val isEpub: Boolean,
+        val fileHash: String?,
+        val fileLastModified: String?,
+        val sizeBytes: Long,
+        val fileName: String,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
@@ -114,12 +114,17 @@ data class PageWrapperDto<T>(
 @Serializable
 data class BookMediaDto(
     val mediaProfile: String = "",
+    val pagesCount: Int = 0,
 )
 
 @Serializable
 data class BookDto(
     val id: String,
     val seriesId: String = "",
+    val name: String = "",
+    val fileLastModified: String? = null,
+    val fileHash: String? = null,
+    val sizeBytes: Long = 0L,
     val readProgress: BookReadProgressDto? = null,
     val media: BookMediaDto? = null,
 )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -46,6 +46,18 @@ class KomgaProgressSyncService(
         }
     }
 
+    suspend fun pullBookProgress(
+        sourceId: Long,
+        chapterUrl: String,
+    ): KomgaApi.BookProgressSnapshot? {
+        if (sourceManager.get(sourceId) !is KomgaSource || !chapterUrl.contains("/api/v1/books/")) return null
+        return runCatching {
+            trackerManager.komga.api.getBookProgress(chapterUrl)
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) { "Failed to pull Komga page progress for $chapterUrl" }
+        }.getOrNull()
+    }
+
     suspend fun syncHistoryFromServer() {
         runCatching {
             val activeServerId = komgaServerPreferences.activeServerId.get()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgress.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgress.kt
@@ -1,0 +1,31 @@
+package eu.kanade.tachiyomi.ui.reader
+
+import androidx.compose.runtime.Immutable
+import kotlin.math.roundToInt
+
+@Immutable
+data class MangaRemoteProgressConflict(
+    val chapterId: Long,
+    val localPageIndex: Int,
+    val localTotalPages: Int,
+    val remotePageIndex: Int,
+    val remoteTotalPages: Int,
+    val remoteVersion: String,
+) {
+    val localPercent: Int
+        get() = pageProgressPercent(localPageIndex, localTotalPages)
+
+    val remotePercent: Int
+        get() = pageProgressPercent(remotePageIndex, remoteTotalPages)
+}
+
+internal fun pageProgressPercent(pageIndex: Int, totalPages: Int): Int {
+    if (totalPages <= 0) return 0
+    return (((pageIndex + 1).toDouble() / totalPages) * 100)
+        .roundToInt()
+        .coerceIn(0, 100)
+}
+
+internal fun hasPublicationChanged(oldVersion: String?, newVersion: String?): Boolean {
+    return oldVersion != null && newVersion != null && oldVersion != newVersion
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -350,6 +351,38 @@ class ReaderActivity : BaseActivity() {
             }
             null -> {}
         }
+
+        state.remoteProgressConflict
+            ?.takeIf { state.dialog == null }
+            ?.let { conflict ->
+                AlertDialog(
+                    onDismissRequest = viewModel::keepLocalProgress,
+                    title = { Text(stringResource(MR.strings.epub_reader_remote_progress_title)) },
+                    text = {
+                        Text(
+                            stringResource(
+                                MR.strings.reader_remote_progress_message,
+                                conflict.localPageIndex + 1,
+                                conflict.localTotalPages,
+                                conflict.localPercent,
+                                conflict.remotePageIndex + 1,
+                                conflict.remoteTotalPages,
+                                conflict.remotePercent,
+                            ),
+                        )
+                    },
+                    dismissButton = {
+                        TextButton(onClick = viewModel::keepLocalProgress) {
+                            Text(stringResource(MR.strings.epub_reader_keep_local_progress))
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = viewModel::useRemoteProgress) {
+                            Text(stringResource(MR.strings.epub_reader_jump_remote_progress))
+                        }
+                    },
+                )
+            }
     }
 
     /**
@@ -706,6 +739,10 @@ class ReaderActivity : BaseActivity() {
      */
     fun onPageSelected(page: ReaderPage) {
         viewModel.onPageSelected(page)
+    }
+
+    fun onPageDisplayed(page: ReaderPage) {
+        viewModel.onPageDisplayed(page)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -40,7 +40,9 @@ import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
+import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -157,6 +159,8 @@ class ReaderViewModel @JvmOverloads constructor(
 
     private var chapterToDownload: Download? = null
     private val currentChapterAutoCacheRequests = mutableSetOf<Long>()
+    private val remoteProgressChecksStarted = mutableSetOf<Long>()
+    private val remoteProgressVersionsHandled = mutableSetOf<String>()
 
     private val unfilteredChapterList by lazy {
         val manga = manga!!
@@ -296,7 +300,6 @@ class ReaderViewModel @JvmOverloads constructor(
                 val manga = getManga.await(mangaId)
                 if (manga != null) {
                     savedState["source_id"] = manga.source
-                    komgaProgressSyncService.syncFromServer(manga)
                     sourceManager.isInitialized.first { it }
                     mutableState.update { it.copy(manga = manga) }
                     if (chapterId == -1L) chapterId = initialChapterId
@@ -305,7 +308,11 @@ class ReaderViewModel @JvmOverloads constructor(
                     val source = sourceManager.getOrStub(manga.source)
                     loader = ChapterLoader(context, downloadManager, downloadProvider, manga, source)
 
-                    loadChapter(loader!!, chapterList.first { chapterId == it.chapter.id })
+                    loadChapter(
+                        loader = loader!!,
+                        chapter = chapterList.first { chapterId == it.chapter.id },
+                        initialPageIndex = chapterPageIndex.takeIf { it >= 0 },
+                    )
                     Result.success(true)
                 } else {
                     // Unlikely but okay
@@ -327,8 +334,9 @@ class ReaderViewModel @JvmOverloads constructor(
     private suspend fun loadChapter(
         loader: ChapterLoader,
         chapter: ReaderChapter,
+        initialPageIndex: Int? = null,
     ): ViewerChapters {
-        loader.loadChapter(chapter)
+        loader.loadChapter(chapter, initialPageIndex)
 
         val chapterPos = chapterList.indexOf(chapter)
         val newChapters = ViewerChapters(
@@ -461,6 +469,9 @@ class ReaderViewModel @JvmOverloads constructor(
 
         val selectedChapter = page.chapter
         val pages = selectedChapter.pages ?: return
+        selectedChapter.requestedPage = page.index
+        chapterPageIndex = page.index
+        selectedChapter.pageLoader?.setActivePage(page)
 
         // Save last page read and mark as read if needed
         viewModelScope.launchNonCancellable {
@@ -478,6 +489,168 @@ class ReaderViewModel @JvmOverloads constructor(
         }
 
         eventChannel.trySend(Event.PageChanged)
+    }
+
+    fun onPageDisplayed(page: ReaderPage) {
+        page.chapter.pageLoader?.onPageDisplayed(page)
+        val currentChapter = getCurrentChapter() ?: return
+        if (currentChapter !== page.chapter || currentChapter.requestedPage != page.index) return
+        logcat {
+            "MangaStartup: active image displayed chapterId=${page.chapter.chapter.id} page=${page.number}"
+        }
+        if (incognitoMode) return
+        val manga = manga ?: return
+        if (sourceManager.get(manga.source) !is KomgaSource) return
+        val currentChapterId = currentChapter.chapter.id ?: return
+        if (!remoteProgressChecksStarted.add(currentChapterId)) return
+
+        viewModelScope.launchIO {
+            refreshKomgaBookProgress(manga, currentChapter)
+        }
+    }
+
+    private suspend fun refreshKomgaBookProgress(manga: Manga, readerChapter: ReaderChapter) {
+        val chapter = readerChapter.chapter
+        val chapterId = chapter.id ?: return
+        logcat { "MangaStartup: remote progress check start chapterId=$chapterId" }
+        val remote = komgaProgressSyncService.pullBookProgress(
+            sourceId = manga.source,
+            chapterUrl = chapter.url,
+        )
+        logcat {
+            "MangaStartup: remote progress check complete chapterId=$chapterId " +
+                "found=${remote != null}"
+        }
+        if (remote == null || remote.isEpub) return
+
+        val oldMemo = chapter.memo
+        val oldPublicationVersion = KomgaChapterMemo.publicationVersion(oldMemo)
+        val updatedMemo = KomgaChapterMemo.mergePublicationMetadata(
+            existing = oldMemo,
+            bookUrl = remote.url,
+            fileHash = remote.fileHash,
+            fileLastModified = remote.fileLastModified,
+            sizeBytes = remote.sizeBytes,
+            fileName = remote.fileName,
+            isEpub = false,
+            pagesCount = remote.totalPages,
+        )
+        val newPublicationVersion = KomgaChapterMemo.publicationVersion(updatedMemo)
+        val publicationMetadataInitialized = oldPublicationVersion == null && newPublicationVersion != null
+        val publicationChanged = hasPublicationChanged(oldPublicationVersion, newPublicationVersion)
+        var pages = readerChapter.pages ?: return
+        val pageCountChanged = remote.totalPages > 0 && remote.totalPages != pages.size
+        val pageLoader = readerChapter.pageLoader ?: return
+
+        if (publicationMetadataInitialized) {
+            logcat {
+                "MangaStartup: publication metadata initialized; preserving visible page list chapterId=$chapterId"
+            }
+        }
+
+        if (publicationChanged || pageCountChanged) {
+            pageLoader.invalidatePageListCache()
+        }
+        if (updatedMemo != oldMemo) {
+            chapter.memo = updatedMemo
+            updateChapter.await(ChapterUpdate(id = chapterId, memo = updatedMemo))
+        }
+
+        if (publicationChanged || pageCountChanged) {
+            val refreshedPages = pageLoader.refreshPages()
+            if (refreshedPages.isNullOrEmpty()) {
+                logcat(LogPriority.WARN) {
+                    "MangaStartup: page list refresh unavailable chapterId=$chapterId " +
+                        "publicationChanged=$publicationChanged pageCountChanged=$pageCountChanged"
+                }
+                return
+            }
+            readerChapter.state = ReaderChapter.State.Loaded(refreshedPages)
+            pages = refreshedPages
+            val activePage = pages[readerChapter.requestedPage.coerceIn(0, pages.lastIndex)]
+            pageLoader.setActivePage(activePage)
+            eventChannel.trySend(Event.ReloadViewerChapters)
+        }
+
+        if (remote.totalPages > 0 && remote.totalPages != pages.size) {
+            logcat(LogPriority.WARN) {
+                "MangaStartup: server/local page count still differs chapterId=$chapterId " +
+                    "server=${remote.totalPages} local=${pages.size}"
+            }
+            return
+        }
+        if (getCurrentChapter() !== readerChapter) return
+
+        val remotePageIndex = remote.pageIndex
+            ?: if (remote.completed && pages.isNotEmpty()) pages.lastIndex else return
+        if (remotePageIndex !in pages.indices) return
+        val localPageIndex = readerChapter.requestedPage.coerceIn(0, pages.lastIndex)
+        if (remotePageIndex == localPageIndex) return
+
+        val remoteVersion = listOf(
+            chapterId,
+            remote.readDate.orEmpty(),
+            remotePageIndex,
+            remote.totalPages,
+            remote.completed,
+        ).joinToString(separator = ":")
+        val shouldShow = synchronized(remoteProgressVersionsHandled) {
+            remoteProgressVersionsHandled.add(remoteVersion)
+        }
+        if (!shouldShow) return
+
+        mutableState.update {
+            it.copy(
+                remoteProgressConflict = MangaRemoteProgressConflict(
+                    chapterId = chapterId,
+                    localPageIndex = localPageIndex,
+                    localTotalPages = pages.size,
+                    remotePageIndex = remotePageIndex,
+                    remoteTotalPages = remote.totalPages.takeIf { count -> count > 0 } ?: pages.size,
+                    remoteVersion = remoteVersion,
+                ),
+            )
+        }
+    }
+
+    fun keepLocalProgress() {
+        val conflict = state.value.remoteProgressConflict ?: return
+        mutableState.update { it.copy(remoteProgressConflict = null) }
+        val currentChapter = getCurrentChapter()?.takeIf { it.chapter.id == conflict.chapterId } ?: return
+        val pages = currentChapter.pages ?: return
+        val localPageIndex = currentChapter.requestedPage.coerceIn(0, pages.lastIndex)
+        viewModelScope.launchIO {
+            komgaProgressSyncService.pushPageProgress(
+                sourceId = manga?.source ?: return@launchIO,
+                chapterUrl = currentChapter.chapter.url,
+                pageIndex = localPageIndex,
+                totalPages = pages.size,
+            )
+        }
+    }
+
+    fun useRemoteProgress() {
+        val conflict = state.value.remoteProgressConflict ?: return
+        mutableState.update { it.copy(remoteProgressConflict = null) }
+        val currentChapter = getCurrentChapter()?.takeIf { it.chapter.id == conflict.chapterId } ?: return
+        val pages = currentChapter.pages ?: return
+        val targetPage = pages.getOrNull(conflict.remotePageIndex) ?: return
+        currentChapter.requestedPage = targetPage.index
+        currentChapter.chapter.last_page_read = targetPage.index
+        chapterPageIndex = targetPage.index
+        currentChapter.pageLoader?.setActivePage(targetPage)
+        state.value.viewer?.moveToPage(targetPage)
+        if (!incognitoMode) {
+            viewModelScope.launchNonCancellable {
+                updateChapter.await(
+                    ChapterUpdate(
+                        id = conflict.chapterId,
+                        read = conflict.remotePageIndex == pages.lastIndex,
+                        lastPageRead = conflict.remotePageIndex.toLong(),
+                    ),
+                )
+            }
+        }
     }
 
     private fun downloadNextChapters() {
@@ -518,6 +691,7 @@ class ReaderViewModel @JvmOverloads constructor(
         if (currentChapter.pageLoader is DownloadPageLoader) return
 
         val manga = manga ?: return
+        if (sourceManager.get(manga.source) is KomgaSource) return
         val chapter = currentChapter.chapter.toDomainChapter() ?: return
         val chapterId = chapter.id
         synchronized(currentChapterAutoCacheRequests) {
@@ -1018,6 +1192,7 @@ class ReaderViewModel @JvmOverloads constructor(
          */
         val viewer: Viewer? = null,
         val dialog: Dialog? = null,
+        val remoteProgressConflict: MangaRemoteProgressConflict? = null,
         val menuVisible: Boolean = false,
         @IntRange(from = -100, to = 100) val brightnessOverlayValue: Int = 0,
     ) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -557,7 +557,16 @@ class ReaderViewModel @JvmOverloads constructor(
         }
 
         if (publicationChanged || pageCountChanged) {
-            val refreshedPages = pageLoader.refreshPages()
+            val refreshedPages = try {
+                pageLoader.refreshPages()
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                logcat(LogPriority.WARN, error) {
+                    "MangaStartup: failed to refresh pages chapterId=$chapterId " +
+                        "publicationChanged=$publicationChanged pageCountChanged=$pageCountChanged"
+                }
+                return
+            }
             if (refreshedPages.isNullOrEmpty()) {
                 logcat(LogPriority.WARN) {
                     "MangaStartup: page list refresh unavailable chapterId=$chapterId " +

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -28,7 +28,7 @@ class ChapterLoader(
      * Assigns the chapter's page loader and loads the its pages. Returns immediately if the chapter
      * is already loaded.
      */
-    suspend fun loadChapter(chapter: ReaderChapter) {
+    suspend fun loadChapter(chapter: ReaderChapter, initialPageIndex: Int? = null) {
         if (chapterIsReady(chapter)) {
             return
         }
@@ -49,11 +49,14 @@ class ChapterLoader(
 
                 // If the chapter is partially read, set the starting page to the last the user read
                 // otherwise use the requested page.
-                if (!chapter.chapter.read) {
+                if (initialPageIndex != null) {
+                    chapter.requestedPage = initialPageIndex
+                } else if (!chapter.chapter.read) {
                     chapter.requestedPage = chapter.chapter.last_page_read
                 }
 
                 chapter.state = ReaderChapter.State.Loaded(pages)
+                loader.setActivePage(pages[chapter.requestedPage.coerceIn(0, pages.lastIndex)])
             } catch (e: Throwable) {
                 chapter.state = ReaderChapter.State.Error(e)
                 throw e

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -6,27 +6,31 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import koharia.komga.download.KomgaChapterMemo
+import koharia.source.komga.KomgaCachePolicy
+import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
-import logcat.LogPriority
+import kotlinx.serialization.json.JsonObject
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.Collections
+import java.util.IdentityHashMap
 import java.util.concurrent.PriorityBlockingQueue
 import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.concurrent.atomics.incrementAndFetch
-import kotlin.math.min
 
 private val pageListCacheWriteScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -41,27 +45,66 @@ internal class HttpPageLoader(
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    /**
-     * A queue used to manage requests one by one while allowing priorities.
-     */
+    /** A priority queue with up to two network workers for Komga and one for other sources. */
     private val queue = PriorityBlockingQueue<PriorityPage>()
 
-    private val preloadSize = 4
+    private val pageLoadGate = PageLoadGate(preloadSize = 4)
+    private val schedulerLock = Any()
+    private val scheduledPages = Collections.newSetFromMap(IdentityHashMap<ReaderPage, Boolean>())
+    private val activeLoads = mutableSetOf<ActivePageLoad>()
+
+    private val domainChapter
+        get() = checkNotNull(chapter.chapter.toDomainChapter())
 
     init {
-        scope.launchIO {
-            flow {
+        val workerCount = if (source is KomgaSource) 2 else 1
+        repeat(workerCount) {
+            scope.launchIO {
                 while (true) {
-                    emit(runInterruptible { queue.take() })
+                    val queuedPage = runInterruptible { queue.take() }
+                    if (queuedPage.page.status != Page.State.Queue) {
+                        synchronized(schedulerLock) {
+                            scheduledPages.remove(queuedPage.page)
+                        }
+                        continue
+                    }
+
+                    val loadJob = launch(start = CoroutineStart.LAZY) {
+                        internalLoadPage(
+                            page = queuedPage.page,
+                            force = queuedPage.priority == PriorityPage.RETRY,
+                            isPrefetch = queuedPage.priority == PriorityPage.ADJACENT,
+                        )
+                    }
+                    val newActiveLoad = ActivePageLoad(
+                        page = queuedPage.page,
+                        priority = queuedPage.priority,
+                        job = loadJob,
+                    )
+                    val shouldStart = synchronized(schedulerLock) {
+                        if (queuedPage.page.status == Page.State.Queue) {
+                            activeLoads += newActiveLoad
+                            true
+                        } else {
+                            scheduledPages.remove(queuedPage.page)
+                            false
+                        }
+                    }
+                    if (!shouldStart) {
+                        loadJob.cancel()
+                        continue
+                    }
+                    try {
+                        loadJob.start()
+                        loadJob.join()
+                    } finally {
+                        synchronized(schedulerLock) {
+                            activeLoads.remove(newActiveLoad)
+                            scheduledPages.remove(queuedPage.page)
+                        }
+                    }
                 }
             }
-                .filter { it.page.status == Page.State.Queue }
-                .collect {
-                    internalLoadPage(
-                        page = it.page,
-                        force = it.priority == PriorityPage.RETRY,
-                    )
-                }
         }
     }
 
@@ -72,34 +115,173 @@ internal class HttpPageLoader(
      * otherwise fallbacks to network.
      */
     override suspend fun getPages(): List<ReaderPage> {
-        val pages = try {
-            chapterCache.getPageListFromCache(chapter.chapter.toDomainChapter()!!).also {
+        return loadPageList(forceNetwork = false).toReaderPages()
+    }
+
+    override suspend fun refreshPages(): List<ReaderPage> {
+        return loadPageList(forceNetwork = true)
+            .toReaderPages()
+            .onEach { it.chapter = chapter }
+    }
+
+    override fun invalidatePageListCache() {
+        chapterCache.removePageListFromCache(domainChapter)
+    }
+
+    private suspend fun loadPageList(forceNetwork: Boolean): List<Page> {
+        val chapterSnapshot = domainChapter
+        if (!forceNetwork) {
+            chapterCache.getPageListFromCache(chapterSnapshot)?.let { cachedPages ->
                 logcat {
-                    "KohariaOfflineDebug: page list cache hit " +
+                    "MangaStartup: page list source=chapter-cache " +
                         "chapterId=${chapter.chapter.id} chapterName=${chapter.chapter.name} " +
-                        "chapterUrl=${chapter.chapter.url} pages=${it.size}"
+                        "chapterUrl=${chapter.chapter.url} pages=${cachedPages.size}"
                 }
-            }
-        } catch (e: Throwable) {
-            if (e is CancellationException) {
-                throw e
-            }
-            logcat(LogPriority.WARN, e) {
-                "KohariaOfflineDebug: page list cache miss, fetching from source " +
-                    "chapterId=${chapter.chapter.id} chapterName=${chapter.chapter.name} " +
-                    "chapterUrl=${chapter.chapter.url}"
-            }
-            source.getPageList(chapter.chapter).also {
-                logcat {
-                    "KohariaOfflineDebug: page list fetched from source " +
-                        "chapterId=${chapter.chapter.id} chapterName=${chapter.chapter.name} " +
-                        "chapterUrl=${chapter.chapter.url} pages=${it.size}"
-                }
+                return cachedPages.withPublicationVersion(chapterSnapshot.memo)
             }
         }
-        return pages.mapIndexed { index, page ->
-            // Don't trust sources and use our own indexing
+
+        logcat {
+            "MangaStartup: page list source=request forceNetwork=$forceNetwork " +
+                "chapterId=${chapter.chapter.id} chapterName=${chapter.chapter.name} " +
+                "chapterUrl=${chapter.chapter.url}"
+        }
+        val sourcePages = try {
+            if (forceNetwork && source is KomgaSource) {
+                source.getPageList(chapter.chapter, KomgaCachePolicy.NetworkFirst)
+            } else {
+                source.getPageList(chapter.chapter)
+            }
+        } catch (error: Exception) {
+            if (error is CancellationException || forceNetwork || source !is KomgaSource) throw error
+            logcat {
+                "MangaStartup: cached page list response failed; retrying network chapterId=${chapter.chapter.id}"
+            }
+            source.getPageList(chapter.chapter, KomgaCachePolicy.NetworkFirst)
+        }.withPublicationVersion(chapterSnapshot.memo)
+        logcat {
+            "MangaStartup: page list request complete forceNetwork=$forceNetwork " +
+                "chapterId=${chapter.chapter.id} pages=${sourcePages.size}"
+        }
+        pageListCacheWriteScope.launch {
+            chapterCache.putPageListToCache(chapterSnapshot, sourcePages)
+        }
+        return sourcePages
+    }
+
+    private fun List<Page>.withPublicationVersion(memo: JsonObject): List<Page> {
+        if (source !is KomgaSource) return this
+        return map { page ->
+            val imageUrl = page.imageUrl ?: return@map page
+            Page(
+                index = page.index,
+                url = page.url,
+                imageUrl = KomgaChapterMemo.versionedPageImageUrl(imageUrl, memo),
+            )
+        }
+    }
+
+    private fun List<Page>.toReaderPages(): List<ReaderPage> {
+        return mapIndexed { index, page ->
             ReaderPage(index, page.url, page.imageUrl)
+        }
+    }
+
+    override fun setActivePage(page: ReaderPage) {
+        val pages = page.chapter.pages
+        val activation = pageLoadGate.activate(page.index, pages?.size ?: 0)
+        val needsUrgentLoad = page.status != Page.State.Ready
+        if (needsUrgentLoad) {
+            preemptPrefetchFor(page, reason = "active-page-missing")
+        }
+        synchronized(schedulerLock) {
+            removeQueuedPagesLocked { queued ->
+                queued.priority == PriorityPage.ADJACENT ||
+                    (queued.priority == PriorityPage.DEFAULT && queued.page !== page)
+            }
+            enqueuePageLocked(page, PriorityPage.DEFAULT)
+            if (!needsUrgentLoad && pages != null) {
+                enqueuePrefetchWindowLocked(pages, activation.prefetchIndexes)
+            }
+        }
+        if (activation.changed) {
+            logcat {
+                "MangaStartup: active page chapterId=${chapter.chapter.id} page=${page.number}"
+            }
+        }
+        if (!needsUrgentLoad && activation.prefetchIndexes.isNotEmpty()) {
+            logPrefetchWindow(page, activation.prefetchIndexes, reason = "page-selected")
+        }
+    }
+
+    override fun onPageDisplayed(page: ReaderPage) {
+        val pages = page.chapter.pages ?: return
+        if (!pageLoadGate.isActive(page.index)) return
+        val prefetchIndexes = pageLoadGate.onPageDisplayed(page.index, pages.size)
+        synchronized(schedulerLock) {
+            removeQueuedPagesLocked { it.priority == PriorityPage.ADJACENT }
+            enqueuePrefetchWindowLocked(pages, prefetchIndexes)
+        }
+        if (prefetchIndexes.isNotEmpty()) {
+            logPrefetchWindow(page, prefetchIndexes, reason = "page-displayed")
+        }
+    }
+
+    private fun preemptPrefetchFor(page: ReaderPage, reason: String) {
+        val prefetchLoads = synchronized(schedulerLock) {
+            activeLoads.filter {
+                it.priority == PriorityPage.ADJACENT && it.page !== page && it.job.isActive
+            }
+        }
+        prefetchLoads.forEach { load ->
+            load.job.cancel()
+            logcat {
+                "MangaStartup: active page preempted prefetch " +
+                    "chapterId=${chapter.chapter.id} prefetchPage=${load.page.number} " +
+                    "activePage=${page.number} reason=$reason"
+            }
+        }
+    }
+
+    private fun enqueuePrefetchWindowLocked(pages: List<ReaderPage>, indexes: List<Int>) {
+        indexes.forEach { index ->
+            pages.getOrNull(index)?.let { enqueuePageLocked(it, PriorityPage.ADJACENT) }
+        }
+    }
+
+    private fun enqueuePageLocked(page: ReaderPage, priority: Int): PriorityPage? {
+        if (page.status != Page.State.Queue) return null
+        val queuedPage = queue.firstOrNull { it.page === page }
+        if (queuedPage != null) {
+            if (queuedPage.priority >= priority) return queuedPage
+            queue.remove(queuedPage)
+            return PriorityPage(page, priority).also { queue.offer(it) }
+        }
+        if (!scheduledPages.add(page)) return null
+        return PriorityPage(page, priority).also { queue.offer(it) }
+    }
+
+    private fun removeQueuedPagesLocked(predicate: (PriorityPage) -> Boolean) {
+        queue.removeIf { queuedPage ->
+            predicate(queuedPage).also { remove ->
+                if (remove) scheduledPages.remove(queuedPage.page)
+            }
+        }
+    }
+
+    private fun removeQueuedPage(queuedPage: PriorityPage) {
+        synchronized(schedulerLock) {
+            if (queue.remove(queuedPage)) {
+                scheduledPages.remove(queuedPage.page)
+            }
+        }
+    }
+
+    private fun logPrefetchWindow(page: ReaderPage, indexes: List<Int>, reason: String) {
+        logcat {
+            "MangaStartup: prefetch window updated reason=$reason " +
+                "chapterId=${chapter.chapter.id} page=${page.number} " +
+                "prefetchPages=${indexes.joinToString { (it + 1).toString() }}"
         }
     }
 
@@ -119,18 +301,20 @@ internal class HttpPageLoader(
             page.status = Page.State.Queue
         }
 
-        val queuedPages = mutableListOf<PriorityPage>()
-        if (page.status == Page.State.Queue) {
-            queuedPages += PriorityPage(page, PriorityPage.DEFAULT).also { queue.offer(it) }
+        val queuedPage = if (page.status == Page.State.Queue && pageLoadGate.isActive(page.index)) {
+            preemptPrefetchFor(page, reason = "active-page-load")
+            synchronized(schedulerLock) {
+                removeQueuedPagesLocked { it.priority == PriorityPage.ADJACENT }
+                enqueuePageLocked(page, PriorityPage.DEFAULT)
+            }
+        } else {
+            null
         }
-        queuedPages += preloadNextPages(page, preloadSize)
 
         suspendCancellableCoroutine<Nothing> { continuation ->
             continuation.invokeOnCancellation {
-                queuedPages.forEach {
-                    if (it.page.status == Page.State.Queue) {
-                        queue.remove(it)
-                    }
+                if (queuedPage != null && queuedPage.page.status == Page.State.Queue) {
+                    removeQueuedPage(queuedPage)
                 }
             }
         }
@@ -143,21 +327,29 @@ internal class HttpPageLoader(
         if (page.status is Page.State.Error) {
             page.status = Page.State.Queue
         }
-        queue.offer(PriorityPage(page, PriorityPage.RETRY))
+        preemptPrefetchFor(page, reason = "retry")
+        synchronized(schedulerLock) {
+            enqueuePageLocked(page, PriorityPage.RETRY)
+        }
     }
 
     override fun recycle() {
         super.recycle()
         scope.cancel()
-        queue.clear()
+        synchronized(schedulerLock) {
+            queue.clear()
+            scheduledPages.clear()
+            activeLoads.clear()
+        }
 
         // Cache current page list progress for online chapters to allow a faster reopen
         chapter.pages?.let { pages ->
+            val chapterSnapshot = domainChapter
             pageListCacheWriteScope.launch {
                 try {
                     // Convert to pages without reader information
                     val pagesToSave = pages.map { Page(it.index, it.url, it.imageUrl) }
-                    chapterCache.putPageListToCache(chapter.chapter.toDomainChapter()!!, pagesToSave)
+                    chapterCache.putPageListToCache(chapterSnapshot, pagesToSave)
                 } catch (e: Throwable) {
                     if (e is CancellationException) {
                         throw e
@@ -168,34 +360,18 @@ internal class HttpPageLoader(
     }
 
     /**
-     * Preloads the given [amount] of pages after the [currentPage] with a lower priority.
-     *
-     * @return a list of [PriorityPage] that were added to the [queue]
-     */
-    private fun preloadNextPages(currentPage: ReaderPage, amount: Int): List<PriorityPage> {
-        val pageIndex = currentPage.index
-        val pages = currentPage.chapter.pages ?: return emptyList()
-        if (pageIndex == pages.lastIndex) return emptyList()
-
-        return pages
-            .subList(pageIndex + 1, min(pageIndex + 1 + amount, pages.size))
-            .mapNotNull {
-                if (it.status == Page.State.Queue) {
-                    PriorityPage(it, PriorityPage.ADJACENT).apply { queue.offer(this) }
-                } else {
-                    null
-                }
-            }
-    }
-
-    /**
      * Loads the page, retrieving the image URL and downloading the image if necessary.
      * Downloaded images are stored in the chapter cache.
      *
      * @param page the page whose source image has to be downloaded.
      */
-    private suspend fun internalLoadPage(page: ReaderPage, force: Boolean) {
+    private suspend fun internalLoadPage(page: ReaderPage, force: Boolean, isPrefetch: Boolean) {
+        val startedAt = System.nanoTime()
         try {
+            logcat {
+                "MangaStartup: page request start chapterId=${chapter.chapter.id} " +
+                    "page=${page.number} prefetch=$isPrefetch"
+            }
             if (page.imageUrl.isNullOrEmpty()) {
                 page.status = Page.State.LoadPage
                 page.imageUrl = source.getImageUrl(page)
@@ -216,14 +392,25 @@ internal class HttpPageLoader(
 
             page.stream = { chapterCache.getImageFile(imageUrl).inputStream() }
             page.status = Page.State.Ready
+            logcat {
+                "MangaStartup: page request complete chapterId=${chapter.chapter.id} " +
+                    "page=${page.number} prefetch=$isPrefetch " +
+                    "elapsedMs=${(System.nanoTime() - startedAt) / 1_000_000}"
+            }
+        } catch (e: CancellationException) {
+            page.status = Page.State.Queue
+            throw e
         } catch (e: Throwable) {
             page.status = Page.State.Error(e)
-            if (e is CancellationException) {
-                throw e
-            }
         }
     }
 }
+
+private data class ActivePageLoad(
+    val page: ReaderPage,
+    val priority: Int,
+    val job: Job,
+)
 
 /**
  * Data class used to keep ordering of pages in order to maintain priority.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/HttpPageLoader.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -98,9 +99,25 @@ internal class HttpPageLoader(
                         loadJob.start()
                         loadJob.join()
                     } finally {
-                        synchronized(schedulerLock) {
+                        val requeuedAsActive = synchronized(schedulerLock) {
                             activeLoads.remove(newActiveLoad)
                             scheduledPages.remove(queuedPage.page)
+                            // The user may select a prefetch after it was cancelled but before this cleanup.
+                            if (
+                                scope.isActive &&
+                                queuedPage.page.status == Page.State.Queue &&
+                                pageLoadGate.isActive(queuedPage.page.index)
+                            ) {
+                                enqueuePageLocked(queuedPage.page, PriorityPage.DEFAULT) != null
+                            } else {
+                                false
+                            }
+                        }
+                        if (requeuedAsActive) {
+                            logcat {
+                                "MangaStartup: cancelled page requeued as active " +
+                                    "chapterId=${chapter.chapter.id} page=${queuedPage.page.number}"
+                            }
                         }
                     }
                 }
@@ -171,12 +188,13 @@ internal class HttpPageLoader(
 
     private fun List<Page>.withPublicationVersion(memo: JsonObject): List<Page> {
         if (source !is KomgaSource) return this
+        val pageImageCacheToken = KomgaChapterMemo.pageImageCacheToken(memo)
         return map { page ->
             val imageUrl = page.imageUrl ?: return@map page
             Page(
                 index = page.index,
                 url = page.url,
-                imageUrl = KomgaChapterMemo.versionedPageImageUrl(imageUrl, memo),
+                imageUrl = KomgaChapterMemo.versionedPageImageUrl(imageUrl, pageImageCacheToken),
             )
         }
     }
@@ -345,10 +363,9 @@ internal class HttpPageLoader(
         // Cache current page list progress for online chapters to allow a faster reopen
         chapter.pages?.let { pages ->
             val chapterSnapshot = domainChapter
+            val pagesToSave = pages.map { Page(it.index, it.url, it.imageUrl) }
             pageListCacheWriteScope.launch {
                 try {
-                    // Convert to pages without reader information
-                    val pagesToSave = pages.map { Page(it.index, it.url, it.imageUrl) }
                     chapterCache.putPageListToCache(chapterSnapshot, pagesToSave)
                 } catch (e: Throwable) {
                     if (e is CancellationException) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoadGate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoadGate.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+internal class PageLoadGate(
+    private val preloadSize: Int,
+) {
+    private var activePageIndex: Int? = null
+    private var prefetchUnlocked = false
+    private var prefetchDirection = Direction.FORWARD
+
+    @Synchronized
+    fun activate(pageIndex: Int, pageCount: Int): Activation {
+        val previousPageIndex = activePageIndex
+        val changed = activePageIndex != pageIndex
+        if (previousPageIndex != null) {
+            prefetchDirection = when {
+                pageIndex < previousPageIndex -> Direction.BACKWARD
+                pageIndex > previousPageIndex -> Direction.FORWARD
+                else -> prefetchDirection
+            }
+        }
+        activePageIndex = pageIndex
+        return Activation(
+            changed = changed,
+            prefetchIndexes = if (prefetchUnlocked) prefetchIndexes(pageIndex, pageCount) else emptyList(),
+        )
+    }
+
+    @Synchronized
+    fun isActive(pageIndex: Int): Boolean = activePageIndex == pageIndex
+
+    @Synchronized
+    fun onPageDisplayed(pageIndex: Int, pageCount: Int): List<Int> {
+        if (activePageIndex != pageIndex || pageCount <= 0) return emptyList()
+        prefetchUnlocked = true
+        return prefetchIndexes(pageIndex, pageCount)
+    }
+
+    private fun prefetchIndexes(pageIndex: Int, pageCount: Int): List<Int> {
+        if (pageCount <= 0) return emptyList()
+        return when (prefetchDirection) {
+            Direction.FORWARD -> {
+                val first = pageIndex + 1
+                val lastExclusive = (first + preloadSize).coerceAtMost(pageCount)
+                if (first < lastExclusive) (first until lastExclusive).toList() else emptyList()
+            }
+            Direction.BACKWARD -> {
+                val first = pageIndex - 1
+                val lastInclusive = (pageIndex - preloadSize).coerceAtLeast(0)
+                if (first >= lastInclusive) (first downTo lastInclusive).toList() else emptyList()
+            }
+        }
+    }
+
+    data class Activation(
+        val changed: Boolean,
+        val prefetchIndexes: List<Int>,
+    )
+
+    private enum class Direction {
+        FORWARD,
+        BACKWARD,
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoader.kt
@@ -29,6 +29,18 @@ abstract class PageLoader {
      */
     open suspend fun loadPage(page: ReaderPage) {}
 
+    /** Marks the page that must be loaded ahead of all speculative work. */
+    open fun setActivePage(page: ReaderPage) {}
+
+    /** Releases speculative work only after the active page has actually been displayed. */
+    open fun onPageDisplayed(page: ReaderPage) {}
+
+    /** Reloads the page list without reusing its local or HTTP cache. */
+    open suspend fun refreshPages(): List<ReaderPage>? = null
+
+    /** Invalidates only the cached page list. Cached page images are versioned separately. */
+    open fun invalidatePageListCache() {}
+
     /**
      * Retries the given [page] in case it failed to load. This method only makes sense when an
      * online source is used.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -257,6 +257,7 @@ class PagerPageHolder(
     override fun onImageLoaded() {
         super.onImageLoaded()
         progressIndicator?.hide()
+        viewer.activity.onPageDisplayed(page)
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -255,6 +255,7 @@ class WebtoonPageHolder(
     private fun onImageDecoded() {
         progressContainer.isVisible = false
         removeErrorLayout()
+        page?.let(viewer.activity::onPageDisplayed)
     }
 
     /**

--- a/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
@@ -13,7 +13,10 @@ import koharia.source.komga.KomgaSource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChapter
+import tachiyomi.domain.chapter.interactor.UpdateChapter
+import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
@@ -26,6 +29,7 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
     private val downloadProvider: DownloadProvider = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChapter: GetChapter = Injekt.get(),
+    private val updateChapter: UpdateChapter = Injekt.get(),
     private val epubCacheManager: EpubCacheManager = Injekt.get(),
 ) {
 
@@ -83,12 +87,22 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             else -> null
         }
 
-        val remoteLookup = if (memoIsEpub == true || localUri != null || !application.isOnline()) {
+        val remoteLookup = if (memoIsEpub != null || localUri != null || !application.isOnline()) {
             Result.success(null)
         } else {
             runCatching { source.getBookDetails(chapter.url) }
         }
         val remoteBook = remoteLookup.getOrNull()
+        if (remoteBook != null) {
+            val updatedMemo = KomgaChapterMemo.mergeInto(
+                existing = chapter.memo,
+                baseUrl = source.baseUrl.trimEnd('/'),
+                book = remoteBook,
+            )
+            if (updatedMemo != chapter.memo) {
+                updateChapter.await(ChapterUpdate(id = chapter.id, memo = updatedMemo))
+            }
+        }
         val resolvedRemotePublicationKey = remoteBook?.let { book ->
             EpubCachePolicy.publicationKey(
                 fileHash = book.fileHash,
@@ -117,7 +131,7 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             else -> EpubReaderSupportResolution.UnsupportedReason.REMOTE_METADATA_UNAVAILABLE
         }
 
-        EpubReaderSupportResolution(
+        val resolution = EpubReaderSupportResolution(
             mangaId = manga.id,
             chapterId = chapter.id,
             sourceId = source.id,
@@ -146,6 +160,12 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             isManualDownload = downloadedFile != null,
             isCompleteCache = downloadedFile == null && cachedBookFile != null,
         )
+        logcat {
+            "MangaStartup: reader route resolved chapterId=${chapter.id} " +
+                "memoType=$memoIsEpub metadataRequested=${memoIsEpub == null && localUri == null} " +
+                "nativeEpub=${resolution.isNativeSupported}"
+        }
+        resolution
     }
 }
 

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import java.security.MessageDigest
 
 data class KomgaBookFingerprint(
     val bookUrl: String,
@@ -31,6 +32,9 @@ object KomgaChapterMemo {
     const val IS_EPUB = "isEpub"
     const val FILE_LAST_MODIFIED = "fileLastModified"
     const val FILE_NAME = "fileName"
+    const val PAGES_COUNT = "pagesCount"
+
+    private const val PAGE_CACHE_VERSION_FRAGMENT = "#koharia-publication="
 
     fun buildFingerprint(baseUrl: String, book: BookDto): KomgaBookFingerprint {
         return KomgaBookFingerprint(
@@ -52,6 +56,7 @@ object KomgaChapterMemo {
             put(IS_EPUB, book.isEpub)
             if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
             if (book.name.isNotBlank()) put(FILE_NAME, book.name)
+            if (book.media.pagesCount > 0) put(PAGES_COUNT, book.media.pagesCount)
         }
     }
 
@@ -92,6 +97,40 @@ object KomgaChapterMemo {
         }
     }
 
+    fun mergeInto(
+        existing: JsonObject,
+        baseUrl: String,
+        book: BookDto,
+    ): JsonObject {
+        val additions = buildMemo(baseUrl, book)
+        return buildJsonObject {
+            existing.forEach { (key, value) -> put(key, value) }
+            additions.forEach { (key, value) -> put(key, value) }
+        }
+    }
+
+    fun mergePublicationMetadata(
+        existing: JsonObject,
+        bookUrl: String,
+        fileHash: String?,
+        fileLastModified: String?,
+        sizeBytes: Long,
+        fileName: String?,
+        isEpub: Boolean,
+        pagesCount: Int,
+    ): JsonObject {
+        return buildJsonObject {
+            existing.forEach { (key, value) -> put(key, value) }
+            if (bookUrl.isNotBlank()) put(BOOK_URL, bookUrl)
+            fileHash?.takeIf(String::isNotBlank)?.let { put(FILE_HASH, it) }
+            fileLastModified?.takeIf(String::isNotBlank)?.let { put(FILE_LAST_MODIFIED, it) }
+            if (sizeBytes > 0L) put(SIZE_BYTES, sizeBytes)
+            fileName?.takeIf(String::isNotBlank)?.let { put(FILE_NAME, it) }
+            put(IS_EPUB, isEpub)
+            if (pagesCount > 0) put(PAGES_COUNT, pagesCount)
+        }
+    }
+
     fun readFingerprint(memo: JsonObject): KomgaBookFingerprint? {
         val bookUrl = memo.string(BOOK_URL).orEmpty()
         if (bookUrl.isBlank()) return null
@@ -114,6 +153,29 @@ object KomgaChapterMemo {
 
     fun fileName(memo: JsonObject): String? = memo.string(FILE_NAME)
 
+    fun pagesCount(memo: JsonObject): Int? = memo.long(PAGES_COUNT)?.toInt()?.takeIf { it > 0 }
+
+    fun publicationVersion(memo: JsonObject): String? {
+        val fileHash = memo.string(FILE_HASH)
+        if (!fileHash.isNullOrBlank()) return "hash:$fileHash"
+
+        val fileLastModified = fileLastModified(memo)
+        val sizeBytes = memo.long(SIZE_BYTES) ?: 0L
+        return if (!fileLastModified.isNullOrBlank() && sizeBytes > 0L) {
+            "modified:$fileLastModified:size:$sizeBytes"
+        } else {
+            null
+        }
+    }
+
+    fun versionedPageImageUrl(imageUrl: String, memo: JsonObject): String {
+        val networkUrl = networkPageImageUrl(imageUrl)
+        val version = publicationVersion(memo) ?: return networkUrl
+        return "$networkUrl$PAGE_CACHE_VERSION_FRAGMENT${version.cacheToken()}"
+    }
+
+    fun networkPageImageUrl(imageUrl: String): String = imageUrl.substringBefore(PAGE_CACHE_VERSION_FRAGMENT)
+
     private fun JsonObject.string(key: String): String? = this[key]?.jsonPrimitive?.contentOrNull()
 
     private fun JsonObject.long(key: String): Long? = this[key]?.jsonPrimitive?.longOrNull
@@ -126,4 +188,11 @@ object KomgaChapterMemo {
 
     private val kotlinx.serialization.json.JsonPrimitive.longOrNull: Long?
         get() = content.toLongOrNull()
+
+    private fun String.cacheToken(): String {
+        return MessageDigest.getInstance("SHA-256")
+            .digest(toByteArray())
+            .take(12)
+            .joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    }
 }

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -168,10 +168,19 @@ object KomgaChapterMemo {
         }
     }
 
+    fun pageImageCacheToken(memo: JsonObject): String? = publicationVersion(memo)?.cacheToken()
+
     fun versionedPageImageUrl(imageUrl: String, memo: JsonObject): String {
+        return versionedPageImageUrl(imageUrl, pageImageCacheToken(memo))
+    }
+
+    fun versionedPageImageUrl(imageUrl: String, cacheToken: String?): String {
         val networkUrl = networkPageImageUrl(imageUrl)
-        val version = publicationVersion(memo) ?: return networkUrl
-        return "$networkUrl$PAGE_CACHE_VERSION_FRAGMENT${version.cacheToken()}"
+        return if (cacheToken != null) {
+            "$networkUrl$PAGE_CACHE_VERSION_FRAGMENT$cacheToken"
+        } else {
+            networkUrl
+        }
     }
 
     fun networkPageImageUrl(imageUrl: String): String = imageUrl.substringBefore(PAGE_CACHE_VERSION_FRAGMENT)

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -23,6 +23,7 @@ import koharia.komga.api.KomgaApiClient
 import koharia.komga.api.dto.BookDto
 import koharia.komga.api.dto.LibraryDto
 import koharia.komga.domain.repository.KomgaRepository
+import koharia.komga.download.KomgaChapterMemo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -162,14 +163,26 @@ class KomgaSource(
     override fun chapterListParse(response: Response) = repository.chapterListParse(response, chapterNameTemplate)
 
     override fun pageListRequest(chapter: eu.kanade.tachiyomi.source.model.SChapter): Request =
-        repository.pageListRequest(chapter, KomgaCachePolicy.NetworkFirst)
+        repository.pageListRequest(chapter, KomgaCachePolicy.Default)
 
     override fun pageListParse(response: Response) = repository.pageListParse(response)
+
+    suspend fun getPageList(
+        chapter: eu.kanade.tachiyomi.source.model.SChapter,
+        cachePolicy: KomgaCachePolicy,
+    ): List<Page> {
+        return client.newCall(repository.pageListRequest(chapter, cachePolicy))
+            .awaitSuccess()
+            .let(repository::pageListParse)
+    }
 
     override fun imageUrlParse(response: Response): String = throw UnsupportedOperationException()
 
     override fun imageRequest(page: Page): Request =
-        GET(page.imageUrl!!, headersBuilder().add("Accept", "image/*,*/*;q=0.8").build())
+        GET(
+            KomgaChapterMemo.networkPageImageUrl(page.imageUrl!!),
+            headersBuilder().add("Accept", "image/*,*/*;q=0.8").build(),
+        )
 
     fun rawFileRequest(chapterUrl: String, rangeStart: Long? = null): Request = apiClient.bookFileRequest(
         chapterUrl,

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgressTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgressTest.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.ui.reader
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class MangaRemoteProgressTest {
+
+    @Test
+    fun `page percentage uses one based visible page`() {
+        assertEquals(1, pageProgressPercent(pageIndex = 0, totalPages = 100))
+        assertEquals(50, pageProgressPercent(pageIndex = 49, totalPages = 100))
+        assertEquals(100, pageProgressPercent(pageIndex = 99, totalPages = 100))
+    }
+
+    @Test
+    fun `page percentage handles unavailable totals`() {
+        assertEquals(0, pageProgressPercent(pageIndex = 0, totalPages = 0))
+    }
+
+    @Test
+    fun `initial publication metadata is not treated as a file change`() {
+        assertEquals(false, hasPublicationChanged(oldVersion = null, newVersion = "hash:v1"))
+    }
+
+    @Test
+    fun `known publication version change is detected`() {
+        assertEquals(true, hasPublicationChanged(oldVersion = "hash:v1", newVersion = "hash:v2"))
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoadGateTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/loader/PageLoadGateTest.kt
@@ -1,0 +1,66 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class PageLoadGateTest {
+
+    @Test
+    fun `prefetch remains closed until active page is displayed`() {
+        val gate = PageLoadGate(preloadSize = 4)
+
+        assertTrue(gate.activate(7, 20).changed)
+        assertTrue(gate.isActive(7))
+        assertFalse(gate.isActive(8))
+        assertEquals(emptyList<Int>(), gate.onPageDisplayed(8, 20))
+        assertEquals(listOf(8, 9, 10, 11), gate.onPageDisplayed(7, 20))
+    }
+
+    @Test
+    fun `selection advances prefetch window after first page is displayed`() {
+        val gate = PageLoadGate(preloadSize = 4)
+        assertEquals(emptyList<Int>(), gate.activate(2, 20).prefetchIndexes)
+        assertEquals(listOf(3, 4, 5, 6), gate.onPageDisplayed(2, 20))
+
+        val selection = gate.activate(5, 20)
+
+        assertTrue(selection.changed)
+        assertEquals(listOf(6, 7, 8, 9), selection.prefetchIndexes)
+    }
+
+    @Test
+    fun `jumping replaces old prefetch window and clamps at chapter end`() {
+        val gate = PageLoadGate(preloadSize = 4)
+        gate.activate(2, 10)
+        gate.onPageDisplayed(2, 10)
+        val selection = gate.activate(8, 10)
+
+        assertEquals(emptyList<Int>(), gate.onPageDisplayed(2, 10))
+        assertEquals(listOf(9), selection.prefetchIndexes)
+    }
+
+    @Test
+    fun `selecting a previous page reverses prefetch direction`() {
+        val gate = PageLoadGate(preloadSize = 4)
+        gate.activate(10, 20)
+        gate.onPageDisplayed(10, 20)
+
+        val selection = gate.activate(9, 20)
+
+        assertEquals(listOf(8, 7, 6, 5), selection.prefetchIndexes)
+        assertEquals(listOf(8, 7, 6, 5), gate.onPageDisplayed(9, 20))
+    }
+
+    @Test
+    fun `backward prefetch clamps at chapter start`() {
+        val gate = PageLoadGate(preloadSize = 4)
+        gate.activate(5, 20)
+        gate.onPageDisplayed(5, 20)
+
+        val selection = gate.activate(1, 20)
+
+        assertEquals(listOf(0), selection.prefetchIndexes)
+    }
+}

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -1,0 +1,37 @@
+package koharia.komga.download
+
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaChapterMemoTest {
+
+    @Test
+    fun `publication version prefers file hash`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.FILE_HASH, "hash-v2")
+            put(KomgaChapterMemo.FILE_LAST_MODIFIED, "2026-07-17T00:00:00Z")
+            put(KomgaChapterMemo.SIZE_BYTES, 128L)
+        }
+
+        assertEquals("hash:hash-v2", KomgaChapterMemo.publicationVersion(memo))
+    }
+
+    @Test
+    fun `page image cache key changes with publication and network url stays clean`() {
+        val firstMemo = buildJsonObject { put(KomgaChapterMemo.FILE_HASH, "hash-v1") }
+        val secondMemo = buildJsonObject { put(KomgaChapterMemo.FILE_HASH, "hash-v2") }
+        val imageUrl = "https://komga.test/api/v1/books/book/pages/1?convert=png"
+
+        val first = KomgaChapterMemo.versionedPageImageUrl(imageUrl, firstMemo)
+        val second = KomgaChapterMemo.versionedPageImageUrl(imageUrl, secondMemo)
+
+        assertNotEquals(first, second)
+        assertTrue(first.startsWith(imageUrl))
+        assertEquals(imageUrl, KomgaChapterMemo.networkPageImageUrl(first))
+        assertEquals(first, KomgaChapterMemo.versionedPageImageUrl(first, firstMemo))
+    }
+}

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -28,8 +28,10 @@ class KomgaChapterMemoTest {
 
         val first = KomgaChapterMemo.versionedPageImageUrl(imageUrl, firstMemo)
         val second = KomgaChapterMemo.versionedPageImageUrl(imageUrl, secondMemo)
+        val firstToken = KomgaChapterMemo.pageImageCacheToken(firstMemo)
 
         assertNotEquals(first, second)
+        assertEquals(first, KomgaChapterMemo.versionedPageImageUrl(imageUrl, firstToken))
         assertTrue(first.startsWith(imageUrl))
         assertEquals(imageUrl, KomgaChapterMemo.networkPageImageUrl(first))
         assertEquals(first, KomgaChapterMemo.versionedPageImageUrl(first, firstMemo))

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1318,6 +1318,7 @@
     <string name="pref_book_cache_info">Book cache is managed separately from downloads. Clearing it does not remove offline downloads, reading progress, or bookmarks.</string>
     <string name="epub_reader_remote_progress_title">Server reading progress</string>
     <string name="epub_reader_remote_progress_message">The server has a different saved position (%1$d%%). Jump to it?</string>
+    <string name="reader_remote_progress_message">Local: page %1$d of %2$d (%3$d%%)\nServer: page %4$d of %5$d (%6$d%%)</string>
     <string name="epub_reader_keep_local_progress">Keep current position</string>
     <string name="epub_reader_jump_remote_progress">Jump to server position</string>
 </resources>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -1179,6 +1179,7 @@
     <string name="pref_book_cache_info">书籍缓存与下载相互独立。清除缓存不会删除离线下载、阅读进度或书签。</string>
     <string name="epub_reader_remote_progress_title">服务器阅读进度</string>
     <string name="epub_reader_remote_progress_message">服务器保存了不同的阅读位置（%1$d%%），是否跳转？</string>
+    <string name="reader_remote_progress_message">本地：第 %1$d/%2$d 页（%3$d%%）\n服务器：第 %4$d/%5$d 页（%6$d%%）</string>
     <string name="epub_reader_keep_local_progress">保留当前位置</string>
     <string name="epub_reader_jump_remote_progress">跳转至服务器进度</string>
 </resources>


### PR DESCRIPTION
## 概述 / Summary

优化 Komga 漫画阅读器的首屏加载、按页缓存、快速翻页预取与单本云端进度复核，使远程漫画更快显示，并在连续翻页、跳页和反向翻页时保持更稳定的加载体验。

Improves first-screen loading, per-page caching, rapid-turn prefetching, and per-book remote progress reconciliation for the Komga manga reader, providing faster display and steadier loading across sequential turns, jumps, and direction changes.

## 功能变化 / Changes

- 优先使用章节 memo 和本地页清单缓存完成漫画路由与页面初始化，减少首屏前的服务器等待。
- 使用出版物版本隔离页清单和图片缓存，书籍文件更新后不会误用旧页面。
- 首屏只加载当前目标页，实际显示后再释放预取任务；当前页始终拥有最高加载优先级。
- Komga 页面请求支持受控的双路网络加载，并对排队及执行中的页面任务去重。
- 预取窗口会随实际翻页方向切换，向后阅读预取后四页，向前翻页预取前四页。
- 首屏显示后仅复核当前书籍的 Komga 进度，不再让整系列进度同步阻塞阅读器。
- 本地与云端页码不同时提供明确选择，并显示双方页码及百分比；隐私模式保持不联网同步。

- Uses chapter metadata and cached page lists to route and initialize manga before remote metadata refreshes.
- Versions page-list and image cache keys so updated publications never reuse stale pages.
- Loads only the target page before first display, then releases prefetching while keeping the active page at the highest priority.
- Adds bounded two-request Komga network loading with queue and in-flight deduplication.
- Switches the four-page prefetch window with the user's reading direction, including backward page turns.
- Reconciles only the current Komga book after first display instead of blocking startup on series-wide progress synchronization.
- Presents local and remote page positions with percentages when they differ, while keeping incognito sessions offline.

## 用户影响 / User impact

远程漫画可以更早显示首张目标页；连续快速翻页不再周期性撞上停滞的预取边界，跳转后反向阅读也会自动加载对应方向的页面。缓存仍属于临时页面缓存，不会改变下载状态。

Remote manga can display the target page sooner. Rapid sequential turns no longer repeatedly hit a stale prefetch boundary, and reversing direction after a jump automatically warms pages in that direction. Cached pages remain temporary cache entries and do not affect download status.

## 检查 / Checks

- `spotlessCheck`
- `:app:compileDebugKotlin`
- 11 unit tests covering publication-version cache keys, remote progress calculations, first-page gating, jumping, bidirectional prefetching, and chapter boundaries
- Manual reader test completed without an obvious regression
