### PR TITLE
发布 0.2.2：服务器与下载管理优化 / Release 0.2.2 server and download improvements

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,8 +57,8 @@ android {
     defaultConfig {
         applicationId = "app.koharia"
 
-        versionCode = 3
-        versionName = "0.2.1"
+        versionCode = 4
+        versionName = "0.2.2"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -42,6 +42,7 @@ import eu.kanade.tachiyomi.di.PreferenceModule
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.ui.base.delegate.SecureActivityDelegate
+import eu.kanade.tachiyomi.util.system.AppShortcutManager
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.GLUtil
 import eu.kanade.tachiyomi.util.system.WebViewUtil
@@ -50,6 +51,7 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notify
 import koharia.core.migration.Migrator
 import koharia.core.migration.migrations.migrations
+import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaServerPreferences
 import koharia.telemetry.TelemetryConfig
@@ -161,6 +163,11 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         val uiPreferences = Injekt.get<UiPreferences>()
         val komgaServerPreferences = Injekt.get<KomgaServerPreferences>()
         val localConfigManager = Injekt.get<KomgaLocalConfigManager>()
+        val libraryClassificationManager = Injekt.get<KomgaLibraryClassificationManager>()
+
+        libraryClassificationManager.enabled.changes()
+            .onEach { enabled -> AppShortcutManager.updateLibraryShortcuts(this, enabled) }
+            .launchIn(scope)
 
         uiPreferences.themeMode.changes()
             .onEach { themeMode ->

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -401,14 +401,15 @@ class DownloadCache(
         notifyChanges()
     }
 
-    suspend fun refreshSourceDirectory(sourceId: Long, directory: UniFile) {
-        val refreshedDirectory = scanSourceDirectory(SourceDirectory(directory))
+    suspend fun refreshSourceDirectories(sourceId: Long, directories: List<UniFile>) {
+        val refreshedDirectory = scanSourceDirectories(directories)
         rootDownloadsDirMutex.withLock {
             rootDownloadsDir.sourceDirs += sourceId to refreshedDirectory
         }
 
         logcat(LogPriority.DEBUG) {
-            "DownloadCache: refreshed source directory sourceId=$sourceId directory=${directory.name}"
+            "DownloadCache: refreshed source directories sourceId=$sourceId " +
+                "directories=${directories.joinToString { it.name.orEmpty() }}"
         }
         notifyChanges()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -430,8 +430,9 @@ class DownloadCache(
         val generation = renewalGeneration.incrementAndGet()
         val renewalActive = synchronized(renewalStateLock) {
             lastRenew = 0L
+            val active = renewalJob?.isActive == true
             renewalJob?.cancel()
-            renewalJob?.isActive == true
+            active
         }
         logcat(LogPriority.DEBUG) {
             "DownloadCache: invalidate requested reason=$reason " +

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -7,6 +7,8 @@ import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.source.Source
 import koharia.source.komga.DownloadDirectoryMode
 import koharia.source.komga.KomgaServerPreferences
+import koharia.source.komga.KomgaServerProfile
+import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -55,6 +57,7 @@ import tachiyomi.domain.storage.service.StorageManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 
@@ -90,6 +93,10 @@ class DownloadCache(
      */
     private var lastRenew = 0L
     private var renewalJob: Job? = null
+    private val renewalGeneration = AtomicLong(0L)
+
+    @Volatile
+    private var suppressedProfileIds: Set<Long>? = null
 
     private val _isInitializing = MutableStateFlow(false)
     val isInitializing = _isInitializing
@@ -119,20 +126,45 @@ class DownloadCache(
                     diskCacheFile.delete()
                 }
             }
+
+            if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.PerServer) {
+                val migrated = komgaServerPreferences.getProfiles()
+                    .map { profile ->
+                        provider.migrateLegacyKomgaServerDir(
+                            KomgaSource(profile.id, profile.name),
+                        )
+                    }
+                    .any { it }
+                if (migrated) {
+                    invalidateCache("legacy_komga_server_directories_migrated")
+                }
+            }
         }
 
         storageManager.changes
-            .onEach { invalidateCache() }
+            .onEach { invalidateCache("storage_changed") }
             .launchIn(scope)
 
         komgaServerPreferences.downloadDirectoryMode.changes()
             .drop(1)
-            .onEach { invalidateCache() }
+            .onEach { mode -> invalidateCache("download_directory_mode_changed:$mode") }
             .launchIn(scope)
 
         komgaServerPreferences.profilesChanges()
             .drop(1)
-            .onEach { invalidateCache() }
+            .onEach { profiles ->
+                val profileIds = profiles.mapTo(mutableSetOf(), KomgaServerProfile::id)
+                if (suppressedProfileIds == profileIds) {
+                    suppressedProfileIds = null
+                    logcat(LogPriority.DEBUG) {
+                        "DownloadCache: profile refresh suppressed ids=${profileIds.joinToString(",")}"
+                    }
+                    return@onEach
+                }
+                invalidateCache(
+                    "server_profiles_changed:ids=${profileIds.joinToString(",")}",
+                )
+            }
             .launchIn(scope)
     }
 
@@ -345,6 +377,9 @@ class DownloadCache(
     }
 
     suspend fun removeSource(source: Source) {
+        logcat(LogPriority.DEBUG) {
+            "DownloadCache: removing source from in-memory index sourceId=${source.id} name=${source.name}"
+        }
         rootDownloadsDirMutex.withLock {
             rootDownloadsDir.sourceDirs -= source.id
         }
@@ -352,16 +387,47 @@ class DownloadCache(
         notifyChanges()
     }
 
-    fun invalidateCache() {
+    suspend fun refreshSourceDirectory(sourceId: Long, directory: UniFile) {
+        val refreshedDirectory = scanSourceDirectory(SourceDirectory(directory))
+        rootDownloadsDirMutex.withLock {
+            rootDownloadsDir.sourceDirs += sourceId to refreshedDirectory
+        }
+
+        logcat(LogPriority.DEBUG) {
+            "DownloadCache: refreshed source directory sourceId=$sourceId directory=${directory.name}"
+        }
+        notifyChanges()
+    }
+
+    /**
+     * Prevents the profile listener from scheduling a second full scan after a removal flow
+     * that has already updated the download cache explicitly.
+     */
+    fun suppressNextProfileRefresh(expectedProfileIds: Set<Long>) {
+        suppressedProfileIds = expectedProfileIds
+        logcat(LogPriority.DEBUG) {
+            "DownloadCache: suppressing next profile refresh ids=${expectedProfileIds.joinToString(",")}"
+        }
+    }
+
+    fun invalidateCache(reason: String = "unspecified") {
+        val generation = renewalGeneration.incrementAndGet()
+        logcat(LogPriority.DEBUG) {
+            "DownloadCache: invalidate requested reason=$reason " +
+                "generation=$generation lastRenew=$lastRenew " +
+                "renewalActive=${renewalJob?.isActive == true}"
+        }
         lastRenew = 0L
         renewalJob?.cancel()
         diskCacheFile.delete()
-        renewCache()
+        if (renewalJob?.isActive != true) {
+            renewCache("invalidate:$reason", generation)
+        }
     }
 
     fun clearDiskCache(): Int {
         val deleted = LocalTempCacheDirectoryProvider.countDownloadIndexFiles(context)
-        invalidateCache()
+        invalidateCache("clear_disk_cache")
         LocalTempCacheDirectoryProvider.clearLegacyDownloadIndexCache(context)
         return deleted
     }
@@ -369,13 +435,20 @@ class DownloadCache(
     /**
      * Renews the downloads cache.
      */
-    private fun renewCache() {
+    private fun renewCache(
+        trigger: String = "periodic_or_lookup",
+        generation: Long = renewalGeneration.get(),
+    ) {
         // Avoid renewing cache if in the process nor too often
         if (lastRenew + renewInterval >= System.currentTimeMillis() || renewalJob?.isActive == true) {
             return
         }
 
         renewalJob = scope.launchIO {
+            val startedAt = System.currentTimeMillis()
+            logcat(LogPriority.DEBUG) {
+                "DownloadCache: full scan started trigger=$trigger"
+            }
             if (lastRenew == 0L) {
                 _isInitializing.emit(true)
             }
@@ -386,6 +459,10 @@ class DownloadCache(
                 sourceManager.isInitialized.first { it }
 
                 sources = getSources()
+            }
+            logcat(LogPriority.DEBUG) {
+                "DownloadCache: full scan enumerating sources=${sources.size} " +
+                    "sourceIds=${sources.joinToString(",") { it.id.toString() }} trigger=$trigger"
             }
 
             rootDownloadsDirMutex.withLock {
@@ -402,30 +479,7 @@ class DownloadCache(
                 sourceDirsByUri.values
                     .map { sourceDir ->
                         async {
-                            sourceDir.mangaDirs = sourceDir.dir?.listFiles().orEmpty()
-                                .filter { it.isDirectory && !it.name.isNullOrBlank() }
-                                .associate { it.name!! to MangaDirectory(it) }
-
-                            sourceDir.mangaDirs.values.forEach { mangaDir ->
-                                val chapterDirs = mangaDir.dir?.listFiles().orEmpty()
-                                    .mapNotNull {
-                                        when {
-                                            // Ignore incomplete downloads
-                                            it.name?.endsWith(Downloader.TMP_DIR_SUFFIX) == true -> null
-                                            // Folder of images
-                                            it.isDirectory -> it.name
-                                            // Supported downloaded files
-                                            it.isFile && DownloadProvider.isSupportedChapterFileExtension(
-                                                it.extension,
-                                            ) -> it.nameWithoutExtension
-                                            // Anything else is irrelevant
-                                            else -> null
-                                        }
-                                    }
-                                    .toMutableSet()
-
-                                mangaDir.chapterDirs = chapterDirs
-                            }
+                            scanSourceDirectory(sourceDir)
                         }
                     }
                     .awaitAll()
@@ -434,12 +488,41 @@ class DownloadCache(
             }
 
             _isInitializing.emit(false)
+            logcat(LogPriority.DEBUG) {
+                "DownloadCache: full scan body completed trigger=$trigger " +
+                    "elapsedMs=${System.currentTimeMillis() - startedAt}"
+            }
         }.also {
-            it.invokeOnCompletion(onCancelling = true) { exception ->
+            // Run after cancellation has fully completed so a newer invalidation can safely
+            // start the replacement scan without being blocked by the old active Job.
+            it.invokeOnCompletion { exception ->
+                val isLatestGeneration = generation == renewalGeneration.get()
                 if (exception != null && exception !is CancellationException) {
                     logcat(LogPriority.ERROR, exception) { "DownloadCache: failed to create cache" }
+                } else if (exception is CancellationException) {
+                    logcat(LogPriority.DEBUG) {
+                        "DownloadCache: full scan cancelled trigger=$trigger " +
+                            "generation=$generation latestGeneration=${renewalGeneration.get()}"
+                    }
                 }
+
+                if (!isLatestGeneration) {
+                    // An invalidation arrived while this scan was running. The cancellation
+                    // callback is the first reliable point at which the old Job is no longer
+                    // active, so restart the latest requested generation here.
+                    logcat(LogPriority.DEBUG) {
+                        "DownloadCache: restarting superseded full scan " +
+                            "generation=${renewalGeneration.get()}"
+                    }
+                    renewCache(
+                        trigger = "superseded:$trigger",
+                        generation = renewalGeneration.get(),
+                    )
+                    return@invokeOnCompletion
+                }
+
                 lastRenew = System.currentTimeMillis()
+                _isInitializing.value = false
                 notifyChanges()
             }
         }
@@ -450,6 +533,33 @@ class DownloadCache(
 
     private fun getSources(): List<Source> {
         return sourceManager.getOnlineSources() + sourceManager.getStubSources()
+    }
+
+    private fun scanSourceDirectory(sourceDir: SourceDirectory): SourceDirectory {
+        sourceDir.mangaDirs = sourceDir.dir?.listFiles().orEmpty()
+            .filter { it.isDirectory && !it.name.isNullOrBlank() }
+            .associate { it.name!! to MangaDirectory(it) }
+
+        sourceDir.mangaDirs.values.forEach { mangaDir ->
+            val chapterDirs = mangaDir.dir?.listFiles().orEmpty()
+                .mapNotNull {
+                    when {
+                        // Ignore incomplete downloads
+                        it.name?.endsWith(Downloader.TMP_DIR_SUFFIX) == true -> null
+                        // Folder of images
+                        it.isDirectory -> it.name
+                        // Supported downloaded files
+                        it.isFile && DownloadProvider.isSupportedChapterFileExtension(it.extension) ->
+                            it.nameWithoutExtension
+                        // Anything else is irrelevant
+                        else -> null
+                    }
+                }
+                .toMutableSet()
+
+            mangaDir.chapterDirs = chapterDirs
+        }
+        return sourceDir
     }
 
     private fun notifyChanges() {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -11,7 +11,6 @@ import koharia.source.komga.KomgaServerProfile
 import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -466,7 +465,7 @@ class DownloadCache(
                 return
             }
 
-            scope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+            scope.launch(Dispatchers.IO) {
                 val startedAt = System.currentTimeMillis()
                 logcat(LogPriority.DEBUG) {
                     "DownloadCache: full scan started trigger=$trigger"
@@ -554,8 +553,6 @@ class DownloadCache(
             _isInitializing.value = false
             notifyChanges()
         }
-        job.start()
-
         // Mainly to notify the indexing notifier UI
         notifyChanges()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -11,6 +11,7 @@ import koharia.source.komga.KomgaServerProfile
 import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -91,9 +92,16 @@ class DownloadCache(
     /**
      * The last time the cache was refreshed.
      */
+    private val renewalStateLock = Any()
+
+    @Volatile
     private var lastRenew = 0L
+
+    @Volatile
     private var renewalJob: Job? = null
     private val renewalGeneration = AtomicLong(0L)
+
+    private val profileRefreshLock = Any()
 
     @Volatile
     private var suppressedProfileIds: Set<Long>? = null
@@ -127,17 +135,19 @@ class DownloadCache(
                 }
             }
 
-            if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.PerServer) {
-                val migrated = komgaServerPreferences.getProfiles()
-                    .map { profile ->
-                        provider.migrateLegacyKomgaServerDir(
-                            KomgaSource(profile.id, profile.name),
-                        )
+            if (komgaServerPreferences.needsDownloadDirectoryLayoutMigration()) {
+                provider.migrateLegacyKomgaDirectories()
+                    .onSuccess { migrated ->
+                        komgaServerPreferences.markDownloadDirectoryLayoutMigrated()
+                        if (migrated) {
+                            invalidateCache("legacy_komga_directories_migrated")
+                        }
                     }
-                    .any { it }
-                if (migrated) {
-                    invalidateCache("legacy_komga_server_directories_migrated")
-                }
+                    .onFailure { error ->
+                        logcat(LogPriority.WARN, error) {
+                            "Failed to migrate legacy Komga download directories; will retry"
+                        }
+                    }
             }
         }
 
@@ -154,8 +164,12 @@ class DownloadCache(
             .drop(1)
             .onEach { profiles ->
                 val profileIds = profiles.mapTo(mutableSetOf(), KomgaServerProfile::id)
-                if (suppressedProfileIds == profileIds) {
+                val suppressRefresh = synchronized(profileRefreshLock) {
+                    val expectedProfileIds = suppressedProfileIds
                     suppressedProfileIds = null
+                    expectedProfileIds == profileIds
+                }
+                if (suppressRefresh) {
                     logcat(LogPriority.DEBUG) {
                         "DownloadCache: profile refresh suppressed ids=${profileIds.joinToString(",")}"
                     }
@@ -404,7 +418,9 @@ class DownloadCache(
      * that has already updated the download cache explicitly.
      */
     fun suppressNextProfileRefresh(expectedProfileIds: Set<Long>) {
-        suppressedProfileIds = expectedProfileIds
+        synchronized(profileRefreshLock) {
+            suppressedProfileIds = expectedProfileIds
+        }
         logcat(LogPriority.DEBUG) {
             "DownloadCache: suppressing next profile refresh ids=${expectedProfileIds.joinToString(",")}"
         }
@@ -412,15 +428,18 @@ class DownloadCache(
 
     fun invalidateCache(reason: String = "unspecified") {
         val generation = renewalGeneration.incrementAndGet()
+        val renewalActive = synchronized(renewalStateLock) {
+            lastRenew = 0L
+            renewalJob?.cancel()
+            renewalJob?.isActive == true
+        }
         logcat(LogPriority.DEBUG) {
             "DownloadCache: invalidate requested reason=$reason " +
                 "generation=$generation lastRenew=$lastRenew " +
-                "renewalActive=${renewalJob?.isActive == true}"
+                "renewalActive=$renewalActive"
         }
-        lastRenew = 0L
-        renewalJob?.cancel()
         diskCacheFile.delete()
-        if (renewalJob?.isActive != true) {
+        if (!renewalActive) {
             renewCache("invalidate:$reason", generation)
         }
     }
@@ -439,93 +458,101 @@ class DownloadCache(
         trigger: String = "periodic_or_lookup",
         generation: Long = renewalGeneration.get(),
     ) {
-        // Avoid renewing cache if in the process nor too often
-        if (lastRenew + renewInterval >= System.currentTimeMillis() || renewalJob?.isActive == true) {
-            return
+        val job = synchronized(renewalStateLock) {
+            // Avoid renewing cache if in the process nor too often.
+            if (lastRenew + renewInterval >= System.currentTimeMillis() || renewalJob?.isActive == true) {
+                return
+            }
+
+            scope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
+                val startedAt = System.currentTimeMillis()
+                logcat(LogPriority.DEBUG) {
+                    "DownloadCache: full scan started trigger=$trigger"
+                }
+                if (lastRenew == 0L) {
+                    _isInitializing.emit(true)
+                }
+
+                // Try to wait until extensions and sources have loaded
+                var sources = emptyList<Source>()
+                withTimeoutOrNull(30.seconds) {
+                    sourceManager.isInitialized.first { it }
+
+                    sources = getSources()
+                }
+                logcat(LogPriority.DEBUG) {
+                    "DownloadCache: full scan enumerating sources=${sources.size} " +
+                        "sourceIds=${sources.joinToString(",") { it.id.toString() }} trigger=$trigger"
+                }
+
+                rootDownloadsDirMutex.withLock {
+                    val updatedRootDir = RootDirectory(storageManager.getDownloadsDirectory())
+
+                    val directoriesByKey = linkedMapOf<String, List<UniFile>>()
+                    val sourceDirectoryKeys = sources.mapNotNull { source ->
+                        val directories = provider.findSourceDirs(source)
+                        if (directories.isEmpty()) return@mapNotNull null
+                        val key = directories.joinToString(separator = "|") { it.uri.toString() }
+                        directoriesByKey.putIfAbsent(key, directories)
+                        source.id to key
+                    }
+                    val scansByKey = directoriesByKey.mapValues { (_, directories) ->
+                        async { scanSourceDirectories(directories) }
+                    }
+                    val scannedDirectories = scansByKey.mapValues { (_, scan) -> scan.await() }
+                    updatedRootDir.sourceDirs = sourceDirectoryKeys.associate { (sourceId, key) ->
+                        sourceId to scannedDirectories.getValue(key)
+                    }
+
+                    rootDownloadsDir = updatedRootDir
+                }
+
+                _isInitializing.emit(false)
+                logcat(LogPriority.DEBUG) {
+                    "DownloadCache: full scan body completed trigger=$trigger " +
+                        "elapsedMs=${System.currentTimeMillis() - startedAt}"
+                }
+            }.also { renewalJob = it }
         }
 
-        renewalJob = scope.launchIO {
-            val startedAt = System.currentTimeMillis()
-            logcat(LogPriority.DEBUG) {
-                "DownloadCache: full scan started trigger=$trigger"
+        // Run after cancellation has fully completed so a newer invalidation can safely
+        // start the replacement scan without being blocked by the old active Job.
+        job.invokeOnCompletion { exception ->
+            synchronized(renewalStateLock) {
+                if (renewalJob === job) renewalJob = null
             }
-            if (lastRenew == 0L) {
-                _isInitializing.emit(true)
-            }
-
-            // Try to wait until extensions and sources have loaded
-            var sources = emptyList<Source>()
-            withTimeoutOrNull(30.seconds) {
-                sourceManager.isInitialized.first { it }
-
-                sources = getSources()
-            }
-            logcat(LogPriority.DEBUG) {
-                "DownloadCache: full scan enumerating sources=${sources.size} " +
-                    "sourceIds=${sources.joinToString(",") { it.id.toString() }} trigger=$trigger"
-            }
-
-            rootDownloadsDirMutex.withLock {
-                val updatedRootDir = RootDirectory(storageManager.getDownloadsDirectory())
-
-                val sourceDirsByUri = mutableMapOf<String, SourceDirectory>()
-                updatedRootDir.sourceDirs = sources.mapNotNull { source ->
-                    val dir = provider.findSourceDir(source) ?: return@mapNotNull null
-                    val uriStr = dir.uri.toString()
-                    val sourceDir = sourceDirsByUri.getOrPut(uriStr) { SourceDirectory(dir) }
-                    source.id to sourceDir
-                }.toMap()
-
-                sourceDirsByUri.values
-                    .map { sourceDir ->
-                        async {
-                            scanSourceDirectory(sourceDir)
-                        }
-                    }
-                    .awaitAll()
-
-                rootDownloadsDir = updatedRootDir
-            }
-
-            _isInitializing.emit(false)
-            logcat(LogPriority.DEBUG) {
-                "DownloadCache: full scan body completed trigger=$trigger " +
-                    "elapsedMs=${System.currentTimeMillis() - startedAt}"
-            }
-        }.also {
-            // Run after cancellation has fully completed so a newer invalidation can safely
-            // start the replacement scan without being blocked by the old active Job.
-            it.invokeOnCompletion { exception ->
-                val isLatestGeneration = generation == renewalGeneration.get()
-                if (exception != null && exception !is CancellationException) {
-                    logcat(LogPriority.ERROR, exception) { "DownloadCache: failed to create cache" }
-                } else if (exception is CancellationException) {
-                    logcat(LogPriority.DEBUG) {
-                        "DownloadCache: full scan cancelled trigger=$trigger " +
-                            "generation=$generation latestGeneration=${renewalGeneration.get()}"
-                    }
+            val isLatestGeneration = generation == renewalGeneration.get()
+            if (exception != null && exception !is CancellationException) {
+                logcat(LogPriority.ERROR, exception) { "DownloadCache: failed to create cache" }
+            } else if (exception is CancellationException) {
+                logcat(LogPriority.DEBUG) {
+                    "DownloadCache: full scan cancelled trigger=$trigger " +
+                        "generation=$generation latestGeneration=${renewalGeneration.get()}"
                 }
+            }
 
-                if (!isLatestGeneration) {
-                    // An invalidation arrived while this scan was running. The cancellation
-                    // callback is the first reliable point at which the old Job is no longer
-                    // active, so restart the latest requested generation here.
-                    logcat(LogPriority.DEBUG) {
-                        "DownloadCache: restarting superseded full scan " +
-                            "generation=${renewalGeneration.get()}"
-                    }
-                    renewCache(
-                        trigger = "superseded:$trigger",
-                        generation = renewalGeneration.get(),
-                    )
-                    return@invokeOnCompletion
+            if (!isLatestGeneration) {
+                // An invalidation arrived while this scan was running. The cancellation
+                // callback is the first reliable point at which the old Job is no longer
+                // active, so restart the latest requested generation here.
+                logcat(LogPriority.DEBUG) {
+                    "DownloadCache: restarting superseded full scan " +
+                        "generation=${renewalGeneration.get()}"
                 }
+                renewCache(
+                    trigger = "superseded:$trigger",
+                    generation = renewalGeneration.get(),
+                )
+                return@invokeOnCompletion
+            }
 
+            synchronized(renewalStateLock) {
                 lastRenew = System.currentTimeMillis()
-                _isInitializing.value = false
-                notifyChanges()
             }
+            _isInitializing.value = false
+            notifyChanges()
         }
+        job.start()
 
         // Mainly to notify the indexing notifier UI
         notifyChanges()
@@ -560,6 +587,25 @@ class DownloadCache(
             mangaDir.chapterDirs = chapterDirs
         }
         return sourceDir
+    }
+
+    private fun scanSourceDirectories(directories: List<UniFile>): SourceDirectory {
+        val mergedMangaDirs = linkedMapOf<String, MangaDirectory>()
+        directories.forEach { directory ->
+            val scannedDirectory = scanSourceDirectory(SourceDirectory(directory))
+            scannedDirectory.mangaDirs.forEach { (name, mangaDir) ->
+                val existing = mergedMangaDirs[name]
+                if (existing == null) {
+                    mergedMangaDirs[name] = mangaDir
+                } else {
+                    existing.chapterDirs += mangaDir.chapterDirs
+                }
+            }
+        }
+        return SourceDirectory(
+            dir = directories.firstOrNull(),
+            mangaDirs = mergedMangaDirs,
+        )
     }
 
     private fun notifyChanges() {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -313,17 +313,28 @@ class DownloadManager(
 
             removeFromDownloadQueue(filteredChapters)
 
-            val (mangaDir, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
+            val (mangaDirs, chapterDirs) = provider.findChapterDirs(filteredChapters, manga, source)
             chapterDirs.distinctBy { it.uri.toString() }.forEach {
                 komgaSharedDownloadIndexManager.deleteIndexedPath(it)
                 it.delete()
             }
-            cache.removeChapters(filteredChapters, manga)
+            val remainingMangaDirs = mangaDirs.filterNot { mangaDir ->
+                if (mangaDir.listFiles()?.isEmpty() != true) return@filterNot false
 
-            // Delete manga directory if empty
-            if (mangaDir?.listFiles()?.isEmpty() == true) {
-                deleteManga(manga, source, removeQueued = false)
+                val relativePath = komgaSharedDownloadIndexManager.relativePathOf(mangaDir)
+                val deleted = mangaDir.delete()
+                if (deleted) {
+                    relativePath?.let { komgaSharedDownloadIndexManager.deleteIndexedPathPrefix(it) }
+                }
+                deleted
             }
+            if (mangaDirs.isNotEmpty() && remainingMangaDirs.isEmpty()) {
+                cache.removeManga(manga)
+            } else {
+                cache.removeChapters(filteredChapters, manga)
+            }
+
+            removeEmptyOwnedSourceDirs(source)
         }
     }
 
@@ -349,20 +360,29 @@ class DownloadManager(
             ) {
                 komgaSharedDownloadIndexManager.deleteMangaIndexedDownloads(manga.id, source.id)
             }
-            provider.findMangaDir(manga.title, source)?.let { mangaDir ->
+            provider.findMangaDirs(manga.title, source).forEach { mangaDir ->
                 komgaSharedDownloadIndexManager.relativePathOf(mangaDir)?.let {
                     komgaSharedDownloadIndexManager.deleteIndexedPathPrefix(it)
                 }
                 mangaDir.delete()
             }
             cache.removeManga(manga)
+            removeEmptyOwnedSourceDirs(source)
+        }
+    }
 
-            // Delete source directory if empty
-            val sourceDir = provider.findSourceDir(source)
-            if (sourceDir?.listFiles()?.isEmpty() == true) {
-                sourceDir.delete()
-                cache.removeSource(source)
-            }
+    private suspend fun removeEmptyOwnedSourceDirs(source: Source) {
+        val ownedSourceDirs = provider.findOwnedSourceDirs(source)
+        ownedSourceDirs
+            .filter { it.listFiles()?.isEmpty() == true }
+            .forEach { it.delete() }
+
+        provider.invalidateSourceDirCache()
+        val remainingSourceDirs = provider.findSourceDirs(source)
+        if (remainingSourceDirs.isEmpty()) {
+            cache.removeSource(source)
+        } else {
+            cache.refreshSourceDirectories(source.id, remainingSourceDirs)
         }
     }
 
@@ -446,35 +466,50 @@ class DownloadManager(
      */
     suspend fun renameManga(manga: Manga, newTitle: String) {
         val source = sourceManager.getOrStub(manga.source)
-        val oldFolder = provider.findMangaDir(manga.title, source) ?: return
+        val oldFolders = provider.findMangaDirs(manga.title, source)
+        if (oldFolders.isEmpty()) return
         val newName = provider.getMangaDirName(newTitle)
 
-        if (oldFolder.name == newName) return
+        if (oldFolders.all { it.name == newName }) return
 
         // just to be safe, don't allow downloads for this manga while renaming it
         downloader.removeFromQueue(manga)
 
-        val capitalizationChanged = oldFolder.name.equals(newName, ignoreCase = true)
-        val oldRelativePathPrefix = komgaSharedDownloadIndexManager.relativePathOf(oldFolder)
-        if (capitalizationChanged) {
-            val tempName = newName + Downloader.TMP_DIR_SUFFIX
-            if (!oldFolder.renameTo(tempName)) {
-                logcat(LogPriority.ERROR) { "Failed to rename manga download folder: ${oldFolder.name}" }
-                return
+        oldFolders.forEach { oldFolder ->
+            val oldName = oldFolder.name ?: return@forEach
+            if (oldName == newName) return@forEach
+
+            val parent = oldFolder.parentFile
+            val oldRelativePathPrefix = komgaSharedDownloadIndexManager.relativePathOf(oldFolder)
+            var currentFolder = oldFolder
+            val capitalizationChanged = oldName.equals(newName, ignoreCase = true)
+            if (capitalizationChanged) {
+                val tempName = newName + Downloader.TMP_DIR_SUFFIX
+                if (!currentFolder.renameTo(tempName)) {
+                    logcat(LogPriority.ERROR) { "Failed to prepare manga download folder rename: $oldName" }
+                    return@forEach
+                }
+                currentFolder = parent?.findFile(tempName) ?: run {
+                    logcat(LogPriority.ERROR) { "Failed to resolve temporary manga download folder: $tempName" }
+                    return@forEach
+                }
+            }
+
+            if (currentFolder.renameTo(newName)) {
+                val renamedFolder = parent?.findFile(newName) ?: currentFolder
+                oldRelativePathPrefix?.let { oldPrefix ->
+                    komgaSharedDownloadIndexManager.relativePathOf(renamedFolder)?.let { newPrefix ->
+                        komgaSharedDownloadIndexManager.updateIndexedPathPrefix(oldPrefix, newPrefix)
+                    }
+                }
+            } else {
+                logcat(LogPriority.ERROR) { "Failed to rename manga download folder: $oldName" }
             }
         }
 
-        if (oldFolder.renameTo(newName)) {
-            val renamedFolder = provider.findMangaDir(newTitle, source) ?: oldFolder
-            oldRelativePathPrefix?.let { oldPrefix ->
-                komgaSharedDownloadIndexManager.relativePathOf(renamedFolder)?.let { newPrefix ->
-                    komgaSharedDownloadIndexManager.updateIndexedPathPrefix(oldPrefix, newPrefix)
-                }
-            }
-            cache.renameManga(manga, renamedFolder, newTitle)
-        } else {
-            logcat(LogPriority.ERROR) { "Failed to rename manga download folder: ${oldFolder.name}" }
-        }
+        // Multiple current and historical source directories can represent one logical manga.
+        // Re-scan their merged contents so a partial SAF rename cannot leave stale cache entries.
+        cache.refreshSourceDirectories(source.id, provider.findSourceDirs(source))
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -172,30 +172,41 @@ class DownloadProvider(
      * @param source the source to query.
      */
     fun getSourceDirName(source: Source): String {
-        val sourceName = when {
-            source is KomgaSource &&
+        return when {
+            isKomgaSource(source) &&
                 komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared -> {
-                KomgaSource.SOURCE_NAME
+                DiskUtil.buildValidFilename(KomgaSource.SOURCE_NAME)
             }
-            else -> source.toString()
+            isKomgaSource(source) -> getKomgaServerDirName(source.name)
+            else -> DiskUtil.buildValidFilename(
+                source.toString(),
+                disallowNonAscii = disallowNonAsciiFilenames,
+            )
         }
-        return DiskUtil.buildValidFilename(
-            sourceName,
-            disallowNonAscii = disallowNonAsciiFilenames,
-        )
     }
 
     fun getSourceDirNames(source: Source): List<String> {
         val primaryName = getSourceDirName(source)
-        if (!shouldIncludeLegacySharedDirsInLookup(source)) {
+        if (!isKomgaSource(source)) {
             return listOf(primaryName)
         }
 
         return buildList {
             add(primaryName)
-            addAll(legacyKomgaSharedSourceDirNames())
-            add(legacyKomgaSourceDirName(source.name))
+            if (shouldIncludeLegacySharedDirsInLookup(source)) {
+                addAll(legacyKomgaSharedSourceDirNames())
+            } else {
+                // Mihon-style source directories included the language suffix. Keep them in
+                // lookup until they can be atomically renamed to the sanitized server name.
+                addAll(legacyKomgaSourceDirNames(source.name))
+            }
         }.distinct()
+    }
+
+    fun getKomgaServerDirName(serverName: String): String {
+        // Server directories must remain stable if the separate non-ASCII filename preference
+        // changes. FAT-invalid characters are still replaced by DiskUtil.
+        return DiskUtil.buildValidFilename(serverName)
     }
 
     /**
@@ -335,28 +346,54 @@ class DownloadProvider(
             sourceDirsCache[cacheKey]
                 ?.takeUnless { it.isExpired() }
                 ?.value
-                ?: getSourceDirNames(source)
-                    .mapNotNull(downloadsDir::findFile)
-                    .distinctBy { it.uri.toString() }
+                ?: findExistingSourceDirs(downloadsDir, source)
                     .also { dirs ->
                         sourceDirsCache[cacheKey] = CacheEntry(dirs)
                     }
         }
     }
 
+    private fun findExistingSourceDirs(downloadsDir: UniFile, source: Source): List<UniFile> {
+        val names = getSourceDirNames(source)
+        val primaryName = names.first()
+        val primaryDir = downloadsDir.findFile(primaryName)
+        if (
+            primaryDir == null &&
+            isKomgaSource(source) &&
+            komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.PerServer
+        ) {
+            val legacyDir = names.drop(1)
+                .mapNotNull(downloadsDir::findFile)
+                .distinctBy { it.uri.toString() }
+                .singleOrNull()
+            if (legacyDir != null && legacyDir.renameTo(primaryName)) {
+                downloadsDir.findFile(primaryName)?.let { migratedDir ->
+                    logcat(LogPriority.INFO) {
+                        "Migrated legacy Komga server directory from ${legacyDir.name} to $primaryName"
+                    }
+                    return listOf(migratedDir)
+                }
+            }
+        }
+
+        return names
+            .mapNotNull(downloadsDir::findFile)
+            .distinctBy { it.uri.toString() }
+    }
+
     private fun resolveSourceDir(downloadsDir: UniFile, source: Source, sourceDirName: String): UniFile? {
         downloadsDir.findFile(sourceDirName)?.let { return it }
 
-        val legacyDir = when {
-            source is KomgaSource &&
-                komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared -> {
-                val legacyDirs = legacyKomgaSharedSourceDirNames()
-                    .mapNotNull(downloadsDir::findFile)
-                    .distinctBy { it.uri.toString() }
-                legacyDirs.singleOrNull()
-            }
-            else -> null
+        val legacyDirNames = when {
+            !isKomgaSource(source) -> emptyList()
+            komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared ->
+                legacyKomgaSharedSourceDirNames()
+            else -> legacyKomgaSourceDirNames(source.name)
         }
+        val legacyDir = legacyDirNames
+            .mapNotNull(downloadsDir::findFile)
+            .distinctBy { it.uri.toString() }
+            .singleOrNull()
 
         if (legacyDir != null) {
             if (legacyDir.name != sourceDirName && legacyDir.renameTo(sourceDirName)) {
@@ -378,32 +415,103 @@ class DownloadProvider(
             ?.also { invalidateSourceDirCache() }
     }
 
+    fun migrateLegacyKomgaServerDir(source: KomgaSource): Boolean {
+        if (komgaServerPreferences.downloadDirectoryMode.get() != DownloadDirectoryMode.PerServer) {
+            return false
+        }
+
+        val downloadsDir = downloadsDir ?: return false
+        val primaryName = getKomgaServerDirName(source.name)
+        if (downloadsDir.findFile(primaryName) != null) {
+            return false
+        }
+
+        val legacyDir = legacyKomgaSourceDirNames(source.name)
+            .mapNotNull(downloadsDir::findFile)
+            .distinctBy { it.uri.toString() }
+            .singleOrNull() ?: return false
+        val legacyName = legacyDir.name
+        if (!legacyDir.renameTo(primaryName)) {
+            logcat(LogPriority.ERROR) {
+                "Failed to migrate legacy Komga server directory ${legacyDir.name} to $primaryName"
+            }
+            return false
+        }
+
+        invalidateSourceDirCache()
+        logcat(LogPriority.INFO) {
+            "Migrated legacy Komga server directory from $legacyName to $primaryName"
+        }
+        return true
+    }
+
+    fun renameKomgaServerDir(source: KomgaSource, newServerName: String): Result<UniFile?> = runCatching {
+        if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared) {
+            return@runCatching null
+        }
+
+        val downloadsDir = downloadsDir ?: throw IOException("Downloads directory is unavailable")
+        val oldDir = findSourceDir(source) ?: return@runCatching null
+        val oldName = oldDir.name ?: return@runCatching null
+        val newName = getKomgaServerDirName(newServerName)
+        if (oldName == newName) return@runCatching oldDir
+
+        val existingTarget = downloadsDir.findFile(newName)
+        if (existingTarget != null && existingTarget.uri != oldDir.uri) {
+            throw IOException("Download directory already exists: $newName")
+        }
+
+        val capitalizationChanged = oldName.equals(newName, ignoreCase = true)
+        if (capitalizationChanged) {
+            val tempName = newName + Downloader.TMP_DIR_SUFFIX
+            if (!oldDir.renameTo(tempName)) {
+                throw IOException("Failed to prepare download directory rename: $oldName")
+            }
+        }
+
+        if (!oldDir.renameTo(newName)) {
+            if (capitalizationChanged) {
+                oldDir.renameTo(oldName)
+            }
+            throw IOException("Failed to rename download directory from $oldName to $newName")
+        }
+
+        invalidateSourceDirCache()
+        downloadsDir.findFile(newName)
+            ?: throw IOException("Renamed download directory is unavailable: $newName")
+    }
+
     private fun legacyKomgaSharedSourceDirNames(): List<String> {
         return buildList {
-            add(legacyKomgaSourceDirName(KomgaSource.SOURCE_NAME))
+            addAll(legacyKomgaSourceDirNames(KomgaSource.SOURCE_NAME))
             komgaServerPreferences.getProfiles().forEach { profile ->
-                add(legacyKomgaSourceDirName(profile.name))
+                addAll(legacyKomgaSourceDirNames(profile.name))
             }
         }.distinct()
     }
 
-    private fun legacyKomgaSourceDirName(sourceName: String): String {
-        return DiskUtil.buildValidFilename(
-            "$sourceName (${KomgaSource.SOURCE_LANG.uppercase()})",
-            disallowNonAscii = disallowNonAsciiFilenames,
-        )
+    private fun legacyKomgaSourceDirNames(sourceName: String): List<String> {
+        val legacyName = "$sourceName (${KomgaSource.SOURCE_LANG.uppercase()})"
+        return listOf(
+            DiskUtil.buildValidFilename(legacyName),
+            DiskUtil.buildValidFilename(legacyName, disallowNonAscii = true),
+        ).distinct()
     }
 
     private fun shouldIncludeLegacySharedDirsInLookup(source: Source): Boolean {
-        return source is KomgaSource &&
+        return isKomgaSource(source) &&
             komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared
+    }
+
+    private fun isKomgaSource(source: Source): Boolean {
+        return source is KomgaSource || source.lang.equals(KomgaSource.SOURCE_LANG, ignoreCase = true)
     }
 
     private fun buildSourceDirsCacheKey(downloadsDir: UniFile, source: Source): String {
         return "${downloadsDir.uri}|${getSourceDirNames(source).joinToString(separator = "|")}"
     }
 
-    private fun invalidateSourceDirCache() {
+    fun invalidateSourceDirCache() {
         synchronized(sourceDirsCache) {
             sourceDirsCache.clear()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -97,11 +97,16 @@ class DownloadProvider(
      * @param source the source of the manga.
      */
     fun findMangaDir(mangaTitle: String, source: Source): UniFile? {
+        return findMangaDirs(mangaTitle, source).firstOrNull()
+    }
+
+    fun findMangaDirs(mangaTitle: String, source: Source): List<UniFile> {
         val mangaDirName = getMangaDirName(mangaTitle)
         return findSourceDirs(source)
             .asSequence()
             .mapNotNull { it.findFile(mangaDirName) }
-            .firstOrNull()
+            .distinctBy { it.uri.toString() }
+            .toList()
     }
 
     /**
@@ -159,11 +164,18 @@ class DownloadProvider(
      * @param manga the manga of the chapter.
      * @param source the source of the chapter.
      */
-    fun findChapterDirs(chapters: List<Chapter>, manga: Manga, source: Source): Pair<UniFile?, List<UniFile>> {
-        val mangaDir = findMangaDir(manga.title, source)
-        return mangaDir to chapters.mapNotNull { chapter ->
-            findChapterDir(chapter.name, chapter.scanlator, chapter.url, manga.title, source)
-        }
+    fun findChapterDirs(chapters: List<Chapter>, manga: Manga, source: Source): Pair<List<UniFile>, List<UniFile>> {
+        val mangaDirs = findMangaDirs(manga.title, source)
+        val chapterDirs = chapters.flatMap { chapter ->
+            val validNames = getValidChapterDirNames(chapter.name, chapter.scanlator, chapter.url)
+            val directMatches = mangaDirs.flatMap { mangaDir ->
+                validNames.mapNotNull(mangaDir::findFile)
+            }
+            directMatches.ifEmpty {
+                listOfNotNull(findChapterDir(chapter.name, chapter.scanlator, chapter.url, manga.title, source))
+            }
+        }.distinctBy { it.uri.toString() }
+        return mangaDirs to chapterDirs
     }
 
     /**
@@ -515,17 +527,20 @@ class DownloadProvider(
             throw IOException("Download directory already exists: $newName")
         }
 
+        var currentDir = oldDir
         val capitalizationChanged = oldName.equals(newName, ignoreCase = true)
         if (capitalizationChanged) {
             val tempName = newName + Downloader.TMP_DIR_SUFFIX
-            if (!oldDir.renameTo(tempName)) {
+            if (!currentDir.renameTo(tempName)) {
                 throw IOException("Failed to prepare download directory rename: $oldName")
             }
+            currentDir = downloadsDir.findFile(tempName)
+                ?: throw IOException("Failed to resolve temporary download directory: $tempName")
         }
 
-        if (!oldDir.renameTo(newName)) {
+        if (!currentDir.renameTo(newName)) {
             if (capitalizationChanged) {
-                oldDir.renameTo(oldName)
+                currentDir.renameTo(oldName)
             }
             throw IOException("Failed to rename download directory from $oldName to $newName")
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -194,11 +194,15 @@ class DownloadProvider(
         return buildList {
             add(primaryName)
             if (shouldIncludeLegacySharedDirsInLookup(source)) {
-                addAll(legacyKomgaSharedSourceDirNames(source.name))
+                addAll(legacyKomgaSharedSourceDirNames(source))
             } else {
                 // Mihon-style source directories included the language suffix. Keep them in
                 // lookup until they can be atomically renamed to the sanitized server name.
                 addAll(legacyKomgaSourceDirNames(source.name))
+                komgaServerPreferences.getDirectoryAliases(source.id).forEach { alias ->
+                    add(getKomgaServerDirName(alias))
+                    addAll(legacyKomgaSourceDirNames(alias))
+                }
                 // Downloads created while shared mode was active remain readable after
                 // switching back to per-server directories, but are never used for new files.
                 add(getKomgaSharedDirName())
@@ -365,6 +369,22 @@ class DownloadProvider(
         }
     }
 
+    internal fun findOwnedSourceDirs(source: Source): List<UniFile> {
+        val ownedNames = buildList {
+            add(getSourceDirName(source))
+            if (isKomgaSource(source) &&
+                komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.PerServer
+            ) {
+                addAll(legacyKomgaSourceDirNames(source.name))
+                komgaServerPreferences.getDirectoryAliases(source.id).forEach { alias ->
+                    add(getKomgaServerDirName(alias))
+                    addAll(legacyKomgaSourceDirNames(alias))
+                }
+            }
+        }.toSet()
+        return findSourceDirs(source).filter { it.name in ownedNames }
+    }
+
     private fun findExistingSourceDirs(downloadsDir: UniFile, source: Source): List<UniFile> {
         val names = getSourceDirNames(source)
         val primaryName = names.first()
@@ -400,7 +420,7 @@ class DownloadProvider(
         val legacyDirNames = when {
             !isKomgaSource(source) -> emptyList()
             komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared ->
-                legacyKomgaSharedSourceDirNames(source.name)
+                legacyKomgaSharedSourceDirNames(source)
             else -> legacyKomgaSourceDirNames(source.name)
         }
         val legacyDir = legacyDirNames
@@ -485,7 +505,7 @@ class DownloadProvider(
         }
 
         val downloadsDir = downloadsDir ?: throw IOException("Downloads directory is unavailable")
-        val oldDir = findSourceDir(source) ?: return@runCatching null
+        val oldDir = findOwnedSourceDirs(source).firstOrNull() ?: return@runCatching null
         val oldName = oldDir.name ?: return@runCatching null
         val newName = getKomgaServerDirName(newServerName)
         if (oldName == newName) return@runCatching oldDir
@@ -515,14 +535,20 @@ class DownloadProvider(
             ?: throw IOException("Renamed download directory is unavailable: $newName")
     }
 
-    private fun legacyKomgaSharedSourceDirNames(sourceName: String): List<String> {
+    private fun legacyKomgaSharedSourceDirNames(source: Source): List<String> {
         return buildList {
             add(DiskUtil.buildValidFilename(KomgaSource.SOURCE_NAME))
             addAll(legacyKomgaSourceDirNames(KomgaSource.SOURCE_NAME))
             komgaServerPreferences.getProfiles().forEach { profile ->
+                add(getKomgaServerDirName(profile.name))
                 addAll(legacyKomgaSourceDirNames(profile.name))
             }
-            addAll(legacyKomgaSourceDirNames(sourceName))
+            add(getKomgaServerDirName(source.name))
+            addAll(legacyKomgaSourceDirNames(source.name))
+            komgaServerPreferences.getDirectoryAliases(source.id).forEach { alias ->
+                add(getKomgaServerDirName(alias))
+                addAll(legacyKomgaSourceDirNames(alias))
+            }
         }.distinct()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -175,7 +175,7 @@ class DownloadProvider(
         return when {
             isKomgaSource(source) &&
                 komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared -> {
-                DiskUtil.buildValidFilename(KomgaSource.SOURCE_NAME)
+                getKomgaSharedDirName()
             }
             isKomgaSource(source) -> getKomgaServerDirName(source.name)
             else -> DiskUtil.buildValidFilename(
@@ -194,11 +194,14 @@ class DownloadProvider(
         return buildList {
             add(primaryName)
             if (shouldIncludeLegacySharedDirsInLookup(source)) {
-                addAll(legacyKomgaSharedSourceDirNames())
+                addAll(legacyKomgaSharedSourceDirNames(source.name))
             } else {
                 // Mihon-style source directories included the language suffix. Keep them in
                 // lookup until they can be atomically renamed to the sanitized server name.
                 addAll(legacyKomgaSourceDirNames(source.name))
+                // Downloads created while shared mode was active remain readable after
+                // switching back to per-server directories, but are never used for new files.
+                add(getKomgaSharedDirName())
             }
         }.distinct()
     }
@@ -206,7 +209,16 @@ class DownloadProvider(
     fun getKomgaServerDirName(serverName: String): String {
         // Server directories must remain stable if the separate non-ASCII filename preference
         // changes. FAT-invalid characters are still replaced by DiskUtil.
-        return DiskUtil.buildValidFilename(serverName)
+        val sanitizedName = DiskUtil.buildValidFilename(serverName)
+        return if (sanitizedName.equals(getKomgaSharedDirName(), ignoreCase = true)) {
+            DiskUtil.buildValidFilename("$serverName (Server)")
+        } else {
+            sanitizedName
+        }
+    }
+
+    private fun getKomgaSharedDirName(): String {
+        return DiskUtil.buildValidFilename("${KomgaSource.SOURCE_NAME} (Shared)")
     }
 
     /**
@@ -339,7 +351,7 @@ class DownloadProvider(
         }
     }
 
-    private fun findSourceDirs(source: Source): List<UniFile> {
+    internal fun findSourceDirs(source: Source): List<UniFile> {
         val downloadsDir = downloadsDir ?: return emptyList()
         val cacheKey = buildSourceDirsCacheKey(downloadsDir, source)
         return synchronized(sourceDirsCache) {
@@ -366,10 +378,11 @@ class DownloadProvider(
                 .mapNotNull(downloadsDir::findFile)
                 .distinctBy { it.uri.toString() }
                 .singleOrNull()
+            val legacyName = legacyDir?.name
             if (legacyDir != null && legacyDir.renameTo(primaryName)) {
                 downloadsDir.findFile(primaryName)?.let { migratedDir ->
                     logcat(LogPriority.INFO) {
-                        "Migrated legacy Komga server directory from ${legacyDir.name} to $primaryName"
+                        "Migrated legacy Komga server directory from $legacyName to $primaryName"
                     }
                     return listOf(migratedDir)
                 }
@@ -387,7 +400,7 @@ class DownloadProvider(
         val legacyDirNames = when {
             !isKomgaSource(source) -> emptyList()
             komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared ->
-                legacyKomgaSharedSourceDirNames()
+                legacyKomgaSharedSourceDirNames(source.name)
             else -> legacyKomgaSourceDirNames(source.name)
         }
         val legacyDir = legacyDirNames
@@ -415,12 +428,37 @@ class DownloadProvider(
             ?.also { invalidateSourceDirCache() }
     }
 
-    fun migrateLegacyKomgaServerDir(source: KomgaSource): Boolean {
-        if (komgaServerPreferences.downloadDirectoryMode.get() != DownloadDirectoryMode.PerServer) {
-            return false
+    fun migrateLegacyKomgaDirectories(): Result<Boolean> = runCatching {
+        val downloadsDir = downloadsDir ?: throw IOException("Downloads directory is unavailable")
+        var migrated = false
+        val sharedName = getKomgaSharedDirName()
+        val legacySharedName = DiskUtil.buildValidFilename(KomgaSource.SOURCE_NAME)
+        if (downloadsDir.findFile(sharedName) == null) {
+            downloadsDir.findFile(legacySharedName)?.let { legacySharedDir ->
+                if (!legacySharedDir.renameTo(sharedName)) {
+                    throw IOException("Failed to migrate shared Komga directory: $legacySharedName")
+                }
+                migrated = true
+                logcat(LogPriority.INFO) {
+                    "Migrated shared Komga directory from $legacySharedName to $sharedName"
+                }
+            }
         }
 
-        val downloadsDir = downloadsDir ?: return false
+        if (komgaServerPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.PerServer) {
+            komgaServerPreferences.getProfiles().forEach { profile ->
+                migrated = migrateLegacyKomgaServerDir(
+                    downloadsDir = downloadsDir,
+                    source = KomgaSource(profile.id, profile.name),
+                ) || migrated
+            }
+        }
+
+        if (migrated) invalidateSourceDirCache()
+        migrated
+    }
+
+    private fun migrateLegacyKomgaServerDir(downloadsDir: UniFile, source: KomgaSource): Boolean {
         val primaryName = getKomgaServerDirName(source.name)
         if (downloadsDir.findFile(primaryName) != null) {
             return false
@@ -432,13 +470,9 @@ class DownloadProvider(
             .singleOrNull() ?: return false
         val legacyName = legacyDir.name
         if (!legacyDir.renameTo(primaryName)) {
-            logcat(LogPriority.ERROR) {
-                "Failed to migrate legacy Komga server directory ${legacyDir.name} to $primaryName"
-            }
-            return false
+            throw IOException("Failed to migrate legacy Komga server directory ${legacyDir.name} to $primaryName")
         }
 
-        invalidateSourceDirCache()
         logcat(LogPriority.INFO) {
             "Migrated legacy Komga server directory from $legacyName to $primaryName"
         }
@@ -481,12 +515,14 @@ class DownloadProvider(
             ?: throw IOException("Renamed download directory is unavailable: $newName")
     }
 
-    private fun legacyKomgaSharedSourceDirNames(): List<String> {
+    private fun legacyKomgaSharedSourceDirNames(sourceName: String): List<String> {
         return buildList {
+            add(DiskUtil.buildValidFilename(KomgaSource.SOURCE_NAME))
             addAll(legacyKomgaSourceDirNames(KomgaSource.SOURCE_NAME))
             komgaServerPreferences.getProfiles().forEach { profile ->
                 addAll(legacyKomgaSourceDirNames(profile.name))
             }
+            addAll(legacyKomgaSourceDirNames(sourceName))
         }.distinct()
     }
 
@@ -504,7 +540,7 @@ class DownloadProvider(
     }
 
     private fun isKomgaSource(source: Source): Boolean {
-        return source is KomgaSource || source.lang.equals(KomgaSource.SOURCE_LANG, ignoreCase = true)
+        return source is KomgaSource || komgaServerPreferences.isKnownServerId(source.id)
     }
 
     private fun buildSourceDirsCacheKey(downloadsDir: UniFile, source: Source): String {

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -16,6 +16,7 @@ import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaServerPreferences
+import koharia.source.komga.KomgaServerProfileManager
 import koharia.source.komga.KomgaServerRemovalManager
 import tachiyomi.core.common.preference.AndroidPreferenceStore
 import tachiyomi.core.common.preference.PreferenceStore
@@ -76,6 +77,13 @@ class PreferenceModule(val app: Application) : InjektModule {
                 downloadCache = get(),
                 komgaSharedDownloadIndexManager = get(),
                 epubCacheManager = get(),
+            )
+        }
+        addSingletonFactory {
+            KomgaServerProfileManager(
+                serverPreferences = get<KomgaServerPreferences>(),
+                downloadProvider = get(),
+                downloadCache = get(),
             )
         }
         addSingletonFactory {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/AppShortcutManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/AppShortcutManager.kt
@@ -1,0 +1,81 @@
+package eu.kanade.tachiyomi.util.system
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.ui.main.MainActivity
+import logcat.LogPriority
+import tachiyomi.core.common.Constants
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.i18n.MR
+
+object AppShortcutManager {
+
+    fun updateLibraryShortcuts(context: Context, classificationEnabled: Boolean) {
+        val shortcuts = if (classificationEnabled) {
+            listOf(
+                createShortcut(
+                    context = context,
+                    id = SHORTCUT_COMICS_ID,
+                    label = context.stringResource(MR.strings.label_comics),
+                    iconRes = R.drawable.sc_collections_bookmark_48dp,
+                    action = Constants.SHORTCUT_LIBRARY,
+                    rank = 0,
+                ),
+                createShortcut(
+                    context = context,
+                    id = SHORTCUT_BOOKS_ID,
+                    label = context.stringResource(MR.strings.label_books),
+                    iconRes = R.drawable.sc_book_48dp,
+                    action = Constants.SHORTCUT_UPDATES,
+                    rank = 1,
+                ),
+            )
+        } else {
+            listOf(
+                createShortcut(
+                    context = context,
+                    id = SHORTCUT_LIBRARY_ID,
+                    label = context.stringResource(MR.strings.label_library),
+                    iconRes = R.drawable.sc_collections_bookmark_48dp,
+                    action = Constants.SHORTCUT_LIBRARY,
+                    rank = 0,
+                ),
+            )
+        }
+
+        runCatching {
+            ShortcutManagerCompat.setDynamicShortcuts(context, shortcuts)
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) { "Failed to update app shortcuts" }
+        }
+    }
+
+    private fun createShortcut(
+        context: Context,
+        id: String,
+        label: String,
+        iconRes: Int,
+        action: String,
+        rank: Int,
+    ): ShortcutInfoCompat {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            this.action = action
+        }
+        return ShortcutInfoCompat.Builder(context, id)
+            .setShortLabel(label)
+            .setLongLabel(label)
+            .setIcon(IconCompat.createWithResource(context, iconRes))
+            .setIntent(intent)
+            .setRank(rank)
+            .build()
+    }
+
+    private const val SHORTCUT_LIBRARY_ID = "dynamic_library"
+    private const val SHORTCUT_COMICS_ID = "dynamic_comics"
+    private const val SHORTCUT_BOOKS_ID = "dynamic_books"
+}

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -59,6 +59,16 @@ class KomgaServerPreferences(
         false,
     )
 
+    private val knownServerIds: Preference<Set<String>> = preferenceStore.getStringSet(
+        PREF_KNOWN_SERVER_IDS,
+        emptySet(),
+    )
+
+    private val downloadDirectoryLayoutVersion: Preference<Int> = preferenceStore.getInt(
+        PREF_DOWNLOAD_DIRECTORY_LAYOUT_VERSION,
+        0,
+    )
+
     fun profilesChanges(): Flow<List<KomgaServerProfile>> {
         return serializedProfiles.changes()
             .map(::decodeProfiles)
@@ -72,6 +82,7 @@ class KomgaServerPreferences(
 
     fun setProfiles(profiles: Collection<KomgaServerProfile>) {
         val normalizedProfiles = normalizeProfiles(profiles.toList())
+        rememberServerIds(normalizedProfiles)
         serializedProfiles.set(normalizedProfiles.mapTo(linkedSetOf(), json::encodeToString))
         // An explicit profile update (including deleting the last profile) is no longer
         // an initialization attempt. This prevents legacy recovery from recreating a
@@ -103,7 +114,28 @@ class KomgaServerPreferences(
             serializedProfiles.set(profiles.mapTo(linkedSetOf(), json::encodeToString))
             hasInitializedProfiles.set(true)
         }
+        rememberServerIds(profiles)
         ensureActiveServerExists(profiles)
+    }
+
+    fun isKnownServerId(serverId: Long): Boolean {
+        return serverId == KomgaSource.ID || serverId.toString() in knownServerIds.get()
+    }
+
+    fun needsDownloadDirectoryLayoutMigration(): Boolean {
+        return downloadDirectoryLayoutVersion.get() < DOWNLOAD_DIRECTORY_LAYOUT_VERSION
+    }
+
+    fun markDownloadDirectoryLayoutMigrated() {
+        downloadDirectoryLayoutVersion.set(DOWNLOAD_DIRECTORY_LAYOUT_VERSION)
+    }
+
+    private fun rememberServerIds(profiles: Collection<KomgaServerProfile>) {
+        val updated = knownServerIds.get().toMutableSet().apply {
+            add(KomgaSource.ID.toString())
+            profiles.mapTo(this) { it.id.toString() }
+        }
+        knownServerIds.set(updated)
     }
 
     private fun hasLegacySourcePreferences(): Boolean {
@@ -151,7 +183,10 @@ class KomgaServerPreferences(
         private const val PREF_LOCAL_CONFIG_MODE = "komga_local_config_mode"
         private const val PREF_DOWNLOAD_DIRECTORY_MODE = "komga_download_directory_mode"
         private const val PREF_HAS_INITIALIZED_PROFILES = "komga_has_initialized_profiles"
+        private const val PREF_KNOWN_SERVER_IDS = "komga_known_server_ids"
+        private const val PREF_DOWNLOAD_DIRECTORY_LAYOUT_VERSION = "komga_download_directory_layout_version"
         private const val PREF_LEGACY_ADDRESS = "Address"
+        private const val DOWNLOAD_DIRECTORY_LAYOUT_VERSION = 1
 
         const val NO_ACTIVE_SERVER = -1L
     }

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -18,6 +18,12 @@ data class KomgaServerProfile(
     val name: String,
 )
 
+@Serializable
+private data class KomgaServerDirectoryAlias(
+    val serverId: Long,
+    val serverName: String,
+)
+
 enum class LocalConfigMode {
     Shared,
     Separate,
@@ -67,6 +73,11 @@ class KomgaServerPreferences(
     private val downloadDirectoryLayoutVersion: Preference<Int> = preferenceStore.getInt(
         PREF_DOWNLOAD_DIRECTORY_LAYOUT_VERSION,
         0,
+    )
+
+    private val serializedDirectoryAliases: Preference<Set<String>> = preferenceStore.getStringSet(
+        PREF_DIRECTORY_ALIASES,
+        emptySet(),
     )
 
     fun profilesChanges(): Flow<List<KomgaServerProfile>> {
@@ -130,6 +141,21 @@ class KomgaServerPreferences(
         downloadDirectoryLayoutVersion.set(DOWNLOAD_DIRECTORY_LAYOUT_VERSION)
     }
 
+    fun getDirectoryAliases(serverId: Long): Set<String> {
+        return decodeDirectoryAliases(serializedDirectoryAliases.get())
+            .asSequence()
+            .filter { it.serverId == serverId }
+            .mapTo(linkedSetOf(), KomgaServerDirectoryAlias::serverName)
+    }
+
+    fun rememberDirectoryAlias(serverId: Long, serverName: String) {
+        val alias = KomgaServerDirectoryAlias(serverId, serverName)
+        val updated = decodeDirectoryAliases(serializedDirectoryAliases.get())
+            .filterNot { it.serverId == serverId && it.serverName == serverName }
+            .plus(alias)
+        serializedDirectoryAliases.set(updated.mapTo(linkedSetOf(), json::encodeToString))
+    }
+
     private fun rememberServerIds(profiles: Collection<KomgaServerProfile>) {
         val updated = knownServerIds.get().toMutableSet().apply {
             add(KomgaSource.ID.toString())
@@ -170,6 +196,12 @@ class KomgaServerPreferences(
             .distinctBy(KomgaServerProfile::id)
     }
 
+    private fun decodeDirectoryAliases(values: Set<String>): List<KomgaServerDirectoryAlias> {
+        return values.mapNotNull { value ->
+            runCatching { json.decodeFromString<KomgaServerDirectoryAlias>(value) }.getOrNull()
+        }
+    }
+
     private fun defaultProfile(): KomgaServerProfile {
         return KomgaServerProfile(
             id = KomgaSource.ID,
@@ -185,6 +217,7 @@ class KomgaServerPreferences(
         private const val PREF_HAS_INITIALIZED_PROFILES = "komga_has_initialized_profiles"
         private const val PREF_KNOWN_SERVER_IDS = "komga_known_server_ids"
         private const val PREF_DOWNLOAD_DIRECTORY_LAYOUT_VERSION = "komga_download_directory_layout_version"
+        private const val PREF_DIRECTORY_ALIASES = "komga_server_directory_aliases"
         private const val PREF_LEGACY_ADDRESS = "Address"
         private const val DOWNLOAD_DIRECTORY_LAYOUT_VERSION = 1
 

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfileManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfileManager.kt
@@ -43,6 +43,7 @@ class KomgaServerProfileManager(
                 source = KomgaSource(currentProfile.id, currentProfile.name),
                 newServerName = newName,
             ).getOrThrow()
+            serverPreferences.rememberDirectoryAlias(serverId, currentProfile.name)
 
             val latestProfiles = serverPreferences.getProfiles()
             val updatedProfiles = latestProfiles.map { profile ->
@@ -55,7 +56,13 @@ class KomgaServerProfileManager(
 
             if (renamedDirectory != null) {
                 runCatching {
-                    downloadCache.refreshSourceDirectory(serverId, renamedDirectory)
+                    val renamedSource = KomgaSource(serverId, newName)
+                    val directories = downloadProvider.findSourceDirs(renamedSource)
+                    check(directories.isNotEmpty()) { "Renamed server download directories are unavailable" }
+                    downloadCache.refreshSourceDirectories(
+                        sourceId = serverId,
+                        directories = directories,
+                    )
                 }.onFailure { error ->
                     logcat(LogPriority.ERROR, error) {
                         "Failed to refresh download cache after renaming Komga server id=$serverId"

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfileManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfileManager.kt
@@ -1,0 +1,73 @@
+package koharia.source.komga
+
+import eu.kanade.tachiyomi.data.download.DownloadCache
+import eu.kanade.tachiyomi.data.download.DownloadProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+
+class KomgaServerProfileManager(
+    private val serverPreferences: KomgaServerPreferences,
+    private val downloadProvider: DownloadProvider,
+    private val downloadCache: DownloadCache,
+) {
+
+    fun directoryNameFor(serverName: String): String {
+        return downloadProvider.getKomgaServerDirName(serverName.trim())
+    }
+
+    fun isDirectoryNameAvailable(serverName: String, excludingServerId: Long? = null): Boolean {
+        val candidate = directoryNameFor(serverName)
+        return serverPreferences.getProfiles().none { profile ->
+            profile.id != excludingServerId &&
+                directoryNameFor(profile.name).equals(candidate, ignoreCase = true)
+        }
+    }
+
+    suspend fun renameServer(serverId: Long, requestedName: String): Result<Unit> = withContext(Dispatchers.IO) {
+        val newName = requestedName.trim()
+        if (newName.isEmpty()) {
+            return@withContext Result.failure(IllegalArgumentException("Server name cannot be empty"))
+        }
+        if (!isDirectoryNameAvailable(newName, serverId)) {
+            return@withContext Result.failure(IllegalArgumentException("Server download directory name conflicts"))
+        }
+
+        val currentProfile = serverPreferences.getProfiles().find { it.id == serverId }
+            ?: return@withContext Result.failure(IllegalStateException("Server profile no longer exists"))
+        if (currentProfile.name == newName) return@withContext Result.success(Unit)
+
+        runCatching {
+            val renamedDirectory = downloadProvider.renameKomgaServerDir(
+                source = KomgaSource(currentProfile.id, currentProfile.name),
+                newServerName = newName,
+            ).getOrThrow()
+
+            val latestProfiles = serverPreferences.getProfiles()
+            val updatedProfiles = latestProfiles.map { profile ->
+                if (profile.id == serverId) profile.copy(name = newName) else profile
+            }
+            check(updatedProfiles.any { it.id == serverId }) { "Server profile was removed during rename" }
+
+            downloadCache.suppressNextProfileRefresh(updatedProfiles.mapTo(mutableSetOf()) { it.id })
+            serverPreferences.setProfiles(updatedProfiles)
+
+            if (renamedDirectory != null) {
+                runCatching {
+                    downloadCache.refreshSourceDirectory(serverId, renamedDirectory)
+                }.onFailure { error ->
+                    logcat(LogPriority.ERROR, error) {
+                        "Failed to refresh download cache after renaming Komga server id=$serverId"
+                    }
+                    downloadCache.invalidateCache("komga_server_renamed:serverId=$serverId")
+                }
+            }
+
+            logcat(LogPriority.INFO) {
+                "Renamed Komga server id=$serverId from=${currentProfile.name} to=$newName " +
+                    "directory=${directoryNameFor(newName)}"
+            }
+        }
+    }
+}

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -69,6 +69,7 @@ class KomgaServerProfilesScreen : Screen() {
         val localConfigManager = remember { Injekt.get<KomgaLocalConfigManager>() }
         val classificationManager = remember { Injekt.get<KomgaLibraryClassificationManager>() }
         val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
+        val serverProfileManager = remember { Injekt.get<KomgaServerProfileManager>() }
         val profiles by serverPreferences.profilesChanges().collectAsState(initial = serverPreferences.getProfiles())
         val activeServerId by serverPreferences.activeServerId.collectAsState()
         val localConfigMode by serverPreferences.localConfigMode.collectAsState()
@@ -243,6 +244,8 @@ class KomgaServerProfilesScreen : Screen() {
 
         if (showAddDialog) {
             AddServerDialog(
+                directoryNameFor = serverProfileManager::directoryNameFor,
+                isNameAvailable = { name -> serverProfileManager.isDirectoryNameAvailable(name) },
                 onDismissRequest = {
                     showAddDialog = false
                     pendingServerName = null
@@ -400,18 +403,22 @@ private fun EmptyServerState(
 
 @Composable
 private fun AddServerDialog(
+    directoryNameFor: (String) -> String,
+    isNameAvailable: (String) -> Boolean,
     onDismissRequest: () -> Unit,
     onAddServer: (String) -> Unit,
 ) {
     var name by rememberSaveable { mutableStateOf("") }
     val focusRequester = remember { FocusRequester() }
     val trimmedName = name.trim()
+    val directoryName = directoryNameFor(trimmedName)
+    val available = trimmedName.isNotEmpty() && isNameAvailable(trimmedName)
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             TextButton(
-                enabled = trimmedName.isNotEmpty(),
+                enabled = available,
                 onClick = { onAddServer(trimmedName) },
             ) {
                 Text(text = stringResource(MR.strings.action_add))
@@ -432,7 +439,15 @@ private fun AddServerDialog(
                 modifier = Modifier.focusRequester(focusRequester),
                 label = { Text(text = stringResource(MR.strings.name)) },
                 supportingText = {
-                    Text(text = stringResource(MR.strings.information_required_plain))
+                    Text(
+                        text = if (trimmedName.isEmpty()) {
+                            stringResource(MR.strings.information_required_plain)
+                        } else if (!available) {
+                            stringResource(MR.strings.komga_server_name_directory_conflict)
+                        } else {
+                            stringResource(MR.strings.komga_server_directory_preview, directoryName)
+                        },
+                    )
                 },
                 singleLine = true,
             )

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -124,7 +124,11 @@ class KomgaServerRemovalManager(
                         "KomgaServerRemoval: deleting per-server download directory " +
                             "serverId=${profile.id} source=${source.name} cleanupMode=$mode"
                     }
-                    downloadProvider.findSourceDir(source)?.delete()
+                    downloadProvider.findOwnedSourceDirs(source).forEach { directory ->
+                        check(directory.delete()) {
+                            "Failed to delete Komga download directory: ${directory.name}"
+                        }
+                    }
                     downloadProvider.invalidateSourceDirCache()
                     downloadCache.removeSource(source)
                     komgaSharedDownloadIndexManager.removeServerIndexes(profile.id)

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -28,11 +28,20 @@ class KomgaServerRemovalManager(
         val currentProfiles = serverPreferences.getProfiles()
         val profile = currentProfiles.find { it.id == serverId } ?: return Result.success(Unit)
 
+        logcat(LogPriority.DEBUG) {
+            "KomgaServerRemoval: requested serverId=$serverId name=${profile.name} " +
+                "cleanupMode=$options directoryMode=${serverPreferences.downloadDirectoryMode.get()}"
+        }
+
         return try {
             withContext(Dispatchers.IO) {
                 // Keep credentials and scoped settings until every retryable
                 // cleanup step succeeds, so a failure cannot orphan the profile.
                 cleanupDownloads(profile, options)
+                logcat(LogPriority.DEBUG) {
+                    "KomgaServerRemoval: download cleanup completed serverId=$serverId " +
+                        "cleanupMode=$options"
+                }
                 epubCacheManager.clearServer(serverId)
                 libraryClassificationManager.clearServer(serverId)
                 localConfigManager.clearScopeForServer(serverId)
@@ -42,7 +51,13 @@ class KomgaServerRemovalManager(
             // another profile while disk/network cleanup is in progress; filtering by ID
             // preserves those concurrent changes instead of writing the stale snapshot.
             val latestProfiles = serverPreferences.getProfiles()
-            serverPreferences.setProfiles(latestProfiles.filterNot { it.id == serverId })
+            val remainingProfiles = latestProfiles.filterNot { it.id == serverId }
+            downloadCache.suppressNextProfileRefresh(remainingProfiles.mapTo(mutableSetOf()) { it.id })
+            serverPreferences.setProfiles(remainingProfiles)
+            logcat(LogPriority.DEBUG) {
+                "KomgaServerRemoval: profile removed serverId=$serverId " +
+                    "remainingProfiles=${remainingProfiles.size}"
+            }
 
             logcat(LogPriority.DEBUG) {
                 "Removed Komga server id=$serverId name=${profile.name} " +
@@ -81,21 +96,50 @@ class KomgaServerRemovalManager(
         profile: KomgaServerProfile,
         mode: DownloadCleanupMode,
     ) {
+        val directoryMode = serverPreferences.downloadDirectoryMode.get()
+        var requiresFullScan = false
         when (mode) {
             DownloadCleanupMode.Preserve -> {
+                logcat(LogPriority.DEBUG) {
+                    "KomgaServerRemoval: preserving files and removing shared indexes " +
+                        "serverId=${profile.id}"
+                }
                 komgaSharedDownloadIndexManager.removeServerIndexes(profile.id)
+                // Keep the existing source entry as well as its files. Manga records can still
+                // resolve this source through the persisted stub after the server is removed.
             }
             else -> {
-                if (serverPreferences.downloadDirectoryMode.get() == DownloadDirectoryMode.Shared) {
+                if (directoryMode == DownloadDirectoryMode.Shared) {
+                    logcat(LogPriority.DEBUG) {
+                        "KomgaServerRemoval: cleaning shared download files serverId=${profile.id} " +
+                            "cleanupMode=$mode"
+                    }
                     komgaSharedDownloadIndexManager.cleanupServerDownloads(profile.id, mode)
+                    // Shared files can belong to more than one server, so deleting them
+                    // requires rebuilding the filesystem-backed index.
+                    requiresFullScan = true
                 } else {
                     val source = KomgaSource(profile.id, profile.name)
+                    logcat(LogPriority.DEBUG) {
+                        "KomgaServerRemoval: deleting per-server download directory " +
+                            "serverId=${profile.id} source=${source.name} cleanupMode=$mode"
+                    }
                     downloadProvider.findSourceDir(source)?.delete()
+                    downloadProvider.invalidateSourceDirCache()
                     downloadCache.removeSource(source)
                     komgaSharedDownloadIndexManager.removeServerIndexes(profile.id)
                 }
             }
         }
-        downloadCache.invalidateCache()
+        if (requiresFullScan) {
+            downloadCache.invalidateCache(
+                "server_removal:serverId=${profile.id},mode=$mode,directoryMode=$directoryMode",
+            )
+        } else {
+            logcat(LogPriority.DEBUG) {
+                "KomgaServerRemoval: skipped full download scan serverId=${profile.id} " +
+                    "mode=$mode directoryMode=$directoryMode"
+            }
+        }
     }
 }

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -43,6 +43,7 @@ class KomgaServerSettingsScreen(
     override fun Content() {
         var showHelpDialog by rememberSaveable { mutableStateOf(false) }
         var showUnsavedDialog by rememberSaveable { mutableStateOf(false) }
+        var isSaving by rememberSaveable { mutableStateOf(false) }
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
@@ -102,28 +103,35 @@ class KomgaServerSettingsScreen(
                     )
                 }
                 IconButton(
+                    enabled = !isSaving,
                     onClick = {
+                        if (isSaving) return@IconButton
+                        isSaving = true
                         scope.launch {
-                            val currentName = serverPreferences.getProfiles()
-                                .find { it.id == sourceId }
-                                ?.name
-                                .orEmpty()
-                            val requestedName = deferredDataStore
-                                ?.getString(KomgaSource.PREF_SERVER_PROFILE_NAME, currentName)
-                                ?.trim()
-                                ?: currentName
-                            val result = serverProfileManager.renameServer(sourceId, requestedName)
-                            if (result.isFailure) {
-                                context.toast(MR.strings.komga_server_rename_failed)
-                                return@launch
-                            }
+                            try {
+                                val currentName = serverPreferences.getProfiles()
+                                    .find { it.id == sourceId }
+                                    ?.name
+                                    .orEmpty()
+                                val requestedName = deferredDataStore
+                                    ?.getString(KomgaSource.PREF_SERVER_PROFILE_NAME, currentName)
+                                    ?.trim()
+                                    ?: currentName
+                                val result = serverProfileManager.renameServer(sourceId, requestedName)
+                                if (result.isFailure) {
+                                    context.toast(MR.strings.komga_server_rename_failed)
+                                    return@launch
+                                }
 
-                            deferredDataStore?.putString(
-                                KomgaSource.PREF_SERVER_PROFILE_NAME,
-                                requestedName,
-                            )
-                            deferredDataStore?.applyChanges()
-                            navigator.pop()
+                                deferredDataStore?.putString(
+                                    KomgaSource.PREF_SERVER_PROFILE_NAME,
+                                    requestedName,
+                                )
+                                deferredDataStore?.applyChanges()
+                                navigator.pop()
+                            } finally {
+                                isSaving = false
+                            }
                         }
                     },
                 ) {

--- a/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerSettingsScreen.kt
@@ -46,6 +46,8 @@ class KomgaServerSettingsScreen(
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
         val serverRemovalManager = remember { Injekt.get<KomgaServerRemovalManager>() }
+        val serverProfileManager = remember { Injekt.get<KomgaServerProfileManager>() }
+        val serverPreferences = remember { Injekt.get<KomgaServerPreferences>() }
         val scope = rememberCoroutineScope()
 
         val komgaSource = remember(sourceId) {
@@ -99,10 +101,32 @@ class KomgaServerSettingsScreen(
                         contentDescription = stringResource(MR.strings.komga_server_settings_help_title),
                     )
                 }
-                IconButton(onClick = {
-                    deferredDataStore?.applyChanges()
-                    navigator.pop()
-                }) {
+                IconButton(
+                    onClick = {
+                        scope.launch {
+                            val currentName = serverPreferences.getProfiles()
+                                .find { it.id == sourceId }
+                                ?.name
+                                .orEmpty()
+                            val requestedName = deferredDataStore
+                                ?.getString(KomgaSource.PREF_SERVER_PROFILE_NAME, currentName)
+                                ?.trim()
+                                ?: currentName
+                            val result = serverProfileManager.renameServer(sourceId, requestedName)
+                            if (result.isFailure) {
+                                context.toast(MR.strings.komga_server_rename_failed)
+                                return@launch
+                            }
+
+                            deferredDataStore?.putString(
+                                KomgaSource.PREF_SERVER_PROFILE_NAME,
+                                requestedName,
+                            )
+                            deferredDataStore?.applyChanges()
+                            navigator.pop()
+                        }
+                    },
+                ) {
                     Icon(
                         imageVector = Icons.Default.Save,
                         contentDescription = stringResource(MR.strings.action_save),

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -688,6 +688,7 @@ class KomgaSource(
         private const val BROWSE_REFRESH_WINDOW_MILLIS = 30_000L
 
         private val SERVER_SETTING_KEYS = setOf(
+            PREF_SERVER_PROFILE_NAME,
             PREF_ADDRESS,
             PREF_USERNAME,
             PREF_PASSWORD,

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -356,6 +356,27 @@ class KomgaSource(
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         fetchFilterOptions()
 
+        val serverProfileManager = Injekt.get<KomgaServerProfileManager>()
+        val serverName = Injekt.get<KomgaServerPreferences>()
+            .getProfiles()
+            .find { it.id == id }
+            ?.name
+            ?: name
+        screen.addEditTextPreference(
+            title = screen.context.stringResource(MR.strings.komga_server_name_title),
+            default = serverName,
+            summary = serverName,
+            dialogMessage = screen.context.stringResource(MR.strings.komga_server_name_help),
+            validate = { value ->
+                value.trim().isNotEmpty() &&
+                    serverProfileManager.isDirectoryNameAvailable(value, id)
+            },
+            validationMessage = screen.context.stringResource(MR.strings.komga_server_name_validation),
+            key = PREF_SERVER_PROFILE_NAME,
+            allowBlank = false,
+            showValueAsSummary = true,
+        )
+
         screen.addEditTextPreference(
             title = screen.context.stringResource(MR.strings.komga_pref_address_title),
             default = "",
@@ -659,6 +680,7 @@ class KomgaSource(
     companion object {
         const val SOURCE_NAME = "Komga"
         const val SOURCE_LANG = "all"
+        internal const val PREF_SERVER_PROFILE_NAME = "Koharia server profile name"
         const val SOURCE_VERSION = 1
         const val TYPE_SERIES = "Series"
         const val TYPE_READ_LISTS = "Read lists"
@@ -828,14 +850,23 @@ private fun PreferenceScreen.addEditTextPreference(
     validate: ((String) -> Boolean)? = null,
     validationMessage: String? = null,
     key: String = title,
+    allowBlank: Boolean = true,
+    showValueAsSummary: Boolean = false,
 ): EditTextPreference {
     return EditTextPreference(context).apply {
         this.key = key
         this.title = title
         this.summary = summary
+        if (showValueAsSummary) {
+            summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
+        }
         setDefaultValue(default)
         dialogTitle = title
         this.dialogMessage = dialogMessage
+
+        fun isValidValue(text: String): Boolean {
+            return if (text.isBlank()) allowBlank else validate?.invoke(text) ?: true
+        }
 
         setOnBindEditTextListener { editText ->
             if (inputType != null) {
@@ -848,7 +879,7 @@ private fun PreferenceScreen.addEditTextPreference(
                         override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
                         override fun afterTextChanged(editable: Editable?) {
                             val text = editable?.toString().orEmpty()
-                            val isValid = text.isBlank() || validate(text)
+                            val isValid = isValidValue(text)
                             editText.error = if (!isValid) validationMessage else null
                             editText.rootView.findViewById<Button>(android.R.id.button1)?.isEnabled =
                                 editText.error == null
@@ -860,8 +891,7 @@ private fun PreferenceScreen.addEditTextPreference(
 
         setOnPreferenceChangeListener { _, newValue ->
             val text = newValue as String
-            val isValid = text.isBlank() || validate?.invoke(text) ?: true
-            isValid
+            isValidValue(text)
         }
     }.also(::addPreference)
 }

--- a/app/src/main/res/drawable/sc_book_48dp.xml
+++ b/app/src/main/res/drawable/sc_book_48dp.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/sc_book_48dp">
+    <background android:drawable="@color/accent_blue" />
+    <foreground>
+        <vector
+            android:width="120dp"
+            android:height="120dp"
+            android:viewportWidth="56"
+            android:viewportHeight="56">
+            <group
+                android:translateX="16"
+                android:translateY="16">
+                <path
+                    android:fillColor="#FFF"
+                    android:pathData="M18,2L6,2c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,4c0,-1.1 -0.9,-2 -2,-2zM9,4h2v5l-1,-0.75L9,9L9,4zM18,20L6,20L6,4h1v9l3,-2.25L13,13L13,4h5v16z" />
+            </group>
+        </vector>
+    </foreground>
+</adaptive-icon>

--- a/app/src/main/shortcuts.xml
+++ b/app/src/main/shortcuts.xml
@@ -1,30 +1,6 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
     <shortcut
         android:enabled="true"
-        android:icon="@drawable/sc_collections_bookmark_48dp"
-        android:shortcutDisabledMessage="@string/app_not_available"
-        android:shortcutId="show_library"
-        android:shortcutLongLabel="@string/label_library"
-        android:shortcutShortLabel="@string/label_library">
-        <intent
-            android:action="eu.kanade.tachiyomi.SHOW_LIBRARY"
-            android:targetClass="eu.kanade.tachiyomi.ui.main.MainActivity"
-            android:targetPackage="${applicationId}" />
-    </shortcut>
-    <shortcut
-        android:enabled="true"
-        android:icon="@drawable/sc_new_releases_48dp"
-        android:shortcutDisabledMessage="@string/app_not_available"
-        android:shortcutId="show_recently_updated"
-        android:shortcutLongLabel="@string/label_recent_updates"
-        android:shortcutShortLabel="@string/label_recent_updates">
-        <intent
-            android:action="eu.kanade.tachiyomi.SHOW_RECENTLY_UPDATED"
-            android:targetClass="eu.kanade.tachiyomi.ui.main.MainActivity"
-            android:targetPackage="${applicationId}" />
-    </shortcut>
-    <shortcut
-        android:enabled="true"
         android:icon="@drawable/sc_history_48dp"
         android:shortcutDisabledMessage="@string/app_not_available"
         android:shortcutId="show_recently_read"
@@ -32,18 +8,6 @@
         android:shortcutShortLabel="@string/label_recent_manga">
         <intent
             android:action="eu.kanade.tachiyomi.SHOW_RECENTLY_READ"
-            android:targetClass="eu.kanade.tachiyomi.ui.main.MainActivity"
-            android:targetPackage="${applicationId}" />
-    </shortcut>
-    <shortcut
-        android:enabled="true"
-        android:icon="@drawable/sc_explore_48dp"
-        android:shortcutDisabledMessage="@string/app_not_available"
-        android:shortcutId="show_catalogues"
-        android:shortcutLongLabel="@string/browse"
-        android:shortcutShortLabel="@string/browse">
-        <intent
-            android:action="eu.kanade.tachiyomi.SHOW_CATALOGUES"
             android:targetClass="eu.kanade.tachiyomi.ui.main.MainActivity"
             android:targetPackage="${applicationId}" />
     </shortcut>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -247,8 +247,8 @@
     <string name="komga_server_management_mode_help_title">Mode descriptions</string>
     <string name="komga_server_management_delete_hint">To delete a server, swipe the server row left to reveal the delete action, then confirm the deletion.</string>
     <string name="komga_scoped_settings_disabled_summary">Add or select a server to change server-scoped settings.</string>
-    <string name="komga_pref_address_title">Komga server address</string>
-    <string name="komga_pref_address_summary">The Komga server address</string>
+    <string name="komga_pref_address_title">Server address</string>
+    <string name="komga_pref_address_summary">The server address</string>
     <string name="komga_pref_address_dialog">The address must not end with a forward slash.</string>
     <string name="komga_pref_address_validation">The URL must start with http:// or https://</string>
     <string name="komga_pref_api_key_title">API key</string>
@@ -1294,6 +1294,12 @@
     <string name="komga_action_discard">Discard</string>
     <string name="komga_server_settings_add_title">Add Server</string>
     <string name="komga_server_settings_edit_title">Edit Server</string>
+    <string name="komga_server_name_title">Server name</string>
+    <string name="komga_server_name_help">Used as the server label and its download folder name. Unsupported filename characters are replaced automatically.</string>
+    <string name="komga_server_name_validation">Enter a name whose download folder is not used by another server.</string>
+    <string name="komga_server_rename_failed">The server could not be renamed. Check that the name is unique and the download directory is available.</string>
+    <string name="komga_server_directory_preview">Download folder: %1$s</string>
+    <string name="komga_server_name_directory_conflict">This name maps to a download folder already used by another server.</string>
     <string name="komga_pref_auth_mode_title">Authentication Mode</string>
     <string name="komga_pref_auth_mode_api_key">API Key</string>
     <string name="komga_pref_auth_mode_credentials">Username and Password</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -80,8 +80,8 @@
     <string name="delete_server">删除服务器</string>
     <string name="delete_server_confirmation">确定要删除服务器“%s”吗？</string>
     <string name="komga_server_delete_failed">无法删除服务器，服务器设置已保留，请重试。</string>
-    <string name="komga_pref_address_title">Komga服务器地址</string>
-    <string name="komga_pref_address_summary">Komga 服务器地址</string>
+    <string name="komga_pref_address_title">服务器地址</string>
+    <string name="komga_pref_address_summary">服务器地址</string>
     <string name="komga_pref_address_dialog">地址末尾不能带斜杠。</string>
     <string name="komga_pref_address_validation">URL 必须以 http:// 或 https:// 开头</string>
     <string name="komga_pref_api_key_title">API Key</string>
@@ -1155,6 +1155,12 @@
     <string name="komga_action_discard">放弃</string>
     <string name="komga_server_settings_add_title">添加服务器</string>
     <string name="komga_server_settings_edit_title">修改服务器</string>
+    <string name="komga_server_name_title">服务器名称</string>
+    <string name="komga_server_name_help">用于服务器显示名称和下载目录名称，不支持作为文件名的字符会被自动替换。</string>
+    <string name="komga_server_name_validation">请输入名称，并确保对应下载目录没有被其他服务器使用。</string>
+    <string name="komga_server_rename_failed">服务器重命名失败，请检查名称是否重复以及下载目录是否可用。</string>
+    <string name="komga_server_directory_preview">下载目录：%1$s</string>
+    <string name="komga_server_name_directory_conflict">该名称对应的下载目录已被其他服务器使用。</string>
     <string name="komga_pref_auth_mode_title">验证模式</string>
     <string name="komga_pref_auth_mode_api_key">API Key</string>
     <string name="komga_pref_auth_mode_credentials">用户名和密码</string>


### PR DESCRIPTION
## 中文

### 修改内容

- 将应用版本提升至 `0.2.2`（`versionCode 4`）。
- 按服务器分开的下载目录改用经过安全处理的服务器名称，并兼容迁移旧版 `Komga (ALL)` 及带语言后缀的目录。
- 支持在服务器编辑页直接修改服务器名称；重命名时同步迁移下载目录，并避免名称或目录冲突。
- 优化服务器删除、重命名及配置变化时的下载索引刷新，减少不必要的全量扫描并保持现有下载可用。
- 简化服务器编辑页面，将“Komga 服务器地址”统一为“服务器地址”。
- 桌面长按快捷方式跟随书架分类设置：关闭时显示“书架”，开启时显示“漫画 / 书籍”，并移除废弃的“更新 / 浏览”入口。

### 用户影响

- 多服务器下载目录更清晰，服务器改名后无需手动搬运下载文件。
- 旧版本下载目录可安全延续使用，不覆盖已有目标目录。
- 服务器管理页面更直观，桌面快捷方式与应用当前导航保持一致。

## English

### Changes

- Bump the app version to `0.2.2` (`versionCode 4`).
- Use sanitized server names for per-server download directories and migrate legacy `Komga (ALL)` and language-suffixed directories safely.
- Allow server names to be edited directly from the server settings screen, including coordinated download-directory renaming and conflict prevention.
- Refine download-index refreshes during server deletion, renaming, and profile changes to avoid unnecessary full scans while preserving existing downloads.
- Simplify server settings terminology by renaming “Komga server address” to “Server address”.
- Keep launcher shortcuts aligned with library classification: show Library when disabled, Comics and Books when enabled, and remove obsolete Updates and Browse entries.

### User impact

- Per-server downloads are easier to identify and remain available after server renaming.
- Existing download directories from older versions continue to work without overwriting conflicting targets.
- Server editing is clearer, and launcher shortcuts now match the active app navigation.

## Checks

- `spotlessCheck`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- Android ShortcutManager verification for both classification states
