### PR TITLE
修复 EPUB 刘海区域显示开关 / Fix EPUB cutout content setting

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -42,7 +42,7 @@ class ReaderPreferences(
 
     val fullscreen: Preference<Boolean> = preferenceStore.getBoolean("fullscreen", true)
 
-    val drawUnderCutout: Preference<Boolean> = preferenceStore.getBoolean("cutout_short", true)
+    val drawUnderCutout: Preference<Boolean> = preferenceStore.getBoolean("cutout_short", false)
 
     val keepScreenOn: Preference<Boolean> = preferenceStore.getBoolean("pref_keep_screen_on_key", false)
 

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -562,16 +562,18 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                                 // Readium applies padding to a white Fragment container. Paint only the reserved
                                 // fullscreen edges here; visible reader menus must keep their Material theme colors.
                                 if (fullscreen && !state.menuVisible) {
-                                    Column(
-                                        modifier = Modifier
-                                            .align(Alignment.TopCenter)
-                                            .fillMaxWidth()
-                                            .background(currentReaderBackgroundColor),
-                                    ) {
-                                        Spacer(
-                                            modifier = Modifier.windowInsetsTopHeight(WindowInsets.displayCutout),
-                                        )
-                                        Spacer(modifier = Modifier.height(fullscreenVerticalPadding))
+                                    if (!drawUnderCutout) {
+                                        Column(
+                                            modifier = Modifier
+                                                .align(Alignment.TopCenter)
+                                                .fillMaxWidth()
+                                                .background(currentReaderBackgroundColor),
+                                        ) {
+                                            Spacer(
+                                                modifier = Modifier.windowInsetsTopHeight(WindowInsets.displayCutout),
+                                            )
+                                            Spacer(modifier = Modifier.height(fullscreenVerticalPadding))
+                                        }
                                     }
                                     Column(
                                         modifier = Modifier
@@ -1257,25 +1259,37 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                     fragment.view?.let { view ->
                         view.setBackgroundColor(theme.readerBackgroundColor(customBackgroundColor))
                         view.setLayerType(View.LAYER_TYPE_HARDWARE, readerColorFilterPaint(grayscale, invertedColors))
-                        view.applyInsetsPadding(
-                            windowInsets = ViewCompat.getRootWindowInsets(view),
+                        view.updateInsetsHandling(
                             fullscreen = fullscreen,
                             drawUnderCutout = drawUnderCutout,
                             verticalMargins = verticalMargins,
                         )
-                        ViewCompat.setOnApplyWindowInsetsListener(view) { insetView, windowInsets ->
-                            insetView.applyInsetsPadding(
-                                windowInsets = windowInsets,
-                                fullscreen = fullscreen,
-                                drawUnderCutout = drawUnderCutout,
-                                verticalMargins = verticalMargins,
-                            )
-                            windowInsets
-                        }
-                        ViewCompat.requestApplyInsets(view)
                     }
                 },
             )
+            LaunchedEffect(
+                chapterId,
+                sessionToken,
+                fullscreen,
+                drawUnderCutout,
+                grayscale,
+                invertedColors,
+                theme,
+                customBackgroundColor,
+                verticalMargins,
+            ) {
+                // AndroidFragment.onUpdate is only invoked when the Fragment is created. Re-apply
+                // layout-affecting reader settings when Compose preferences change in the same session.
+                readerFragment?.view?.let { view ->
+                    view.setBackgroundColor(theme.readerBackgroundColor(customBackgroundColor))
+                    view.setLayerType(View.LAYER_TYPE_HARDWARE, readerColorFilterPaint(grayscale, invertedColors))
+                    view.updateInsetsHandling(
+                        fullscreen = fullscreen,
+                        drawUnderCutout = drawUnderCutout,
+                        verticalMargins = verticalMargins,
+                    )
+                }
+            }
         }
     }
 
@@ -1322,6 +1336,29 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         }
     }
 
+    private fun View.updateInsetsHandling(
+        fullscreen: Boolean,
+        drawUnderCutout: Boolean,
+        verticalMargins: Float,
+    ) {
+        applyInsetsPadding(
+            windowInsets = ViewCompat.getRootWindowInsets(this),
+            fullscreen = fullscreen,
+            drawUnderCutout = drawUnderCutout,
+            verticalMargins = verticalMargins,
+        )
+        ViewCompat.setOnApplyWindowInsetsListener(this) { insetView, windowInsets ->
+            insetView.applyInsetsPadding(
+                windowInsets = windowInsets,
+                fullscreen = fullscreen,
+                drawUnderCutout = drawUnderCutout,
+                verticalMargins = verticalMargins,
+            )
+            windowInsets
+        }
+        ViewCompat.requestApplyInsets(this)
+    }
+
     private fun View.applyInsetsPadding(
         windowInsets: WindowInsetsCompat?,
         fullscreen: Boolean,
@@ -1335,8 +1372,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             !drawUnderCutout -> displayCutout
             else -> Insets.NONE
         }
-        // EPUB text must always stay below the camera cutout, even when edge drawing is enabled.
-        val topInset = if (fullscreen) displayCutout.top else systemBars.top
+        val topInset = when {
+            !fullscreen -> systemBars.top
+            !drawUnderCutout -> displayCutout.top
+            else -> 0
+        }
         val bottomInset = when {
             !fullscreen -> systemBars.bottom
             !drawUnderCutout -> displayCutout.bottom
@@ -1347,7 +1387,6 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         } else {
             0
         }
-
         setPadding(
             horizontalInsets.left,
             topInset + verticalPadding,


### PR DESCRIPTION
## 修改内容 / Changes

- 将 EPUB 阅读器的“在屏幕刘海区域显示内容”默认值改为关闭。
- 开启后，全屏阅读正文可以进入刘海区域，不再被顶部背景覆盖层遮挡。
- 阅读页面内动态切换设置后，重新应用 WindowInsets，关闭设置菜单并隐藏系统栏后仍保持最新的刘海区域布局。
- 关闭该选项时继续绘制顶部安全区背景，保持系统栏与正文区域的视觉区分。

## 原因 / Why

阅读器原先的 WindowInsets listener 捕获了初始化时的设置值，导致在设置页切换后重新进入全屏时恢复旧 padding；同时全屏顶部背景层会覆盖进入刘海区域的正文。

The WindowInsets listener retained the initial setting after the reader preference changed, restoring stale padding when returning to fullscreen. The fullscreen top overlay could also cover content drawn under the cutout.

## 验证 / Validation

- `spotlessApply`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- 在 Android 虚拟机中验证默认关闭、开启设置、关闭设置菜单并进入全屏后的正文与刘海区域显示。
- Verified the setting toggle and fullscreen behavior on the Android emulator.
