### PR TITLE
修复服务器删除后状态复用 / Fix deleted server state reuse

### DIFF
--- a/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaLocalConfigManager.kt
@@ -122,13 +122,8 @@ class KomgaLocalConfigManager(
     }
 
     fun clearScopeForServer(serverId: Long) {
-        if (serverPreferences.localConfigMode.get() != LocalConfigMode.Separate) {
-            logcat(LogPriority.DEBUG) {
-                "Skipping scoped config cleanup for serverId=$serverId because local config mode is shared"
-            }
-            return
-        }
-
+        // A server may still have a dedicated scope after switching back to shared mode.
+        // Removing the profile must clear that stale scope without touching shared settings.
         val targetPrefix = serverScopePrefix(serverId)
         val keysToDelete = preferenceStore.getAll().keys.filter { it.startsWith(targetPrefix) }
         if (keysToDelete.isEmpty()) return

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.Json
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
+import kotlin.random.Random
 
 @Serializable
 data class KomgaServerProfile(
@@ -131,6 +132,29 @@ class KomgaServerPreferences(
 
     fun isKnownServerId(serverId: Long): Boolean {
         return serverId == KomgaSource.ID || serverId.toString() in knownServerIds.get()
+    }
+
+    @Synchronized
+    fun allocateServerId(): Long {
+        // Historical IDs remain reserved because preserved manga, downloads, and source stubs
+        // can still reference them after a profile is deleted. Reusing one would also make a
+        // newly added server inherit any ID-keyed state left for those preserved records.
+        val reservedIds = knownServerIds.get()
+            .mapNotNullTo(mutableSetOf(), String::toLongOrNull)
+            .apply {
+                add(KomgaSource.ID)
+                getProfiles().mapTo(this, KomgaServerProfile::id)
+            }
+        val nextSequentialId = reservedIds.maxOrNull()
+            ?.takeIf { it < Long.MAX_VALUE }
+            ?.plus(1)
+        val allocatedId = nextSequentialId ?: generateSequence {
+            Random.nextLong(1, Long.MAX_VALUE)
+        }.first { it !in reservedIds }
+
+        reservedIds += allocatedId
+        knownServerIds.set(reservedIds.mapTo(linkedSetOf()) { it.toString() })
+        return allocatedId
     }
 
     fun needsDownloadDirectoryLayoutMigration(): Boolean {

--- a/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerPreferences.kt
@@ -180,6 +180,7 @@ class KomgaServerPreferences(
         serializedDirectoryAliases.set(updated.mapTo(linkedSetOf(), json::encodeToString))
     }
 
+    @Synchronized
     private fun rememberServerIds(profiles: Collection<KomgaServerProfile>) {
         val updated = knownServerIds.get().toMutableSet().apply {
             add(KomgaSource.ID.toString())

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -57,7 +57,6 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import kotlin.random.Random
 
 class KomgaServerProfilesScreen : Screen() {
 
@@ -87,7 +86,7 @@ class KomgaServerProfilesScreen : Screen() {
 
         fun createServer(name: String) {
             val newProfile = KomgaServerProfile(
-                id = nextServerId(profiles),
+                id = serverPreferences.allocateServerId(),
                 name = name,
             )
             serverPreferences.setProfiles(profiles + newProfile)
@@ -552,25 +551,6 @@ private fun LocalConfigModeOption(
         Column {
             Text(text = title)
             Text(text = summary)
-        }
-    }
-}
-
-private fun nextServerId(profiles: List<KomgaServerProfile>): Long {
-    val existingIds = profiles.mapTo(mutableSetOf(), KomgaServerProfile::id)
-    val maxId = existingIds.maxOrNull()
-
-    if (maxId != null && maxId < Long.MAX_VALUE) {
-        val candidate = maxId + 1
-        if (candidate !in existingIds) {
-            return candidate
-        }
-    }
-
-    while (true) {
-        val candidate = Random.nextLong(1, Long.MAX_VALUE)
-        if (candidate !in existingIds) {
-            return candidate
         }
     }
 }

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -89,7 +89,7 @@ class KomgaServerProfilesScreen : Screen() {
                 id = serverPreferences.allocateServerId(),
                 name = name,
             )
-            serverPreferences.setProfiles(profiles + newProfile)
+            serverPreferences.setProfiles(serverPreferences.getProfiles() + newProfile)
             localConfigManager.initializeScopeForNewServer(newProfile.id)
             serverPreferences.activeServerId.set(newProfile.id)
             navigator.push(

--- a/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerRemovalManager.kt
@@ -45,7 +45,7 @@ class KomgaServerRemovalManager(
                 epubCacheManager.clearServer(serverId)
                 libraryClassificationManager.clearServer(serverId)
                 localConfigManager.clearScopeForServer(serverId)
-                clearServerSettingsIfNeeded(serverId)
+                clearServerSettings(serverId)
             }
             // Read the profiles again after cleanup. The settings screen can edit or add
             // another profile while disk/network cleanup is in progress; filtering by ID
@@ -76,19 +76,14 @@ class KomgaServerRemovalManager(
         }
     }
 
-    private fun clearServerSettingsIfNeeded(serverId: Long) {
-        if (serverPreferences.localConfigMode.get() == LocalConfigMode.Shared) {
-            logcat(LogPriority.DEBUG) {
-                "Skipping persisted source settings cleanup for Komga server id=$serverId because local config mode is shared"
-            }
-            return
-        }
-
+    private fun clearServerSettings(serverId: Long) {
+        // Connection settings always live in source_<id>; local config mode only controls
+        // reader/app preferences and must not decide whether credentials are removed.
         eu.kanade.tachiyomi.source.sourcePreferences("source_$serverId")
             .edit { clear() }
 
         logcat(LogPriority.DEBUG) {
-            "Cleared persisted source settings for Komga server id=$serverId (downloads preserved)"
+            "Cleared persisted source connection settings for Komga server id=$serverId"
         }
     }
 


### PR DESCRIPTION
## 修改内容 / What changed

- 删除 Komga 服务器时，无论本地配置采用共用还是独立模式，都会清除对应的服务器地址、用户名、密码和 API Key。
- 清理服务器曾经使用过的独立本地配置，即使用户删除前已经切换回共用配置模式。
- 为新服务器分配从未使用过的 ID，避免复用已删除服务器及其保留内容所引用的历史 ID。
- 保留现有下载文件策略；删除服务器时选择保留的下载不会被本次修改删除。

- Clear the removed Komga server's address, username, password, and API key regardless of whether local configuration is shared or separate.
- Remove stale per-server local configuration even if the user switched back to shared mode before deleting the server.
- Allocate a never-used ID for every new server so it cannot inherit a deleted server's identity or ID-scoped state.
- Preserve the existing download retention behavior; downloads explicitly kept during server removal are not deleted by this change.

## 原因 / Root cause

新服务器 ID 之前只避开当前存在的服务器，因此删除最高 ID 的服务器后，该 ID 可能立即被再次分配。同时，共用本地配置模式会跳过 `source_<serverId>` 的清理，但服务器连接信息实际始终保存在该文件中。两者组合后，重新添加服务器会读到已删除服务器的连接信息和相关状态。

Server IDs previously avoided only active profiles, allowing the highest deleted ID to be allocated again. Server removal also skipped clearing `source_<serverId>` in shared local-config mode even though connection settings always live there. Together, these behaviors caused a newly added server to inherit the deleted server's connection details and ID-scoped state.

## 用户影响 / User impact

删除服务器后重新添加服务器，将获得全新的身份和空白连接配置，不再自动复用旧服务器信息。历史 ID 仍保持保留，以确保既有漫画、StubSource 与保留下载的引用不会错误指向新服务器。

After a server is removed, adding another server now starts with a fresh identity and blank connection settings. Historical IDs remain reserved so existing manga, source stubs, and preserved download references cannot be reassigned to the new server.

## 验证 / Validation

- `./gradlew.bat :app:compileDebugKotlin`
- `./gradlew.bat spotlessCheck`
