### PR TITLE
修复 EPUB 打开崩溃 / Prevent EPUB launch state serialization crash

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -37,13 +37,23 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.jvm.Transient
 
 sealed class KomgaLibraryTab(
     private val libraryScope: KomgaLibraryScope,
     private val tabIndex: UShort,
 ) : Tab {
 
-    private var komgaBrowseScreen = newScreen(KomgaServerPreferences.NO_ACTIVE_SERVER)
+    // Voyager serializes Tab instances when the host Activity is stopped. The
+    // browse screen owns coroutine channels and must therefore stay runtime-only.
+    @Transient
+    private var runtimeBrowseScreen: KomgaLibraryScreen? = null
+
+    private fun browseScreen(): KomgaLibraryScreen {
+        return runtimeBrowseScreen ?: newScreen(KomgaServerPreferences.NO_ACTIVE_SERVER).also {
+            runtimeBrowseScreen = it
+        }
+    }
 
     override val options: TabOptions
         @Composable
@@ -68,7 +78,7 @@ sealed class KomgaLibraryTab(
         }
 
     override suspend fun onReselect(navigator: Navigator) {
-        komgaBrowseScreen.refresh()
+        browseScreen().refresh()
     }
 
     @Composable
@@ -100,13 +110,13 @@ sealed class KomgaLibraryTab(
         var hasEntered by remember { mutableStateOf(false) }
 
         SideEffect {
-            komgaBrowseScreen = activeScreen
+            runtimeBrowseScreen = activeScreen
         }
 
         LaunchedEffect(isSelected) {
             if (isSelected) {
                 if (hasEntered) {
-                    komgaBrowseScreen.refresh()
+                    browseScreen().refresh()
                 } else {
                     hasEntered = true
                 }
@@ -116,9 +126,9 @@ sealed class KomgaLibraryTab(
         activeScreen.Content()
     }
 
-    suspend fun search(query: String) = komgaBrowseScreen.search(query)
+    suspend fun search(query: String) = browseScreen().search(query)
 
-    suspend fun searchGenre(name: String) = komgaBrowseScreen.searchGenre(name)
+    suspend fun searchGenre(name: String) = browseScreen().searchGenre(name)
 
     private fun newScreen(sourceId: Long) = KomgaLibraryScreen(
         sourceId = sourceId,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryTab.kt
@@ -47,11 +47,15 @@ sealed class KomgaLibraryTab(
     // Voyager serializes Tab instances when the host Activity is stopped. The
     // browse screen owns coroutine channels and must therefore stay runtime-only.
     @Transient
+    @Volatile
     private var runtimeBrowseScreen: KomgaLibraryScreen? = null
 
     private fun browseScreen(): KomgaLibraryScreen {
-        return runtimeBrowseScreen ?: newScreen(KomgaServerPreferences.NO_ACTIVE_SERVER).also {
-            runtimeBrowseScreen = it
+        runtimeBrowseScreen?.let { return it }
+        return synchronized(this) {
+            runtimeBrowseScreen ?: newScreen(KomgaServerPreferences.NO_ACTIVE_SERVER).also {
+                runtimeBrowseScreen = it
+            }
         }
     }
 

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -95,10 +95,14 @@ data class KomgaLibraryScreen(
     // serializable Voyager Screen prevents Activity state saving from trying to
     // serialize kotlinx.coroutines' BufferedChannel implementation.
     @Transient
+    @Volatile
     private var runtimeEvents: RuntimeEvents? = null
 
     private fun events(): RuntimeEvents {
-        return runtimeEvents ?: RuntimeEvents().also { runtimeEvents = it }
+        runtimeEvents?.let { return it }
+        return synchronized(this) {
+            runtimeEvents ?: RuntimeEvents().also { runtimeEvents = it }
+        }
     }
 
     override fun onProvideAssistUrl() = assistUrl

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -79,6 +79,7 @@ import tachiyomi.presentation.core.screens.LoadingScreen
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.jvm.Transient
 import kotlin.math.roundToInt
 
 data class KomgaLibraryScreen(
@@ -89,8 +90,16 @@ data class KomgaLibraryScreen(
 ) : Screen(), AssistContentScreen {
 
     private var assistUrl: String? = null
-    private val queryEvent = Channel<SearchType>()
-    private val refreshEvent = Channel<Unit>(capacity = Channel.CONFLATED)
+
+    // These channels are runtime event buses. Keeping them out of the
+    // serializable Voyager Screen prevents Activity state saving from trying to
+    // serialize kotlinx.coroutines' BufferedChannel implementation.
+    @Transient
+    private var runtimeEvents: RuntimeEvents? = null
+
+    private fun events(): RuntimeEvents {
+        return runtimeEvents ?: RuntimeEvents().also { runtimeEvents = it }
+    }
 
     override fun onProvideAssistUrl() = assistUrl
 
@@ -306,7 +315,7 @@ data class KomgaLibraryScreen(
         }
 
         LaunchedEffect(Unit) {
-            queryEvent.receiveAsFlow()
+            events().query.receiveAsFlow()
                 .collectLatest {
                     when (it) {
                         is SearchType.Genre -> screenModel.searchGenre(it.txt)
@@ -316,15 +325,20 @@ data class KomgaLibraryScreen(
         }
 
         LaunchedEffect(Unit) {
-            refreshEvent.receiveAsFlow().collectLatest {
+            events().refresh.receiveAsFlow().collectLatest {
                 screenModel.refresh()
             }
         }
     }
 
-    suspend fun search(query: String) = queryEvent.send(SearchType.Text(query))
-    suspend fun searchGenre(name: String) = queryEvent.send(SearchType.Genre(name))
-    suspend fun refresh() = refreshEvent.send(Unit)
+    suspend fun search(query: String) = events().query.send(SearchType.Text(query))
+    suspend fun searchGenre(name: String) = events().query.send(SearchType.Genre(name))
+    suspend fun refresh() = events().refresh.send(Unit)
+
+    private class RuntimeEvents {
+        val query = Channel<SearchType>()
+        val refresh = Channel<Unit>(capacity = Channel.CONFLATED)
+    }
 
     sealed class SearchType(val txt: String) {
         class Text(txt: String) : SearchType(txt)


### PR DESCRIPTION
## 中文\n修复打开 EPUB 后 Activity 进入后台时的崩溃。书架 Tab 和 Komga 书架 Screen 不再把搜索、刷新事件通道及其运行时页面对象交给 Voyager/Android 状态保存进行序列化；进程重建后会按需重新创建运行时事件对象。这样可以避免 BufferedChannel 被写入 Bundle 导致 BadParcelableException，同时保留书架搜索、刷新和重新进入行为。\n\n## English\nFixes the crash that occurred when opening an EPUB and Android saved the host Activity state. The library tab and Komga library screen no longer serialize runtime screens or coroutine event channels; those runtime objects are recreated on demand after process restoration. This prevents BufferedChannel from being written into the Bundle and preserves library search, refresh, and re-entry behavior.