### PR TITLE
稳定服务器切换后的详情路由 / Stabilize routes across Komga server switches

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -448,6 +448,8 @@ class NotificationReceiver : BroadcastReceiver() {
                 Intent(context, MainActivity::class.java).setAction(Constants.SHORTCUT_MANGA)
                     .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                     .putExtra(Constants.MANGA_EXTRA, manga.id)
+                    .putExtra(Constants.MANGA_SOURCE_EXTRA, manga.source)
+                    .putExtra(Constants.MANGA_URL_EXTRA, manga.url)
                     .putExtra("notificationId", manga.id.hashCode())
                     .putExtra("groupId", groupId)
             return PendingIntent.getActivity(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt
@@ -171,7 +171,14 @@ object HomeScreen : Screen() {
                         }
 
                         if (it is Tab.Library && it.mangaIdToOpen != null) {
-                            navigator.push(MangaScreen(it.mangaIdToOpen, it.fromSource))
+                            navigator.push(
+                                MangaScreen(
+                                    mangaId = it.mangaIdToOpen,
+                                    fromSource = it.fromSource,
+                                    sourceId = it.sourceId,
+                                    mangaUrl = it.mangaUrl,
+                                ),
+                            )
                         }
                         if (it is Tab.More && it.toDownloads) {
                             navigator.push(DownloadQueueScreen)
@@ -266,6 +273,8 @@ object HomeScreen : Screen() {
         data class Library(
             val mangaIdToOpen: Long? = null,
             val fromSource: Boolean = false,
+            val sourceId: Long? = null,
+            val mangaUrl: String? = null,
         ) : Tab
         data object Updates : Tab
         data object History : Tab

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -185,10 +185,12 @@ class MainActivity : BaseActivity() {
                     komgaServerPreferences.activeServerId.changes()
                         .drop(1)
                         .collectLatest {
-                            // Details and browse state are keyed by the
-                            // previous server. Return to the home tabs before
-                            // the new source renders.
-                            navigator.popUntilRoot()
+                            // Only discard screens whose content is keyed by the previous
+                            // server. Server-management screens can change the active server
+                            // while adding/editing a profile and must remain on the stack.
+                            when (navigator.lastItem) {
+                                is MangaScreen, is KomgaLibraryScreen -> navigator.popUntilRoot()
+                            }
                         }
                 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -78,6 +78,7 @@ import eu.kanade.tachiyomi.util.system.updaterEnabled
 import eu.kanade.tachiyomi.util.view.setComposeContent
 import koharia.core.migration.Migrator
 import koharia.komga.ui.library.KomgaLibraryScreen
+import koharia.source.komga.KomgaServerPreferences
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -109,6 +110,7 @@ class MainActivity : BaseActivity() {
     private val chapterCache: ChapterCache by injectLazy()
 
     private val getIncognitoState: GetIncognitoState by injectLazy()
+    private val komgaServerPreferences: KomgaServerPreferences by injectLazy()
 
     // To be checked by splash screen. If true then splash screen will be removed.
     var ready = false
@@ -178,6 +180,16 @@ class MainActivity : BaseActivity() {
                     (navigator.lastItem as? KomgaLibraryScreen)?.sourceId
                         .let(getIncognitoState::subscribe)
                         .collectLatest { incognito = it }
+                }
+                LaunchedEffect(navigator) {
+                    komgaServerPreferences.activeServerId.changes()
+                        .drop(1)
+                        .collectLatest {
+                            // Details and browse state are keyed by the
+                            // previous server. Return to the home tabs before
+                            // the new source renders.
+                            navigator.popUntilRoot()
+                        }
                 }
 
                 val scaffoldInsets = WindowInsets.navigationBars.only(WindowInsetsSides.Horizontal)
@@ -371,8 +383,10 @@ class MainActivity : BaseActivity() {
             Constants.SHORTCUT_MANGA -> {
                 val idToOpen = intent.extras?.getLong(Constants.MANGA_EXTRA) ?: return false
                 val fromSource = intent.extras?.getBoolean(Constants.FROM_SOURCE_EXTRA, false) ?: false
+                val sourceId = intent.extras?.getLong(Constants.MANGA_SOURCE_EXTRA)?.takeUnless { it == 0L }
+                val mangaUrl = intent.extras?.getString(Constants.MANGA_URL_EXTRA)
                 navigator.popUntilRoot()
-                HomeScreen.Tab.Library(idToOpen, fromSource)
+                HomeScreen.Tab.Library(idToOpen, fromSource, sourceId, mangaUrl)
             }
             Constants.SHORTCUT_UPDATES -> HomeScreen.Tab.Updates
             Constants.SHORTCUT_HISTORY -> HomeScreen.Tab.History

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -59,11 +59,15 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.screens.EmptyScreen
 import tachiyomi.presentation.core.screens.LoadingScreen
 
 class MangaScreen(
-    private val mangaId: Long,
+    val mangaId: Long,
     val fromSource: Boolean = false,
+    val sourceId: Long? = null,
+    val mangaUrl: String? = null,
 ) : Screen(), AssistContentScreen {
 
     override fun onProvideAssistUrl(): String? = null
@@ -81,8 +85,15 @@ class MangaScreen(
         val scope = rememberCoroutineScope()
         val epubReaderLauncher = remember { EpubReaderLauncher() }
         val lifecycleOwner = LocalLifecycleOwner.current
-        val screenModel = rememberScreenModel {
-            MangaScreenModel(context, lifecycleOwner.lifecycle, mangaId, fromSource)
+        val screenModel = rememberScreenModel(tag = "$mangaId:$sourceId:$mangaUrl") {
+            MangaScreenModel(
+                context = context,
+                lifecycle = lifecycleOwner.lifecycle,
+                mangaId = mangaId,
+                isFromSource = fromSource,
+                routeSourceId = sourceId,
+                routeUrl = mangaUrl,
+            )
         }
 
         val state by screenModel.state.collectAsStateWithLifecycle()
@@ -90,6 +101,11 @@ class MangaScreen(
 
         if (state is MangaScreenModel.State.Loading) {
             LoadingScreen()
+            return
+        }
+
+        if (state is MangaScreenModel.State.Error) {
+            EmptyScreen(stringRes = MR.strings.epub_reader_manga_not_found)
             return
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.core.net.toUri
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -84,11 +83,9 @@ class MangaScreen(
         val haptic = LocalHapticFeedback.current
         val scope = rememberCoroutineScope()
         val epubReaderLauncher = remember { EpubReaderLauncher() }
-        val lifecycleOwner = LocalLifecycleOwner.current
         val screenModel = rememberScreenModel(tag = "$mangaId:$sourceId:$mangaUrl") {
             MangaScreenModel(
-                context = context,
-                lifecycle = lifecycleOwner.lifecycle,
+                context = context.applicationContext,
                 mangaId = mangaId,
                 isFromSource = fromSource,
                 routeSourceId = sourceId,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -7,8 +7,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.util.fastAny
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.preference.asState
@@ -127,8 +125,7 @@ private fun mergeEpubProgressions(
 
 class MangaScreenModel(
     private val context: Context,
-    private val lifecycle: Lifecycle,
-    private var mangaId: Long,
+    private val mangaId: Long,
     private val isFromSource: Boolean,
     private val routeSourceId: Long? = null,
     private val routeUrl: String? = null,
@@ -165,6 +162,9 @@ class MangaScreenModel(
 
     private val successState: State.Success?
         get() = state.value as? State.Success
+
+    private val currentMangaId: Long
+        get() = successState?.manga?.id ?: mangaId
 
     val manga: Manga?
         get() = successState?.manga
@@ -219,23 +219,23 @@ class MangaScreenModel(
                 mutableState.update { State.Error }
                 return@launchIO
             }
-            mangaId = manga.id
+            val resolvedMangaId = manga.id
 
             val chaptersDeferred = async {
-                getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true)
+                getMangaAndChapters.awaitChapters(resolvedMangaId, applyScanlatorFilter = true)
             }
-            val localProgressDeferred = async { getEpubProgress.awaitByMangaId(mangaId) }
+            val localProgressDeferred = async { getEpubProgress.awaitByMangaId(resolvedMangaId) }
             val remoteProgressDeferred = async {
                 runCatching {
-                    getEpubRemoteProgressCache.awaitByMangaId(mangaId)
+                    getEpubRemoteProgressCache.awaitByMangaId(resolvedMangaId)
                 }.onFailure { error ->
                     logcat(LogPriority.WARN, error) {
-                        "Failed to load cached EPUB remote progress for mangaId=$mangaId"
+                        "Failed to load cached EPUB remote progress for mangaId=$resolvedMangaId"
                     }
                 }.getOrDefault(emptyList())
             }
-            val availableScanlatorsDeferred = async { getAvailableScanlators.await(mangaId) }
-            val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
+            val availableScanlatorsDeferred = async { getAvailableScanlators.await(resolvedMangaId) }
+            val excludedScanlatorsDeferred = async { getExcludedScanlators.await(resolvedMangaId) }
 
             val epubProgresses = mergeEpubProgressions(
                 localProgresses = localProgressDeferred.await(),
@@ -251,15 +251,14 @@ class MangaScreenModel(
 
             launch {
                 combine(
-                    getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
-                    getEpubProgress.subscribeByMangaId(mangaId),
-                    getEpubRemoteProgressCache.subscribeByMangaId(mangaId),
+                    getMangaAndChapters.subscribe(resolvedMangaId, applyScanlatorFilter = true).distinctUntilChanged(),
+                    getEpubProgress.subscribeByMangaId(resolvedMangaId),
+                    getEpubRemoteProgressCache.subscribeByMangaId(resolvedMangaId),
                     downloadCache.changes,
                     downloadManager.queueState,
                 ) { mangaAndChapters, localProgresses, remoteProgresses, _, _ ->
                     Triple(mangaAndChapters, localProgresses, remoteProgresses)
                 }
-                    .flowWithLifecycle(lifecycle)
                     .collectLatest { (mangaAndChapters, localProgresses, remoteProgresses) ->
                         val (updatedManga, chapters) = mangaAndChapters
                         updateSuccessState {
@@ -275,8 +274,7 @@ class MangaScreenModel(
             }
 
             launch {
-                getExcludedScanlators.subscribe(mangaId)
-                    .flowWithLifecycle(lifecycle)
+                getExcludedScanlators.subscribe(resolvedMangaId)
                     .distinctUntilChanged()
                     .collectLatest { excludedScanlators ->
                         updateSuccessState { it.copy(excludedScanlators = excludedScanlators) }
@@ -284,8 +282,7 @@ class MangaScreenModel(
             }
 
             launch {
-                getAvailableScanlators.subscribe(mangaId)
-                    .flowWithLifecycle(lifecycle)
+                getAvailableScanlators.subscribe(resolvedMangaId)
                     .distinctUntilChanged()
                     .collectLatest { availableScanlators ->
                         updateSuccessState { it.copy(availableScanlators = availableScanlators) }
@@ -361,7 +358,12 @@ class MangaScreenModel(
 
     private suspend fun resolveManga(): Manga? {
         val byId = getMangaAndChapters.awaitMangaOrNull(mangaId)
-        if (byId != null && (routeSourceId == null || byId.source == routeSourceId)) return byId
+        if (byId != null &&
+            (routeSourceId == null || byId.source == routeSourceId) &&
+            (routeUrl.isNullOrBlank() || byId.url == routeUrl)
+        ) {
+            return byId
+        }
 
         return if (!routeUrl.isNullOrBlank() && routeSourceId != null) {
             mangaRepository.getMangaByUrlAndSourceId(routeUrl, routeSourceId)
@@ -400,17 +402,17 @@ class MangaScreenModel(
             if (!force) delay(EPUB_REMOTE_PROGRESS_DELAY_MS)
             val remote = runCatching {
                 epubRemoteProgressCoordinator.syncManga(
-                    mangaId = mangaId,
+                    mangaId = currentMangaId,
                     sourceId = source.id,
                     chapters = chapters,
                     force = force,
                 )
             }.onFailure { error ->
                 logcat(LogPriority.WARN, error) {
-                    "Failed to refresh EPUB remote progress for mangaId=$mangaId"
+                    "Failed to refresh EPUB remote progress for mangaId=$currentMangaId"
                 }
             }.getOrDefault(emptyList()).associateBy { it.chapterId }
-            val local = getEpubProgress.awaitByMangaId(mangaId).associateBy { it.chapterId }
+            val local = getEpubProgress.awaitByMangaId(currentMangaId).associateBy { it.chapterId }
             updateSuccessState { state ->
                 state.copy(
                     chapters = state.chapters.map { item ->
@@ -440,11 +442,13 @@ class MangaScreenModel(
 
         screenModelScope.launchIO {
             runCatching {
-                val latestManga = getMangaAndChapters.awaitManga(mangaId)
+                val latestManga = getMangaAndChapters.awaitManga(currentMangaId)
                 addTracks.bindEnhancedTrackers(latestManga, source)
                 komgaProgressSyncService.syncFromServer(latestManga)
             }.onFailure { error ->
-                logcat(LogPriority.WARN, error) { "Failed to sync Komga progress in background for mangaId=$mangaId" }
+                logcat(LogPriority.WARN, error) {
+                    "Failed to sync Komga progress in background for mangaId=$currentMangaId"
+                }
             }
         }
     }
@@ -664,7 +668,7 @@ class MangaScreenModel(
 
     private fun moveMangaToCategory(categoryIds: List<Long>) {
         screenModelScope.launchIO {
-            setMangaCategories.await(mangaId, categoryIds)
+            setMangaCategories.await(currentMangaId, categoryIds)
         }
     }
 
@@ -686,7 +690,6 @@ class MangaScreenModel(
             downloadManager.statusFlow()
                 .filter { it.manga.id == successState?.manga?.id }
                 .catch { error -> logcat(LogPriority.ERROR, error) }
-                .flowWithLifecycle(lifecycle)
                 .collect {
                     withUIContext {
                         updateDownloadState(it)
@@ -698,7 +701,6 @@ class MangaScreenModel(
             downloadManager.progressFlow()
                 .filter { it.manga.id == successState?.manga?.id }
                 .catch { error -> logcat(LogPriority.ERROR, error) }
-                .flowWithLifecycle(lifecycle)
                 .collect {
                     withUIContext {
                         updateDownloadState(it)
@@ -788,7 +790,7 @@ class MangaScreenModel(
             screenModelScope.launch {
                 snackbarHostState.showSnackbar(message = message)
             }
-            val newManga = mangaRepository.getMangaById(mangaId)
+            val newManga = mangaRepository.getMangaById(currentMangaId)
             updateSuccessState { it.copy(manga = newManga, isRefreshingData = false) }
         }
     }
@@ -954,13 +956,13 @@ class MangaScreenModel(
 
             refreshTrackers()
 
-            val tracks = getTracks.await(mangaId)
+            val tracks = getTracks.await(currentMangaId)
             val maxChapterNumber = chapters.maxOf { it.chapterNumber }
             val shouldPromptTrackingUpdate = tracks.any { track -> maxChapterNumber > track.lastChapterRead }
 
             if (!shouldPromptTrackingUpdate) return@launchIO
             if (autoTrackState == AutoTrackState.ALWAYS) {
-                trackChapter.await(context, mangaId, maxChapterNumber)
+                trackChapter.await(context, currentMangaId, maxChapterNumber)
                 withUIContext {
                     context.toast(context.stringResource(MR.strings.trackers_updated_summary, maxChapterNumber.toInt()))
                 }
@@ -975,7 +977,7 @@ class MangaScreenModel(
             )
 
             if (result == SnackbarResult.ActionPerformed) {
-                trackChapter.await(context, mangaId, maxChapterNumber)
+                trackChapter.await(context, currentMangaId, maxChapterNumber)
             }
         }
     }
@@ -983,11 +985,11 @@ class MangaScreenModel(
     private suspend fun refreshTrackers(
         refreshTracks: RefreshTracks = Injekt.get(),
     ) {
-        refreshTracks.await(mangaId)
+        refreshTracks.await(currentMangaId)
             .filter { it.first != null }
             .forEach { (track, e) ->
                 logcat(LogPriority.ERROR, e) {
-                    "Failed to refresh track data mangaId=$mangaId for service ${track!!.id}"
+                    "Failed to refresh track data mangaId=$currentMangaId for service ${track!!.id}"
                 }
                 withUIContext {
                     context.toast(
@@ -1265,7 +1267,6 @@ class MangaScreenModel(
                 val supportedTrackerTracks = mangaTracks.filter { it.trackerId in supportedTrackerIds }
                 supportedTrackerTracks.size to supportedTrackers.isNotEmpty()
             }
-                .flowWithLifecycle(lifecycle)
                 .distinctUntilChanged()
                 .collectLatest { (trackingCount, hasLoggedInTrackers) ->
                     updateSuccessState {
@@ -1321,7 +1322,7 @@ class MangaScreenModel(
 
     fun setExcludedScanlators(excludedScanlators: Set<String>) {
         screenModelScope.launchIO {
-            setExcludedScanlators.await(mangaId, excludedScanlators)
+            setExcludedScanlators.await(currentMangaId, excludedScanlators)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -128,8 +128,10 @@ private fun mergeEpubProgressions(
 class MangaScreenModel(
     private val context: Context,
     private val lifecycle: Lifecycle,
-    private val mangaId: Long,
+    private var mangaId: Long,
     private val isFromSource: Boolean,
+    private val routeSourceId: Long? = null,
+    private val routeUrl: String? = null,
     private val libraryPreferences: LibraryPreferences = Injekt.get(),
     private val trackPreferences: TrackPreferences = Injekt.get(),
     readerPreferences: ReaderPreferences = Injekt.get(),
@@ -198,64 +200,27 @@ class MangaScreenModel(
     private inline fun updateSuccessState(func: (State.Success) -> State.Success) {
         mutableState.update {
             when (it) {
-                State.Loading -> it
+                State.Loading, State.Error -> it
                 is State.Success -> func(it)
             }
         }
     }
 
     init {
-        screenModelScope.launchIO {
-            combine(
-                getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
-                getEpubProgress.subscribeByMangaId(mangaId),
-                getEpubRemoteProgressCache.subscribeByMangaId(mangaId),
-                downloadCache.changes,
-                downloadManager.queueState,
-            ) { mangaAndChapters, localProgresses, remoteProgresses, _, _ ->
-                Triple(mangaAndChapters, localProgresses, remoteProgresses)
-            }
-                .flowWithLifecycle(lifecycle)
-                .collectLatest { (mangaAndChapters, localProgresses, remoteProgresses) ->
-                    val (manga, chapters) = mangaAndChapters
-                    updateSuccessState {
-                        it.copy(
-                            manga = manga,
-                            chapters = chapters.toChapterListItems(
-                                manga,
-                                mergeEpubProgressions(localProgresses, remoteProgresses),
-                            ),
-                        )
-                    }
-                }
-        }
-
-        screenModelScope.launchIO {
-            getExcludedScanlators.subscribe(mangaId)
-                .flowWithLifecycle(lifecycle)
-                .distinctUntilChanged()
-                .collectLatest { excludedScanlators ->
-                    updateSuccessState {
-                        it.copy(excludedScanlators = excludedScanlators)
-                    }
-                }
-        }
-
-        screenModelScope.launchIO {
-            getAvailableScanlators.subscribe(mangaId)
-                .flowWithLifecycle(lifecycle)
-                .distinctUntilChanged()
-                .collectLatest { availableScanlators ->
-                    updateSuccessState {
-                        it.copy(availableScanlators = availableScanlators)
-                    }
-                }
-        }
-
         observeDownloads()
 
         screenModelScope.launchIO {
-            val mangaDeferred = async { getMangaAndChapters.awaitManga(mangaId) }
+            val manga = resolveManga()
+            if (manga == null) {
+                logcat(LogPriority.WARN) {
+                    "Manga route is no longer valid: mangaId=$mangaId, " +
+                        "routeSourceId=$routeSourceId, hasRouteUrl=${!routeUrl.isNullOrBlank()}"
+                }
+                mutableState.update { State.Error }
+                return@launchIO
+            }
+            mangaId = manga.id
+
             val chaptersDeferred = async {
                 getMangaAndChapters.awaitChapters(mangaId, applyScanlatorFilter = true)
             }
@@ -272,7 +237,6 @@ class MangaScreenModel(
             val availableScanlatorsDeferred = async { getAvailableScanlators.await(mangaId) }
             val excludedScanlatorsDeferred = async { getExcludedScanlators.await(mangaId) }
 
-            val manga = mangaDeferred.await()
             val epubProgresses = mergeEpubProgressions(
                 localProgresses = localProgressDeferred.await(),
                 remoteProgresses = remoteProgressDeferred.await(),
@@ -284,6 +248,49 @@ class MangaScreenModel(
                 allowSharedDownloadLookup = false,
             )
             val source = Injekt.get<SourceManager>().getOrStub(manga.source)
+
+            launch {
+                combine(
+                    getMangaAndChapters.subscribe(mangaId, applyScanlatorFilter = true).distinctUntilChanged(),
+                    getEpubProgress.subscribeByMangaId(mangaId),
+                    getEpubRemoteProgressCache.subscribeByMangaId(mangaId),
+                    downloadCache.changes,
+                    downloadManager.queueState,
+                ) { mangaAndChapters, localProgresses, remoteProgresses, _, _ ->
+                    Triple(mangaAndChapters, localProgresses, remoteProgresses)
+                }
+                    .flowWithLifecycle(lifecycle)
+                    .collectLatest { (mangaAndChapters, localProgresses, remoteProgresses) ->
+                        val (updatedManga, chapters) = mangaAndChapters
+                        updateSuccessState {
+                            it.copy(
+                                manga = updatedManga,
+                                chapters = chapters.toChapterListItems(
+                                    updatedManga,
+                                    mergeEpubProgressions(localProgresses, remoteProgresses),
+                                ),
+                            )
+                        }
+                    }
+            }
+
+            launch {
+                getExcludedScanlators.subscribe(mangaId)
+                    .flowWithLifecycle(lifecycle)
+                    .distinctUntilChanged()
+                    .collectLatest { excludedScanlators ->
+                        updateSuccessState { it.copy(excludedScanlators = excludedScanlators) }
+                    }
+            }
+
+            launch {
+                getAvailableScanlators.subscribe(mangaId)
+                    .flowWithLifecycle(lifecycle)
+                    .distinctUntilChanged()
+                    .collectLatest { availableScanlators ->
+                        updateSuccessState { it.copy(availableScanlators = availableScanlators) }
+                    }
+            }
 
             if (!manga.favorite) {
                 setMangaDefaultChapterFlags.await(manga)
@@ -349,6 +356,17 @@ class MangaScreenModel(
                 syncEpubProgressInBackground(source, current.chapters.map { it.chapter })
             }
             syncKomgaProgressInBackground(source)
+        }
+    }
+
+    private suspend fun resolveManga(): Manga? {
+        val byId = getMangaAndChapters.awaitMangaOrNull(mangaId)
+        if (byId != null && (routeSourceId == null || byId.source == routeSourceId)) return byId
+
+        return if (!routeUrl.isNullOrBlank() && routeSourceId != null) {
+            mangaRepository.getMangaByUrlAndSourceId(routeUrl, routeSourceId)
+        } else {
+            null
         }
     }
 
@@ -1310,6 +1328,9 @@ class MangaScreenModel(
     sealed interface State {
         @Immutable
         data object Loading : State
+
+        @Immutable
+        data object Error : State
 
         @Immutable
         data class Success(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -622,6 +622,10 @@ class ReaderActivity : BaseActivity() {
                 Intent(this, MainActivity::class.java).apply {
                     action = Constants.SHORTCUT_MANGA
                     putExtra(Constants.MANGA_EXTRA, id)
+                    viewModel.manga?.let { manga ->
+                        putExtra(Constants.MANGA_SOURCE_EXTRA, manga.source)
+                        putExtra(Constants.MANGA_URL_EXTRA, manga.url)
+                    }
                     addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 },
             )

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -1194,15 +1194,18 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     private fun openMangaScreen() {
         lifecycleScope.launch {
-            val detailsMangaId = viewModel.resolveDetailsMangaId() ?: return@launch
+            val detailsRoute = viewModel.resolveDetailsRoute() ?: return@launch
             logcat(LogPriority.DEBUG) {
-                val sourceId = intent.extras?.getLong("source", -1L)
-                "EPUB openMangaScreen detailsMangaId=$detailsMangaId readerMangaId=${viewModel.state.value.mangaId} chapterId=${viewModel.state.value.chapterId} sourceId=$sourceId"
+                "EPUB openMangaScreen detailsMangaId=${detailsRoute.mangaId} " +
+                    "readerMangaId=${viewModel.state.value.mangaId} " +
+                    "chapterId=${viewModel.state.value.chapterId} sourceId=${detailsRoute.sourceId}"
             }
             startActivity(
                 Intent(this@EpubReaderActivity, MainActivity::class.java).apply {
                     action = Constants.SHORTCUT_MANGA
-                    putExtra(Constants.MANGA_EXTRA, detailsMangaId)
+                    putExtra(Constants.MANGA_EXTRA, detailsRoute.mangaId)
+                    putExtra(Constants.MANGA_SOURCE_EXTRA, detailsRoute.sourceId)
+                    putExtra(Constants.MANGA_URL_EXTRA, detailsRoute.mangaUrl)
                     putExtra(Constants.FROM_SOURCE_EXTRA, true)
                     addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                 },

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -613,14 +613,28 @@ class EpubReaderViewModel @JvmOverloads constructor(
         return mangaId to chapterId
     }
 
-    suspend fun resolveDetailsMangaId(): Long? {
-        val sourceId = currentSourceId.takeIf { it > 0 } ?: return mangaId.takeIf { it > 0 }
+    suspend fun resolveDetailsRoute(): DetailsRoute? {
+        val fallbackMangaId = mangaId.takeIf { it > 0 } ?: return null
+        val sourceId = currentSourceId.takeIf { it > 0 }
         val chapterUrl = currentChapterUrl?.substringBefore('#')?.removeSuffix("/")
-        val matchedBookMangaId = chapterUrl
-            ?.let { getMangaByUrlAndSourceId.await(it, sourceId)?.id }
-            ?.takeIf { it > 0 }
-        return matchedBookMangaId ?: mangaId.takeIf { it > 0 }
+        val matchedBook = if (sourceId != null) {
+            chapterUrl?.let { getMangaByUrlAndSourceId.await(it, sourceId) }
+        } else {
+            null
+        }
+        val detailsManga = matchedBook ?: getManga.await(fallbackMangaId) ?: return null
+        return DetailsRoute(
+            mangaId = detailsManga.id,
+            sourceId = detailsManga.source,
+            mangaUrl = detailsManga.url,
+        )
     }
+
+    data class DetailsRoute(
+        val mangaId: Long,
+        val sourceId: Long,
+        val mangaUrl: String,
+    )
 
     fun showMenus(visible: Boolean) {
         mutableState.update { it.copy(menuVisible = visible) }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -126,7 +126,7 @@ data class KomgaLibraryScreen(
         val getIncognitoState: GetIncognitoState = Injekt.get()
         val libraryClassificationManager: KomgaLibraryClassificationManager = Injekt.get()
 
-        val screenModel = rememberScreenModel {
+        val screenModel = rememberScreenModel(tag = "$sourceId:$libraryScope:$listingQuery") {
             KomgaLibraryScreenModel(
                 sourceId = sourceId,
                 listingQuery = listingQuery,
@@ -284,7 +284,16 @@ data class KomgaLibraryScreen(
                         showLibraryBadges = false,
                         onWebViewClick = onWebViewClick,
                         onHelpClick = onHelpClick,
-                        onMangaClick = { navigator.push((MangaScreen(it.id, true))) },
+                        onMangaClick = {
+                            navigator.push(
+                                MangaScreen(
+                                    mangaId = it.id,
+                                    fromSource = true,
+                                    sourceId = it.source,
+                                    mangaUrl = it.url,
+                                ),
+                            )
+                        },
                         onMangaLongClick = {},
                         modifier = Modifier.offset { IntOffset(x = 0, y = pullOffsetPx.roundToInt()) },
                     )

--- a/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
@@ -10,6 +10,8 @@ object Constants {
 
     const val MANGA_EXTRA = "manga"
     const val FROM_SOURCE_EXTRA = "from_source"
+    const val MANGA_SOURCE_EXTRA = "manga_source"
+    const val MANGA_URL_EXTRA = "manga_url"
 
     const val MAIN_ACTIVITY = "eu.kanade.tachiyomi.ui.main.MainActivity"
 

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -31,10 +31,22 @@ class MangaRepositoryImpl(
             .awaitAsOne()
     }
 
+    override suspend fun getMangaByIdOrNull(id: Long): Manga? {
+        return database.mangasQueries
+            .getMangaById(id, MangaMapper::mapManga)
+            .awaitAsOneOrNull()
+    }
+
     override suspend fun getMangaByIdAsFlow(id: Long): Flow<Manga> {
         return database.mangasQueries
             .getMangaById(id, MangaMapper::mapManga)
             .subscribeToOne()
+    }
+
+    override suspend fun getMangaByIdAsFlowOrNull(id: Long): Flow<Manga?> {
+        return database.mangasQueries
+            .getMangaById(id, MangaMapper::mapManga)
+            .subscribeToOneOrNull()
     }
 
     override suspend fun getMangaByUrlAndSourceId(url: String, sourceId: Long): Manga? {

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetMangaWithChapters.kt
@@ -2,6 +2,7 @@ package tachiyomi.domain.manga.interactor
 
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.manga.model.Manga
@@ -14,15 +15,17 @@ class GetMangaWithChapters(
 
     suspend fun subscribe(id: Long, applyScanlatorFilter: Boolean = false): Flow<Pair<Manga, List<Chapter>>> {
         return combine(
-            mangaRepository.getMangaByIdAsFlow(id),
+            mangaRepository.getMangaByIdAsFlowOrNull(id),
             chapterRepository.getChapterByMangaIdAsFlow(id, applyScanlatorFilter),
-        ) { manga, chapters ->
-            Pair(manga, chapters)
-        }
+        ) { manga, chapters -> manga?.let { Pair(it, chapters) } }.filterNotNull()
     }
 
     suspend fun awaitManga(id: Long): Manga {
         return mangaRepository.getMangaById(id)
+    }
+
+    suspend fun awaitMangaOrNull(id: Long): Manga? {
+        return mangaRepository.getMangaByIdOrNull(id)
     }
 
     suspend fun awaitChapters(id: Long, applyScanlatorFilter: Boolean = false): List<Chapter> {

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -10,7 +10,11 @@ interface MangaRepository {
 
     suspend fun getMangaById(id: Long): Manga
 
+    suspend fun getMangaByIdOrNull(id: Long): Manga?
+
     suspend fun getMangaByIdAsFlow(id: Long): Flow<Manga>
+
+    suspend fun getMangaByIdAsFlowOrNull(id: Long): Flow<Manga?>
 
     suspend fun getMangaByUrlAndSourceId(url: String, sourceId: Long): Manga?
 


### PR DESCRIPTION
## 修改内容 / What changed

- 在书架、通知和阅读器返回详情页的路由中携带漫画的 source ID 与稳定 URL。
- 当旧数据库 ID 在服务器切换后失效时，按 source 与 URL 重新解析当前服务器中的对应记录。
- 详情页遇到已删除或无法恢复的记录时显示安全空状态，不再因缺失数据库行崩溃。
- 服务器切换时返回主导航根节点，避免继续复用上一服务器的详情页和分页状态。
- 为合并书架、漫画和书籍页面使用独立 ScreenModel 标识，防止跨服务器或分区复用旧状态。
- 增加 nullable Manga repository 查询并让订阅在记录短暂缺失时安全等待。

- Carry the manga source ID and stable URL through library, notification, and reader-to-details routes.
- Resolve stale database IDs against the active server by source and URL after a server switch.
- Show a safe empty state when a deleted route cannot be recovered instead of crashing on a missing row.
- Return to the home navigation root when the active server changes so stale detail and paging state is discarded.
- Give merged, comic, and book library screens distinct ScreenModel identities.
- Add nullable manga repository queries and make subscriptions tolerate transiently missing rows.

## 用户影响 / User impact

切换 Komga 服务器后，详情页、通知入口和阅读器返回路径不会再误用上一服务器的本地 ID；可匹配内容会自动恢复，已删除内容会安全退出。

After switching Komga servers, detail routes no longer reuse local IDs from the previous server. Matching content is recovered automatically and deleted content fails safely.

## 验证 / Checks

- `:app:compileDebugKotlin`
- `:domain:test`
- `spotlessCheck`
