### PR TITLE
恢复旧服务器配置并保护删除流程 / Recover legacy Komga profiles safely

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -144,6 +144,7 @@ class AppModule(val app: Application) : InjektModule {
         }
         addSingletonFactory {
             KomgaServerPreferences(
+                context = app,
                 preferenceStore = get<PreferenceStore>(),
                 json = get<Json>(),
             ).also(KomgaServerPreferences::ensureProfilesInitialized)

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -1,5 +1,6 @@
 package koharia.source.komga
 
+import android.content.Context
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -28,6 +29,7 @@ enum class DownloadDirectoryMode {
 }
 
 class KomgaServerPreferences(
+    private val context: Context,
     preferenceStore: PreferenceStore,
     private val json: Json,
 ) {
@@ -75,16 +77,36 @@ class KomgaServerPreferences(
     }
 
     fun ensureProfilesInitialized() {
-        if (hasInitializedProfiles.get()) {
-            ensureActiveServerExists(getProfiles())
-            return
+        val persistedProfiles = decodeProfiles(serializedProfiles.get())
+        val profiles = buildList {
+            addAll(persistedProfiles)
+
+            // 0.1.x stored the only Komga server in source_<KomgaSource.ID>.
+            // Keep that stable ID as the first profile when an interrupted or
+            // partial upgrade left the new profile list incomplete. The
+            // source preference file is intentionally left untouched: the
+            // existing address and credentials are already keyed by this ID.
+            if (hasLegacySourcePreferences() && none { it.id == KomgaSource.ID }) {
+                add(defaultProfile())
+            }
+
+            // A fresh install has no legacy source preference to inspect.
+            if (isEmpty()) add(defaultProfile())
         }
 
-        val profiles = decodeProfiles(serializedProfiles.get())
-            .ifEmpty { listOf(defaultProfile()) }
-        serializedProfiles.set(profiles.mapTo(linkedSetOf(), json::encodeToString))
-        hasInitializedProfiles.set(true)
+        if (!hasInitializedProfiles.get() || profiles != persistedProfiles) {
+            serializedProfiles.set(profiles.mapTo(linkedSetOf(), json::encodeToString))
+            hasInitializedProfiles.set(true)
+        }
         ensureActiveServerExists(profiles)
+    }
+
+    private fun hasLegacySourcePreferences(): Boolean {
+        val preferences = context.getSharedPreferences(
+            "source_${KomgaSource.ID}",
+            Context.MODE_PRIVATE,
+        )
+        return preferences.contains(PREF_LEGACY_ADDRESS)
     }
 
     private fun ensureActiveServerExists(profiles: List<KomgaServerProfile>) {
@@ -124,6 +146,7 @@ class KomgaServerPreferences(
         private const val PREF_LOCAL_CONFIG_MODE = "komga_local_config_mode"
         private const val PREF_DOWNLOAD_DIRECTORY_MODE = "komga_download_directory_mode"
         private const val PREF_HAS_INITIALIZED_PROFILES = "komga_has_initialized_profiles"
+        private const val PREF_LEGACY_ADDRESS = "Address"
 
         const val NO_ACTIVE_SERVER = -1L
     }

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -73,11 +73,16 @@ class KomgaServerPreferences(
     fun setProfiles(profiles: Collection<KomgaServerProfile>) {
         val normalizedProfiles = normalizeProfiles(profiles.toList())
         serializedProfiles.set(normalizedProfiles.mapTo(linkedSetOf(), json::encodeToString))
+        // An explicit profile update (including deleting the last profile) is no longer
+        // an initialization attempt. This prevents legacy recovery from recreating a
+        // profile the user deliberately removed.
+        hasInitializedProfiles.set(true)
         ensureActiveServerExists(normalizedProfiles)
     }
 
     fun ensureProfilesInitialized() {
         val persistedProfiles = decodeProfiles(serializedProfiles.get())
+        val isFirstInitialization = !hasInitializedProfiles.get()
         val profiles = buildList {
             addAll(persistedProfiles)
 
@@ -86,15 +91,15 @@ class KomgaServerPreferences(
             // partial upgrade left the new profile list incomplete. The
             // source preference file is intentionally left untouched: the
             // existing address and credentials are already keyed by this ID.
-            if (hasLegacySourcePreferences() && none { it.id == KomgaSource.ID }) {
+            if (isFirstInitialization && hasLegacySourcePreferences() && none { it.id == KomgaSource.ID }) {
                 add(defaultProfile())
             }
 
             // A fresh install has no legacy source preference to inspect.
-            if (isEmpty()) add(defaultProfile())
+            if (isFirstInitialization && isEmpty()) add(defaultProfile())
         }
 
-        if (!hasInitializedProfiles.get() || profiles != persistedProfiles) {
+        if (isFirstInitialization || profiles != persistedProfiles) {
             serializedProfiles.set(profiles.mapTo(linkedSetOf(), json::encodeToString))
             hasInitializedProfiles.set(true)
         }

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -43,6 +44,7 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.more.settings.widget.ListPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.PreferenceGroupHeader
 import eu.kanade.presentation.util.Screen
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -62,6 +64,7 @@ class KomgaServerProfilesScreen : Screen() {
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
+        val context = LocalContext.current
         val serverPreferences = remember { Injekt.get<KomgaServerPreferences>() }
         val localConfigManager = remember { Injekt.get<KomgaLocalConfigManager>() }
         val classificationManager = remember { Injekt.get<KomgaLibraryClassificationManager>() }
@@ -273,8 +276,12 @@ class KomgaServerProfilesScreen : Screen() {
                 onDismissRequest = { profileToDelete = null },
                 onDelete = {
                     scope.launch {
-                        serverRemovalManager.removeServer(profile.id)
-                        profileToDelete = null
+                        val result = serverRemovalManager.removeServer(profile.id)
+                        if (result.isSuccess) {
+                            profileToDelete = null
+                        } else {
+                            context.toast(MR.strings.komga_server_delete_failed)
+                        }
                     }
                 },
             )

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.download.DownloadCache
 import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.data.download.KomgaSharedDownloadIndexManager
 import koharia.epub.cache.EpubCacheManager
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import logcat.LogPriority
@@ -23,24 +24,36 @@ class KomgaServerRemovalManager(
     suspend fun removeServer(
         serverId: Long,
         options: DownloadCleanupMode = DownloadCleanupMode.Preserve,
-    ) {
+    ): Result<Unit> {
         val currentProfiles = serverPreferences.getProfiles()
-        val profile = currentProfiles.find { it.id == serverId } ?: return
+        val profile = currentProfiles.find { it.id == serverId } ?: return Result.success(Unit)
 
-        withContext(Dispatchers.IO) {
-            clearServerSettingsIfNeeded(serverId)
-            cleanupDownloads(profile, options)
-            epubCacheManager.clearServer(serverId)
-            libraryClassificationManager.clearServer(serverId)
-            localConfigManager.clearScopeForServer(serverId)
-        }
-        serverPreferences.setProfiles(currentProfiles - profile)
+        return try {
+            withContext(Dispatchers.IO) {
+                // Keep credentials and scoped settings until every retryable
+                // cleanup step succeeds, so a failure cannot orphan the profile.
+                cleanupDownloads(profile, options)
+                epubCacheManager.clearServer(serverId)
+                libraryClassificationManager.clearServer(serverId)
+                localConfigManager.clearScopeForServer(serverId)
+                clearServerSettingsIfNeeded(serverId)
+            }
+            serverPreferences.setProfiles(currentProfiles - profile)
 
-        logcat(LogPriority.DEBUG) {
-            "Removed Komga server id=$serverId name=${profile.name} " +
-                "(localConfigMode=${serverPreferences.localConfigMode.get()}, " +
-                "downloadDirectoryMode=${serverPreferences.downloadDirectoryMode.get()}, " +
-                "cleanupMode=$options)"
+            logcat(LogPriority.DEBUG) {
+                "Removed Komga server id=$serverId name=${profile.name} " +
+                    "(localConfigMode=${serverPreferences.localConfigMode.get()}, " +
+                    "downloadDirectoryMode=${serverPreferences.downloadDirectoryMode.get()}, " +
+                    "cleanupMode=$options)"
+            }
+            Result.success(Unit)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Throwable) {
+            logcat(LogPriority.ERROR, exception) {
+                "Failed to remove Komga server id=$serverId; profile and scoped settings were retained"
+            }
+            Result.failure(exception)
         }
     }
 

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -38,7 +38,11 @@ class KomgaServerRemovalManager(
                 localConfigManager.clearScopeForServer(serverId)
                 clearServerSettingsIfNeeded(serverId)
             }
-            serverPreferences.setProfiles(currentProfiles - profile)
+            // Read the profiles again after cleanup. The settings screen can edit or add
+            // another profile while disk/network cleanup is in progress; filtering by ID
+            // preserves those concurrent changes instead of writing the stale snapshot.
+            val latestProfiles = serverPreferences.getProfiles()
+            serverPreferences.setProfiles(latestProfiles.filterNot { it.id == serverId })
 
             logcat(LogPriority.DEBUG) {
                 "Removed Komga server id=$serverId name=${profile.name} " +

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.util.Screen
@@ -24,6 +25,7 @@ import eu.kanade.tachiyomi.data.preference.DeferredSharedPreferencesDataStore
 import eu.kanade.tachiyomi.source.sourcePreferences
 import eu.kanade.tachiyomi.ui.source.DataStoreHolder
 import eu.kanade.tachiyomi.ui.source.SourcePreferencesScreen
+import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.launch
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.i18n.MR
@@ -42,6 +44,7 @@ class KomgaServerSettingsScreen(
         var showHelpDialog by rememberSaveable { mutableStateOf(false) }
         var showUnsavedDialog by rememberSaveable { mutableStateOf(false) }
         val navigator = LocalNavigator.currentOrThrow
+        val context = LocalContext.current
         val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
         val scope = rememberCoroutineScope()
 
@@ -64,7 +67,11 @@ class KomgaServerSettingsScreen(
         fun discardAndPop() {
             scope.launch {
                 if (isNew) {
-                    serverRemovalManager.removeServer(sourceId)
+                    val result = serverRemovalManager.removeServer(sourceId)
+                    if (result.isFailure) {
+                        context.toast(MR.strings.komga_server_delete_failed)
+                        return@launch
+                    }
                 }
                 navigator.pop()
             }

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -70,7 +70,6 @@ class KomgaServerSettingsScreen(
                     val result = serverRemovalManager.removeServer(sourceId)
                     if (result.isFailure) {
                         context.toast(MR.strings.komga_server_delete_failed)
-                        return@launch
                     }
                 }
                 navigator.pop()

--- a/app/src/test/java/koharia/source/komga/KomgaLibraryClassificationManagerTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaLibraryClassificationManagerTest.kt
@@ -1,5 +1,9 @@
 package koharia.source.komga
 
+import android.content.Context
+import android.content.SharedPreferences
+import io.mockk.every
+import io.mockk.mockk
 import koharia.komga.api.dto.LibraryDto
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -63,7 +67,13 @@ class KomgaLibraryClassificationManagerTest {
     private fun fixture(): Fixture {
         val store = InMemoryPreferenceStore()
         val json = Json { ignoreUnknownKeys = true }
-        val serverPreferences = KomgaServerPreferences(store, json)
+        val legacyPreferences = mockk<SharedPreferences> {
+            every { contains(any()) } returns false
+        }
+        val context = mockk<Context> {
+            every { getSharedPreferences(any(), any()) } returns legacyPreferences
+        }
+        val serverPreferences = KomgaServerPreferences(context, store, json)
         val localConfigManager = KomgaLocalConfigManager(
             preferenceStore = store,
             serverPreferences = serverPreferences,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -223,6 +223,7 @@
     <string name="action_add_server">Add server</string>
     <string name="delete_server">Delete server</string>
     <string name="delete_server_confirmation">Do you wish to delete the server "%s"?</string>
+    <string name="komga_server_delete_failed">Couldn\'t delete the server. Your server settings were kept; please try again.</string>
     <string name="komga_no_servers_title">No servers added</string>
     <string name="komga_no_servers_summary">Add a Komga server to browse your library and edit server-scoped settings.</string>
     <string name="komga_local_config_mode">Local configuration mode</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -79,6 +79,7 @@
     <string name="action_add_server">添加服务器</string>
     <string name="delete_server">删除服务器</string>
     <string name="delete_server_confirmation">确定要删除服务器“%s”吗？</string>
+    <string name="komga_server_delete_failed">无法删除服务器，服务器设置已保留，请重试。</string>
     <string name="komga_pref_address_title">Komga服务器地址</string>
     <string name="komga_pref_address_summary">Komga 服务器地址</string>
     <string name="komga_pref_address_dialog">地址末尾不能带斜杠。</string>


### PR DESCRIPTION
## 修改内容 / What changed

- 升级后重新检查旧版单服务器 SharedPreferences，并在新服务器列表缺失时恢复稳定的 Komga 默认配置。
- 新安装仍创建默认服务器，已有多服务器配置保持不变。
- 删除服务器时先完成下载、缓存、分类和作用域配置清理，全部成功后才移除服务器凭据。
- 删除失败时保留服务器配置并显示可重试提示，协程取消仍按正常取消传播。
- 更新受构造函数变化影响的服务器分类测试。

- Recover the stable default Komga profile when legacy single-server preferences exist but the migrated profile list is incomplete.
- Preserve existing multi-server profiles and the fresh-install default behavior.
- Remove server credentials only after downloads, caches, classifications, and scoped settings are cleaned successfully.
- Keep the server profile and show a retryable error when cleanup fails while preserving coroutine cancellation semantics.
- Update the affected server classification test fixture.

## 用户影响 / User impact

从旧版本升级后，已有 Komga 地址和凭据不会因不完整的多服务器迁移而消失；删除服务器失败也不会留下无法重试的孤立数据。

Legacy Komga credentials survive incomplete profile migration, and failed server removal remains recoverable without orphaning scoped data.

## 验证 / Checks

- `:app:compileDebugKotlin`
- `:app:testDebugUnitTest --tests koharia.source.komga.KomgaLibraryClassificationManagerTest`
- `spotlessCheck`
