### PR TITLE
发布 0.2.1 并调整阅读器默认设置 / Release 0.2.1 and update reader defaults

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
     defaultConfig {
         applicationId = "app.koharia"
 
-        versionCode = 2
-        versionName = "0.2.0"
+        versionCode = 3
+        versionName = "0.2.1"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -26,7 +26,7 @@ class ReaderPreferences(
 
     val doubleTapAnimSpeed: Preference<Int> = preferenceStore.getInt("pref_double_tap_anim_speed", 500)
 
-    val showPageNumber: Preference<Boolean> = preferenceStore.getBoolean("pref_show_page_number_key", true)
+    val showPageNumber: Preference<Boolean> = preferenceStore.getBoolean("pref_show_page_number_key", false)
 
     val verticalNavigatorForLongStrip: Preference<Boolean> = preferenceStore.getBoolean(
         "pref_webtoon_vertical_navigator",

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -241,9 +241,6 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             val currentTheme by epubLayoutPreferences.theme.changes().collectAsState(epubLayoutPreferences.theme.get())
             val currentCustomBackgroundColor by epubLayoutPreferences.customBackgroundColor.changes()
                 .collectAsState(epubLayoutPreferences.customBackgroundColor.get())
-            val currentReaderBackgroundColor = remember(currentTheme, currentCustomBackgroundColor) {
-                Color(currentTheme.readerBackgroundColor(currentCustomBackgroundColor))
-            }
             val currentReadingMode by epubLayoutPreferences.readingMode.changes()
                 .collectAsState(epubLayoutPreferences.readingMode.get())
             val currentPageDirection by epubLayoutPreferences.pageDirection.changes()
@@ -299,6 +296,15 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             val grayscale by readerPreferences.grayscale.changes().collectAsState(readerPreferences.grayscale.get())
             val invertedColors by readerPreferences.invertedColors.changes()
                 .collectAsState(readerPreferences.invertedColors.get())
+            val currentReaderBackgroundColor = remember(
+                currentTheme,
+                currentCustomBackgroundColor,
+                grayscale,
+                invertedColors,
+            ) {
+                Color(currentTheme.readerBackgroundColor(currentCustomBackgroundColor))
+                    .applyReaderColorFilter(grayscale, invertedColors)
+            }
             val subtitle = remember(state.chapterTitle, state.currentSectionTitle, state.progressionPercent) {
                 listOfNotNull(
                     state.chapterTitle,
@@ -1380,6 +1386,31 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private fun readerVerticalPaddingDp(verticalMargins: Float): Float {
         return READER_EDGE_PADDING_DP +
             EpubLayoutPreferences.VERTICAL_MARGIN_BASE_DP * verticalMargins
+    }
+
+    /**
+     * Applies the same grayscale/inversion operations as [readerColorFilterPaint] to Compose edge colors.
+     * The reader Fragment is filtered by an Android [ColorMatrixColorFilter], while the Compose edge bands
+     * are separate layers and therefore need the transformed color explicitly.
+     */
+    private fun Color.applyReaderColorFilter(grayscale: Boolean, invertedColors: Boolean): Color {
+        var red = red
+        var green = green
+        var blue = blue
+
+        if (grayscale) {
+            val luminance = 0.213f * red + 0.715f * green + 0.072f * blue
+            red = luminance
+            green = luminance
+            blue = luminance
+        }
+        if (invertedColors) {
+            red = 1f - red
+            green = 1f - green
+            blue = 1f - blue
+        }
+
+        return Color(red, green, blue, alpha)
     }
 
     private fun EpubLayoutPreferences.Theme.readerBackgroundColor(customBackgroundColor: Int): Int {

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -17,17 +17,23 @@ import android.view.WindowManager
 import androidx.activity.compose.BackHandler
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ModalDrawerSheet
@@ -235,12 +241,18 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             val currentTheme by epubLayoutPreferences.theme.changes().collectAsState(epubLayoutPreferences.theme.get())
             val currentCustomBackgroundColor by epubLayoutPreferences.customBackgroundColor.changes()
                 .collectAsState(epubLayoutPreferences.customBackgroundColor.get())
+            val currentReaderBackgroundColor = remember(currentTheme, currentCustomBackgroundColor) {
+                Color(currentTheme.readerBackgroundColor(currentCustomBackgroundColor))
+            }
             val currentReadingMode by epubLayoutPreferences.readingMode.changes()
                 .collectAsState(epubLayoutPreferences.readingMode.get())
             val currentPageDirection by epubLayoutPreferences.pageDirection.changes()
                 .collectAsState(epubLayoutPreferences.pageDirection.get())
             val currentVerticalMargins by epubLayoutPreferences.verticalMargins.changes()
                 .collectAsState(epubLayoutPreferences.verticalMargins.get())
+            val fullscreenVerticalPadding = remember(currentVerticalMargins) {
+                readerVerticalPaddingDp(currentVerticalMargins).dp
+            }
             val navigationModeWebtoon by readerPreferences.navigationModeWebtoon.changes()
                 .collectAsState(readerPreferences.navigationModeWebtoon.get())
             val navigationModePager by readerPreferences.navigationModePager.changes()
@@ -540,6 +552,37 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                                     customBackgroundColor = currentCustomBackgroundColor,
                                     verticalMargins = currentVerticalMargins,
                                 )
+
+                                // Readium applies padding to a white Fragment container. Paint only the reserved
+                                // fullscreen edges here; visible reader menus must keep their Material theme colors.
+                                if (fullscreen && !state.menuVisible) {
+                                    Column(
+                                        modifier = Modifier
+                                            .align(Alignment.TopCenter)
+                                            .fillMaxWidth()
+                                            .background(currentReaderBackgroundColor),
+                                    ) {
+                                        Spacer(
+                                            modifier = Modifier.windowInsetsTopHeight(WindowInsets.displayCutout),
+                                        )
+                                        Spacer(modifier = Modifier.height(fullscreenVerticalPadding))
+                                    }
+                                    Column(
+                                        modifier = Modifier
+                                            .align(Alignment.BottomCenter)
+                                            .fillMaxWidth()
+                                            .background(currentReaderBackgroundColor),
+                                    ) {
+                                        Spacer(modifier = Modifier.height(fullscreenVerticalPadding))
+                                        if (!drawUnderCutout) {
+                                            Spacer(
+                                                modifier = Modifier.windowInsetsBottomHeight(
+                                                    WindowInsets.displayCutout,
+                                                ),
+                                            )
+                                        }
+                                    }
+                                }
 
                                 ReaderContentOverlay(
                                     brightness = 0,
@@ -1293,17 +1336,17 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             !drawUnderCutout -> displayCutout.bottom
             else -> 0
         }
-        val edgePadding = if (fullscreen) readerEdgePaddingPx() else 0
-        val verticalMargin = (
-            EpubLayoutPreferences.VERTICAL_MARGIN_BASE_DP *
-                verticalMargins * resources.displayMetrics.density
-            ).roundToInt()
+        val verticalPadding = if (fullscreen) {
+            (readerVerticalPaddingDp(verticalMargins) * resources.displayMetrics.density).roundToInt()
+        } else {
+            0
+        }
 
         setPadding(
             horizontalInsets.left,
-            topInset + edgePadding + verticalMargin,
+            topInset + verticalPadding,
             horizontalInsets.right,
-            bottomInset + edgePadding + verticalMargin,
+            bottomInset + verticalPadding,
         )
     }
 
@@ -1333,8 +1376,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         }
     }
 
-    private fun View.readerEdgePaddingPx(): Int {
-        return (READER_EDGE_PADDING_DP * resources.displayMetrics.density).roundToInt()
+    // Shared by the Fragment padding and fullscreen background overlays so their bounds cannot drift apart.
+    private fun readerVerticalPaddingDp(verticalMargins: Float): Float {
+        return READER_EDGE_PADDING_DP +
+            EpubLayoutPreferences.VERTICAL_MARGIN_BASE_DP * verticalMargins
     }
 
     private fun EpubLayoutPreferences.Theme.readerBackgroundColor(customBackgroundColor: Int): Int {

--- a/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderPreferences.kt
@@ -13,7 +13,7 @@ class EpubReaderPreferences(
         preferenceStore.getBoolean("epub_reader_sync_progression_komga", true)
 
     val correctKomgaServerTimestamps: Preference<Boolean> =
-        preferenceStore.getBoolean("epub_reader_correct_komga_server_timestamps", false)
+        preferenceStore.getBoolean("epub_reader_correct_komga_server_timestamps", true)
 
     fun komgaServerTimestampOffsetMinutes(sourceId: Long): Preference<Long> =
         preferenceStore.getLong("epub_reader_komga_server_timestamp_offset_minutes_$sourceId", 0L)


### PR DESCRIPTION
## 修改内容 / Changes

- 将应用版本更新至 `0.2.1`（versionCode 3）。
- 默认开启 Komga 服务器时间戳修正，改善服务器时间不准确时的阅读进度判断。
- 默认关闭阅读页面的页码/进度显示，为新安装用户提供更简洁的阅读界面；已有用户的已保存偏好不受影响。
- EPUB 全屏阅读时，顶部摄像头安全区和底部安全区跟随当前阅读背景色，保证切换背景颜色后整页显示一致；阅读菜单仍保留独立的主题色。

- Bump the app version to `0.2.1` (versionCode 3).
- Enable Komga server timestamp correction by default to improve progress decisions when server timestamps are inaccurate.
- Disable page/progress display by default for a cleaner reader experience on new installations; existing user choices remain unchanged.
- Make the top camera-safe area and bottom safe area follow the active EPUB reader background in fullscreen mode, while keeping reader menus on their own theme colors.

## 用户影响 / User impact

这些默认值仅影响尚未保存对应偏好的新安装或新配置；不会覆盖现有用户已选择的设置。全屏阅读时，背景色会覆盖正文上下由系统安全区和阅读边距保留的区域。

These defaults apply only when the corresponding preferences have not been saved yet. In fullscreen reading, the selected background color also covers the safe-area and reader-margin regions above and below the content.

## 验证 / Validation

按当前快速开发约定，本次完成差异与格式检查，未运行完整编译验证。

Per the current rapid-development workflow, the change was reviewed with diff and whitespace checks; a full build was not run.