### PR TITLE
修复 EPUB release 交互与 RTL 横排 / Fix EPUB WebView and horizontal RTL layout

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -88,3 +88,8 @@
 # Firebase
 -keep class com.google.firebase.installations.** { *; }
 -keep interface com.google.firebase.installations.** { *; }
+
+# WebView invokes these methods by their JavaScript names, so R8 must not remove or rename them.
+-keepclassmembers class * {
+    @android.webkit.JavascriptInterface <methods>;
+}

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -93,7 +93,10 @@ internal class EpubPaginationScannerFragment : Fragment() {
         }
         childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
             initialLocator = firstLocator,
-            initialPreferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences),
+            initialPreferences = epubPreferencesBridge.toReadiumPreferences(
+                preferences = epubLayoutPreferences,
+                publicationMetadata = session.publication.metadata,
+            ),
             paginationListener = paginationListener,
             configuration = EpubNavigatorFragment.Configuration(
                 shouldApplyInsetsPadding = false,

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -1043,7 +1043,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             .distinctUntilChanged()
             .onEach {
                 epubReaderFragment()?.submitPreferences(
-                    epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences),
+                    epubPreferencesBridge.toReadiumPreferences(
+                        preferences = epubLayoutPreferences,
+                        publicationMetadata = currentPublicationMetadata(),
+                    ),
                 )
             }
             .launchIn(lifecycleScope)
@@ -1091,7 +1094,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private fun applyCurrentReadiumPreferences(fragment: EpubReaderFragment? = epubReaderFragment()) {
         val activeFragment = fragment?.takeIf { it.isAdded && it.view != null } ?: return
         val viewport = paginationViewport ?: return
-        val preferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences)
+        val preferences = epubPreferencesBridge.toReadiumPreferences(
+            preferences = epubLayoutPreferences,
+            publicationMetadata = currentPublicationMetadata(),
+        )
         activeFragment.submitPreferences(preferences)
         paginationJob?.cancel()
         paginationJob = lifecycleScope.launch {
@@ -1121,6 +1127,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 }
             }
         }
