### PR TITLE
调整阅读器默认排版与方向 / Refine reader defaults and orientation

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -285,7 +285,7 @@ object SettingsReaderScreen : SearchableSettings {
                     add(
                         epubLayoutSliderPreference(
                             value = lineHeight,
-                            valueRange = 100..200 step 10,
+                            valueRange = 100..200 step 5,
                             title = stringResource(MR.strings.pref_epub_line_height),
                             onValueChanged = epubLayoutPreferences.lineHeight::set,
                         ),
@@ -293,7 +293,7 @@ object SettingsReaderScreen : SearchableSettings {
                     add(
                         epubLayoutSliderPreference(
                             value = paragraphSpacing,
-                            valueRange = 0..200 step 10,
+                            valueRange = 0..200 step 5,
                             title = stringResource(MR.strings.pref_epub_paragraph_spacing),
                             onValueChanged = epubLayoutPreferences.paragraphSpacing::set,
                         ),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -523,7 +523,8 @@ object SettingsReaderScreen : SearchableSettings {
             preferenceItems = persistentListOf(
                 Preference.PreferenceItem.ListPreference(
                     preference = readerPreferences.defaultOrientationType,
-                    entries = ReaderOrientation.entries.drop(1)
+                    entries = ReaderOrientation.entries
+                        .filterNot { it == ReaderOrientation.FREE }
                         .associate { it.flagValue to stringResource(it.stringRes) }
                         .toImmutableMap(),
                     title = stringResource(MR.strings.pref_rotation_type),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -53,8 +53,12 @@ class ReaderPreferences(
 
     val defaultOrientationType: Preference<Int> = preferenceStore.getInt(
         "pref_default_orientation_type_key",
-        ReaderOrientation.FREE.flagValue,
-    )
+        ReaderOrientation.DEFAULT.flagValue,
+    ).also { preference ->
+        // FREE and DEFAULT both follow the system. Normalize the legacy FREE
+        // default so every settings surface can display the explicit default.
+        if (preference.get() == ReaderOrientation.FREE.flagValue) preference.delete()
+    }
 
     val webtoonDoubleTapZoomEnabled: Preference<Boolean> = preferenceStore.getBoolean(
         "pref_enable_double_tap_zoom_webtoon",

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/setting/ReaderPreferences.kt
@@ -3,6 +3,13 @@ package eu.kanade.tachiyomi.ui.reader.setting
 import android.os.Build
 import androidx.compose.ui.graphics.BlendMode
 import dev.icerock.moko.resources.StringResource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
@@ -51,14 +58,12 @@ class ReaderPreferences(
         ReadingMode.RIGHT_TO_LEFT.flagValue,
     )
 
-    val defaultOrientationType: Preference<Int> = preferenceStore.getInt(
-        "pref_default_orientation_type_key",
-        ReaderOrientation.DEFAULT.flagValue,
-    ).also { preference ->
-        // FREE and DEFAULT both follow the system. Normalize the legacy FREE
-        // default so every settings surface can display the explicit default.
-        if (preference.get() == ReaderOrientation.FREE.flagValue) preference.delete()
-    }
+    val defaultOrientationType: Preference<Int> = DefaultOrientationPreference(
+        preferenceStore.getInt(
+            "pref_default_orientation_type_key",
+            ReaderOrientation.DEFAULT.flagValue,
+        ),
+    )
 
     val webtoonDoubleTapZoomEnabled: Preference<Boolean> = preferenceStore.getBoolean(
         "pref_enable_double_tap_zoom_webtoon",
@@ -259,6 +264,44 @@ class ReaderPreferences(
                     ),
                 )
             }
+        }
+    }
+}
+
+/**
+ * FREE was previously stored as the global default even though DEFAULT has the same
+ * system-following behavior. Normalize reads for every dynamic Komga preference scope;
+ * per-title orientation preferences still retain FREE as a distinct selection.
+ */
+private class DefaultOrientationPreference(
+    private val delegate: Preference<Int>,
+) : Preference<Int> {
+
+    override fun key(): String = delegate.key()
+
+    override fun get(): Int = normalize(delegate.get())
+
+    override fun set(value: Int) = delegate.set(normalize(value))
+
+    override fun isSet(): Boolean = delegate.isSet()
+
+    override fun delete() = delegate.delete()
+
+    override fun defaultValue(): Int = normalize(delegate.defaultValue())
+
+    override fun changes(): Flow<Int> = delegate.changes()
+        .map(::normalize)
+        .distinctUntilChanged()
+
+    override fun stateIn(scope: CoroutineScope): StateFlow<Int> {
+        return changes().stateIn(scope, SharingStarted.Eagerly, get())
+    }
+
+    private fun normalize(value: Int): Int {
+        return if (value == ReaderOrientation.FREE.flagValue) {
+            ReaderOrientation.DEFAULT.flagValue
+        } else {
+            value
         }
     }
 }

--- a/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
@@ -31,10 +31,10 @@ class EpubLayoutPreferences(
         preferenceStore.getFloat("epub_layout_font_size", 1.0f)
 
     val lineHeight: Preference<Float> =
-        preferenceStore.getFloat("epub_layout_line_height", 1.2f)
+        preferenceStore.getFloat("epub_layout_line_height", 1.7f)
 
     val paragraphSpacing: Preference<Float> =
-        preferenceStore.getFloat("epub_layout_paragraph_spacing", 0.0f)
+        preferenceStore.getFloat("epub_layout_paragraph_spacing", 0.05f)
 
     val paragraphIndent: Preference<Float> =
         preferenceStore.getFloat("epub_layout_paragraph_indent", 2.0f)
@@ -46,13 +46,13 @@ class EpubLayoutPreferences(
         preferenceStore.getFloat("epub_layout_vertical_margins", 1.0f)
 
     val spacingMode: Preference<SpacingMode> =
-        preferenceStore.getEnum("epub_layout_spacing_mode", SpacingMode.CUSTOM)
+        preferenceStore.getEnum("epub_layout_spacing_mode", SpacingMode.STANDARD)
 
     val fontFamily: Preference<FontFamily> =
         preferenceStore.getEnum("epub_layout_font_family", FontFamily.ORIGINAL)
 
     val publisherStyles: Preference<Boolean> =
-        preferenceStore.getBoolean("epub_layout_publisher_styles", true)
+        preferenceStore.getBoolean("epub_layout_publisher_styles", false)
 
     val readWithVolumeKeys: Preference<Boolean> =
         preferenceStore.getBoolean("epub_layout_volume_keys", true)

--- a/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
@@ -1,6 +1,8 @@
 package koharia.epub.settings
 
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -18,5 +20,27 @@ class EpubReaderPreferenceDefaultsTest {
         assertTrue(epubPreference.get())
         assertFalse(comicPreference.get())
         assertNotEquals(epubPreference.key(), comicPreference.key())
+    }
+
+    @Test
+    fun `EPUB typography defaults to standard spacing without publisher styles`() {
+        val preferences = EpubLayoutPreferences(InMemoryPreferenceStore())
+
+        assertEquals(EpubLayoutPreferences.SpacingMode.STANDARD, preferences.spacingMode.get())
+        assertEquals(1.7f, preferences.lineHeight.get())
+        assertEquals(0.05f, preferences.paragraphSpacing.get())
+        assertFalse(preferences.publisherStyles.get())
+    }
+
+    @Test
+    fun `legacy free global orientation is exposed as default`() {
+        val store = InMemoryPreferenceStore()
+        store.getInt("pref_default_orientation_type_key").set(ReaderOrientation.FREE.flagValue)
+
+        val orientation = ReaderPreferences(store).defaultOrientationType
+
+        assertEquals(ReaderOrientation.DEFAULT.flagValue, orientation.get())
+        orientation.set(ReaderOrientation.FREE.flagValue)
+        assertEquals(ReaderOrientation.DEFAULT.flagValue, orientation.get())
     }
 }


### PR DESCRIPTION
## 修改内容 / What changed

- 将 EPUB 字体与间距默认模式设为“标准”，并采用对应的标准行高与段落间距。
- 默认关闭出版商样式，让新安装和未保存自定义设置的阅读会话使用统一排版。
- 将设备方向默认值从旧 `FREE` 规范化为显式 `DEFAULT`。
- 设置页面隐藏语义重复的 `FREE` 项，同时继续提供系统默认方向。

- Use the standard EPUB spacing preset with its matching line height and paragraph spacing defaults.
- Disable publisher styles by default so new and unsaved reading sessions use consistent typography.
- Normalize the legacy `FREE` orientation default to the explicit `DEFAULT` value.
- Hide the duplicate `FREE` option while keeping the system-default orientation available.

## 用户影响 / User impact

新阅读会话默认采用更适合正文阅读的标准间距和统一样式，屏幕方向设置也不再显示无法解释的空值或重复选项。

New reading sessions start with standard spacing and consistent typography, while orientation settings no longer expose an ambiguous duplicate value.

## 验证 / Checks

- `:app:compileDebugKotlin`
- `spotlessCheck`