+    }
+
+    private fun currentPublicationMetadata(): org.readium.r2.shared.publication.Metadata? {
+        return sessionRepository.get(viewModel.state.value.chapterId)?.publication?.metadata
     }
 
     private fun reloadEpubSessionForPublisherStyles(enabled: Boolean) {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -113,7 +113,10 @@ class EpubReaderFragment : Fragment() {
         }
         childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
             initialLocator = session.initialLocator,
-            initialPreferences = epubPreferencesBridge.toReadiumPreferences(epubLayoutPreferences),
+            initialPreferences = epubPreferencesBridge.toReadiumPreferences(
+                preferences = epubLayoutPreferences,
+                publicationMetadata = session.publication.metadata,
+            ),
             listener = navigatorListener,
             paginationListener = paginationListener,
             configuration = EpubNavigatorFragment.Configuration(

--- a/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
@@ -4,17 +4,24 @@ import androidx.core.graphics.ColorUtils
 import org.readium.r2.navigator.epub.EpubPreferences
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.navigator.preferences.Color as ReadiumColor
 import org.readium.r2.navigator.preferences.FontFamily as ReadiumFontFamily
 import org.readium.r2.navigator.preferences.Theme as ReadiumTheme
+import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 
 @OptIn(ExperimentalReadiumApi::class)
 class EpubPreferencesBridge {
 
-    fun toReadiumPreferences(preferences: EpubLayoutPreferences): EpubPreferences {
+    fun toReadiumPreferences(
+        preferences: EpubLayoutPreferences,
+        publicationMetadata: Metadata? = null,
+    ): EpubPreferences {
         return toReadiumPreferences(
             readingMode = preferences.readingMode.get(),
             pageDirection = preferences.pageDirection.get(),
+            pageDirectionExplicit = preferences.pageDirection.isSet(),
+            publicationMetadata = publicationMetadata,
             theme = preferences.theme.get(),
             fontSize = preferences.fontSize.get(),
             lineHeight = preferences.lineHeight.get(),
@@ -39,8 +46,15 @@ class EpubPreferencesBridge {
         fontFamily: EpubLayoutPreferences.FontFamily,
         publisherStyles: Boolean,
         customBackgroundColor: Int = EpubLayoutPreferences.DEFAULT_CUSTOM_BACKGROUND_COLOR,
+        pageDirectionExplicit: Boolean = true,
+        publicationMetadata: Metadata? = null,
     ): EpubPreferences {
-        val flowPreferences = resolveReadiumFlowPreferences(readingMode, pageDirection)
+        val flowPreferences = resolveReadiumFlowPreferences(
+            readingMode = readingMode,
+            pageDirection = pageDirection,
+            pageDirectionExplicit = pageDirectionExplicit,
+            publicationMetadata = publicationMetadata,
+        )
         return EpubPreferences(
             scroll = flowPreferences.scroll,
             readingProgression = flowPreferences.readingProgression,
@@ -116,14 +130,30 @@ internal data class ReadiumFlowPreferences(
 internal fun resolveReadiumFlowPreferences(
     readingMode: EpubLayoutPreferences.ReadingMode,
     pageDirection: EpubLayoutPreferences.PageDirection,
+    pageDirectionExplicit: Boolean = true,
+    publicationMetadata: Metadata? = null,
 ): ReadiumFlowPreferences {
+    val nativeVerticalPublication = publicationMetadata?.isNativeVerticalPublication() == true
+    val effectivePageDirection = if (nativeVerticalPublication && !pageDirectionExplicit) {
+        EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT
+    } else {
+        pageDirection
+    }
     return ReadiumFlowPreferences(
         scroll = readingMode == EpubLayoutPreferences.ReadingMode.SCROLL,
-        readingProgression = pageDirection.toReadiumReadingProgression(),
-        // Page direction controls navigation only. Without an explicit value, Readium treats
-        // CJK + RTL as vertical writing and also forces the navigator into scroll mode.
-        verticalText = false,
+        readingProgression = effectivePageDirection.toReadiumReadingProgression(),
+        // Preserve a publication's native CJK vertical layout only when the user has not
+        // explicitly overridden its direction. Ordinary books using RTL for page navigation
+        // remain horizontal.
+        verticalText = nativeVerticalPublication &&
+            effectivePageDirection == EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT,
     )
+}
+
+private fun Metadata.isNativeVerticalPublication(): Boolean {
+    val language = languages.firstOrNull()?.lowercase() ?: return false
+    val isCjk = language == "ja" || language == "ko" || language.substringBefore('-') == "zh"
+    return isCjk && readingProgression == PublicationReadingProgression.RTL
 }
 
 internal fun EpubLayoutPreferences.PageDirection.toReadiumReadingProgression(): ReadingProgression {

--- a/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
@@ -40,9 +40,11 @@ class EpubPreferencesBridge {
         publisherStyles: Boolean,
         customBackgroundColor: Int = EpubLayoutPreferences.DEFAULT_CUSTOM_BACKGROUND_COLOR,
     ): EpubPreferences {
+        val flowPreferences = resolveReadiumFlowPreferences(readingMode, pageDirection)
         return EpubPreferences(
-            scroll = readingMode == EpubLayoutPreferences.ReadingMode.SCROLL,
-            readingProgression = pageDirection.toReadiumReadingProgression(),
+            scroll = flowPreferences.scroll,
+            readingProgression = flowPreferences.readingProgression,
+            verticalText = flowPreferences.verticalText,
             theme = theme.toReadiumTheme(customBackgroundColor),
             backgroundColor = ReadiumColor(theme.backgroundColor(customBackgroundColor)),
             textColor = ReadiumColor(theme.textColor(customBackgroundColor)),
@@ -103,6 +105,25 @@ class EpubPreferencesBridge {
             EpubLayoutPreferences.FontFamily.OPEN_DYSLEXIC -> ReadiumFontFamily.OPEN_DYSLEXIC
         }
     }
+}
+
+internal data class ReadiumFlowPreferences(
+    val scroll: Boolean,
+    val readingProgression: ReadingProgression,
+    val verticalText: Boolean,
+)
+
+internal fun resolveReadiumFlowPreferences(
+    readingMode: EpubLayoutPreferences.ReadingMode,
+    pageDirection: EpubLayoutPreferences.PageDirection,
+): ReadiumFlowPreferences {
+    return ReadiumFlowPreferences(
+        scroll = readingMode == EpubLayoutPreferences.ReadingMode.SCROLL,
+        readingProgression = pageDirection.toReadiumReadingProgression(),
+        // Page direction controls navigation only. Without an explicit value, Readium treats
+        // CJK + RTL as vertical writing and also forces the navigator into scroll mode.
+        verticalText = false,
+    )
 }
 
 internal fun EpubLayoutPreferences.PageDirection.toReadiumReadingProgression(): ReadingProgression {

--- a/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
@@ -19,4 +19,28 @@ class EpubPreferencesBridgeTest {
 
         assertEquals(ReadingProgression.RTL, progression)
     }
+
+    @Test
+    fun `right to left pagination keeps CJK text horizontal`() {
+        val preferences = resolveReadiumFlowPreferences(
+            readingMode = EpubLayoutPreferences.ReadingMode.PAGINATED,
+            pageDirection = EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT,
+        )
+
+        assertEquals(ReadingProgression.RTL, preferences.readingProgression)
+        assertEquals(false, preferences.scroll)
+        assertEquals(false, preferences.verticalText)
+    }
+
+    @Test
+    fun `continuous scroll keeps CJK text horizontal after right to left pagination`() {
+        val preferences = resolveReadiumFlowPreferences(
+            readingMode = EpubLayoutPreferences.ReadingMode.SCROLL,
+            pageDirection = EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT,
+        )
+
+        assertEquals(ReadingProgression.RTL, preferences.readingProgression)
+        assertEquals(true, preferences.scroll)
+        assertEquals(false, preferences.verticalText)
+    }
 }

--- a/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
@@ -3,6 +3,8 @@ package koharia.epub.settings
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.readium.r2.navigator.preferences.ReadingProgression
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 
 class EpubPreferencesBridgeTest {
 
@@ -41,6 +43,38 @@ class EpubPreferencesBridgeTest {
 
         assertEquals(ReadingProgression.RTL, preferences.readingProgression)
         assertEquals(true, preferences.scroll)
+        assertEquals(false, preferences.verticalText)
+    }
+
+    @Test
+    fun `native CJK vertical publication keeps its original direction when not overridden`() {
+        val preferences = resolveReadiumFlowPreferences(
+            readingMode = EpubLayoutPreferences.ReadingMode.PAGINATED,
+            pageDirection = EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT,
+            pageDirectionExplicit = false,
+            publicationMetadata = Metadata(
+                languages = listOf("ja"),
+                readingProgression = PublicationReadingProgression.RTL,
+            ),
+        )
+
+        assertEquals(ReadingProgression.RTL, preferences.readingProgression)
+        assertEquals(true, preferences.verticalText)
+    }
+
+    @Test
+    fun `explicit LTR overrides native CJK vertical publication`() {
+        val preferences = resolveReadiumFlowPreferences(
+            readingMode = EpubLayoutPreferences.ReadingMode.PAGINATED,
+            pageDirection = EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT,
+            pageDirectionExplicit = true,
+            publicationMetadata = Metadata(
+                languages = listOf("ja"),
+                readingProgression = PublicationReadingProgression.RTL,
+            ),
+        )
+
+        assertEquals(ReadingProgression.LTR, preferences.readingProgression)
         assertEquals(false, preferences.verticalText)
     }
 }


### PR DESCRIPTION
## 修改内容 / What changed

- 保留所有标记为 `@JavascriptInterface` 的 WebView 方法，防止 release R8 删除或重命名 Readium 的点击、拖动和错误回调。
- 将页面前进方向与文字书写方向解耦：从右到左翻页仍使用 RTL progression，但明确保持横排文字。
- 连续滚动即使继承上一次 RTL 页面方向，也不会被 Readium 自动推断为 CJK 竖排或强制改变布局模式。
- 增加覆盖 LTR、RTL 单页及 RTL 后连续滚动的纯偏好映射测试。

- Preserve every `@JavascriptInterface` WebView method so release R8 cannot remove or rename Readium tap, drag, and error callbacks.
- Separate page progression from writing direction: right-to-left navigation keeps RTL progression while text remains horizontal.
- Keep continuous scrolling horizontal even when the previous paginated direction was RTL, avoiding Readium's automatic CJK vertical-text inference.
- Add pure preference-mapping tests for LTR, RTL pagination, and continuous scrolling after RTL.

## 用户影响 / User impact

release 版本中点击正文可以正常关闭阅读设置，Readium 拖动交互也能正常回调；单页从右到左和连续滚动不再把中文或日文正文变成竖排。

Release builds regain reliable Readium WebView interactions, while RTL pagination and continuous scrolling no longer turn CJK text vertical.

## 验证 / Checks

- `:app:compileDebugKotlin`
- `:app:testDebugUnitTest --tests koharia.epub.settings.EpubPreferencesBridgeTest`
- `:app:minifyReleaseWithR8`
- R8 mapping confirms `onTap`, `onDragEnd`, and `logError` retain their JavaScript names
- `spotlessCheck`
