### PR TITLE
适配多语言 Koharia 文档链接 / Localize Koharia documentation links

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/GuidesStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/GuidesStep.kt
@@ -10,10 +10,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.theme.TachiyomiPreviewTheme
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
@@ -26,6 +28,7 @@ internal class GuidesStep(
 
     @Composable
     override fun Content() {
+        val context = LocalContext.current
         val handler = LocalUriHandler.current
 
         Column(
@@ -35,7 +38,7 @@ internal class GuidesStep(
             Text(stringResource(MR.strings.onboarding_guides_new_user, stringResource(MR.strings.app_name)))
             Button(
                 modifier = Modifier.fillMaxWidth(),
-                onClick = { handler.openUri(GETTING_STARTED_URL) },
+                onClick = { handler.openUri(DocumentationUrls.gettingStarted(context)) },
             ) {
                 Text(stringResource(MR.strings.getting_started_guide))
             }
@@ -55,8 +58,6 @@ internal class GuidesStep(
         }
     }
 }
-
-const val GETTING_STARTED_URL = "https://koharia.app/docs/guides/getting-started"
 
 @PreviewLightDark
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/StorageStep.kt
@@ -77,7 +77,7 @@ internal class StorageStep : OnboardingStep {
             Text(stringResource(MR.strings.onboarding_storage_help_info, stringResource(MR.strings.app_name)))
             Button(
                 modifier = Modifier.fillMaxWidth(),
-                onClick = { handler.openUri(SettingsDataScreen.HELP_URL) },
+                onClick = { handler.openUri(SettingsDataScreen.helpUrl(context)) },
             ) {
                 Text(stringResource(MR.strings.onboarding_storage_help_action))
             }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsDataScreen.kt
@@ -67,6 +67,7 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.displayablePath
 import tachiyomi.core.common.util.lang.launchNonCancellable
@@ -88,7 +89,7 @@ import uy.kohesive.injekt.api.get
 object SettingsDataScreen : SearchableSettings {
 
     val restorePreferenceKeyString = MR.strings.label_backup
-    const val HELP_URL = "https://koharia.app/docs/faq/storage"
+    fun helpUrl(context: Context) = DocumentationUrls.storage(context)
 
     @ReadOnlyComposable
     @Composable
@@ -96,8 +97,9 @@ object SettingsDataScreen : SearchableSettings {
 
     @Composable
     override fun RowScope.AppBarAction() {
+        val context = LocalContext.current
         val uriHandler = LocalUriHandler.current
-        IconButton(onClick = { uriHandler.openUri(HELP_URL) }) {
+        IconButton(onClick = { uriHandler.openUri(helpUrl(context)) }) {
             Icon(
                 imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                 contentDescription = stringResource(MR.strings.tracking_guide),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -39,6 +39,7 @@ import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.updaterEnabled
 import kotlinx.coroutines.launch
 import logcat.LogPriority
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
@@ -154,7 +155,7 @@ object AboutScreen : Screen() {
                 item {
                     TextPreferenceWidget(
                         title = stringResource(MR.strings.privacy_policy),
-                        onPreferenceClick = { uriHandler.openUri("https://koharia.app/privacy/") },
+                        onPreferenceClick = { uriHandler.openUri(DocumentationUrls.privacy(context)) },
                     )
                 }
 

--- a/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/webview/WebViewScreenContent.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -53,6 +54,7 @@ import eu.kanade.tachiyomi.util.system.getHtml
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.i18n.stringResource
@@ -80,6 +82,7 @@ fun WebViewScreenContent(
     onUrlChange: (String) -> Unit = {},
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
 
     val windowStack = remember {
         mutableStateStackOf(
@@ -297,7 +300,7 @@ fun WebViewScreenContent(
                                     .clip(MaterialTheme.shapes.small)
                                     .clickable {
                                         uriHandler.openUri(
-                                            "https://koharia.app/docs/guides/troubleshooting/#cloudflare",
+                                            DocumentationUrls.troubleshooting(context),
                                         )
                                     },
                             )

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -6,7 +6,6 @@ import eu.kanade.domain.chapter.model.toSChapter
 import eu.kanade.domain.manga.model.getComicInfo
 import eu.kanade.tachiyomi.data.cache.ChapterCache
 import eu.kanade.tachiyomi.data.download.model.Download
-import eu.kanade.tachiyomi.data.library.LibraryUpdateNotifier
 import eu.kanade.tachiyomi.data.notification.NotificationHandler
 import eu.kanade.tachiyomi.source.UnmeteredSource
 import eu.kanade.tachiyomi.source.model.Page
@@ -43,6 +42,7 @@ import kotlinx.coroutines.supervisorScope
 import logcat.LogPriority
 import nl.adaptivity.xmlutil.serialization.XML
 import okhttp3.Response
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.util.lang.launchIO
@@ -433,7 +433,7 @@ class Downloader(
                             context.stringResource(MR.strings.app_name),
                         ),
                         WARNING_NOTIF_TIMEOUT_MS,
-                        NotificationHandler.openUrl(context, LibraryUpdateNotifier.HELP_WARNING_URL),
+                        NotificationHandler.openUrl(context, DocumentationUrls.library(context)),
                     )
                 }
                 DownloadJob.start(context)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.preference.getAndSet
 import tachiyomi.core.common.util.lang.withIOContext
@@ -380,7 +381,12 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             if (errors.isNotEmpty()) {
                 val file = context.createFileInCacheDir("mihon_update_errors.txt")
                 file.bufferedWriter().use { out ->
-                    out.write(context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n")
+                    out.write(
+                        context.stringResource(
+                            MR.strings.library_errors_help,
+                            DocumentationUrls.troubleshooting(context),
+                        ) + "\n\n",
+                    )
                     // Error file format:
                     // ! Error
                     //   # Source
@@ -406,8 +412,6 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         private const val TAG = "LibraryUpdate"
         private const val WORK_NAME_AUTO = "LibraryUpdate-auto"
         private const val WORK_NAME_MANUAL = "LibraryUpdate-manual"
-
-        private const val ERROR_LOG_HELP_URL = "https://koharia.app/docs/guides/troubleshooting/"
 
         private const val MANGA_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 60
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotifier.kt
@@ -29,6 +29,7 @@ import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
 import tachiyomi.core.common.Constants
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.i18n.pluralStringResource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.domain.chapter.model.Chapter
@@ -133,7 +134,7 @@ class LibraryUpdateNotifier(
             )
             setSmallIcon(R.drawable.ic_warning_white_24dp)
             setTimeoutAfter(Downloader.WARNING_NOTIF_TIMEOUT_MS)
-            setContentIntent(NotificationHandler.openUrl(context, HELP_WARNING_URL))
+            setContentIntent(NotificationHandler.openUrl(context, DocumentationUrls.library(context)))
         }
     }
 
@@ -372,11 +373,6 @@ class LibraryUpdateNotifier(
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-    }
-
-    companion object {
-        const val HELP_WARNING_URL =
-            "https://koharia.app/docs/faq/library#why-am-i-warned-about-large-bulk-updates-and-downloads"
     }
 }
 

--- a/app/src/main/java/koharia/feature/upcoming/UpcomingScreenContent.kt
+++ b/app/src/main/java/koharia/feature/upcoming/UpcomingScreenContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -30,7 +31,7 @@ import koharia.feature.upcoming.components.calendar.Calendar
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.coroutines.launch
-import tachiyomi.core.common.Constants
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.FastScrollLazyColumn
@@ -90,13 +91,14 @@ fun UpcomingScreenContent(
 @Composable
 private fun UpcomingToolbar() {
     val navigator = LocalNavigator.currentOrThrow
+    val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
 
     AppBar(
         title = stringResource(MR.strings.label_upcoming),
         navigateUp = navigator::pop,
         actions = {
-            IconButton(onClick = { uriHandler.openUri(Constants.URL_HELP_UPCOMING) }) {
+            IconButton(onClick = { uriHandler.openUri(DocumentationUrls.library(context)) }) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                     contentDescription = stringResource(MR.strings.upcoming_guide),

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.IntOffset
@@ -63,7 +64,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
-import tachiyomi.core.common.Constants
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.source.interactor.GetRemoteManga
@@ -165,6 +166,7 @@ data class KomgaLibraryScreen(
         }
 
         val uriHandler = LocalUriHandler.current
+        val context = LocalContext.current
         val snackbarHostState = remember { SnackbarHostState() }
         val mangaList = screenModel.mangaPagerFlow.collectAsLazyPagingItems()
         val isRefreshing =
@@ -182,7 +184,7 @@ data class KomgaLibraryScreen(
             }
         }
 
-        val onHelpClick = { uriHandler.openUri(Constants.URL_HELP) }
+        val onHelpClick = { uriHandler.openUri(DocumentationUrls.troubleshooting(context)) }
         val onWebViewClick = f@{
             val source = screenModel.source as? HttpSource ?: return@f
             navigator.push(

--- a/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/Constants.kt
@@ -1,8 +1,6 @@
 package tachiyomi.core.common
 
 object Constants {
-    const val URL_HELP = "https://koharia.app/docs/guides/troubleshooting/"
-    const val URL_HELP_UPCOMING = "https://koharia.app/docs/faq/updates/upcoming"
     const val URL_DONATE_IFDIAN = "https://ifdian.net/a/album-Koharia"
     const val URL_DONATE_PATREON = "https://patreon.com/mihon/membership"
     const val URL_DONATE_OPENCOLLECTIVE = "https://opencollective.com/mihon/contribute"

--- a/core/common/src/main/kotlin/tachiyomi/core/common/DocumentationUrls.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/DocumentationUrls.kt
@@ -1,0 +1,27 @@
+package tachiyomi.core.common
+
+import android.content.Context
+import java.util.Locale
+
+object DocumentationUrls {
+
+    fun gettingStarted(context: Context) = localized(context, "docs/guides/getting-started")
+
+    fun troubleshooting(context: Context) = localized(context, "docs/guides/troubleshooting/")
+
+    fun library(context: Context) = localized(context, "docs/faq/library")
+
+    fun storage(context: Context) = localized(context, "docs/faq/storage")
+
+    fun privacy(context: Context) = localized(context, "privacy/")
+
+    private fun localized(context: Context, path: String): String {
+        val locales = context.resources.configuration.locales
+        val language = if (locales.isEmpty) Locale.getDefault().language else locales[0].language
+        val localePath = if (language.lowercase(Locale.ROOT) in CHINESE_LANGUAGE_CODES) "zh" else "en"
+        return "$BASE_URL/$localePath/$path"
+    }
+
+    private const val BASE_URL = "https://koharia.org"
+    private val CHINESE_LANGUAGE_CODES = setOf("zh", "zho", "chi")
+}

--- a/core/common/src/main/kotlin/tachiyomi/core/common/DocumentationUrls.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/DocumentationUrls.kt
@@ -23,5 +23,20 @@ object DocumentationUrls {
     }
 
     private const val BASE_URL = "https://koharia.org"
-    private val CHINESE_LANGUAGE_CODES = setOf("zh", "zho", "chi")
+
+    // Include common ISO codes for Chinese macrolanguage varieties in addition to
+    // Simplified/Traditional BCP 47 tags, whose normalized language is `zh`.
+    private val CHINESE_LANGUAGE_CODES = setOf(
+        "zh",
+        "zho",
+        "chi",
+        "cmn",
+        "yue",
+        "wuu",
+        "hak",
+        "nan",
+        "gan",
+        "hsn",
+        "lzh",
+    )
 }

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -2,4 +2,4 @@
 
 This module houses the string resources and translations.
 
-Original English strings are managed in `src/commonMain/moko-resources/base/`. Translations are done externally via Weblate. See [our website](https://koharia.app/docs/contribute#translation) for more details. 
+Original English strings are managed in `src/commonMain/moko-resources/base/`. Translations are done externally via Weblate. See [our website](https://koharia.org/en/docs/contribute) for more details.

--- a/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
+++ b/source-local/src/androidMain/kotlin/tachiyomi/source/local/LocalSource.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.decodeFromStream
 import logcat.LogPriority
 import nl.adaptivity.xmlutil.core.AndroidXmlReader
 import nl.adaptivity.xmlutil.serialization.XML
+import tachiyomi.core.common.DocumentationUrls
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.extension
 import tachiyomi.core.common.storage.nameWithoutExtension
@@ -363,7 +364,7 @@ actual class LocalSource(
 
     companion object {
         const val ID = 0L
-        const val HELP_URL = "https://koharia.app/docs/guides/local-source/"
+        fun helpUrl(context: Context) = DocumentationUrls.storage(context)
 
         private val LATEST_THRESHOLD = 7.days.inWholeMilliseconds
     }


### PR DESCRIPTION
## 修改内容 / What changed

- 将应用内帮助、引导、隐私政策和 FAQ 链接从历史 `koharia.app` 域名迁移到 `koharia.org`。
- 新增统一的文档 URL 解析器，避免各页面分别硬编码域名和语言路径。
- 当前 App 语言属于广义中文时自动打开 `/zh/` 页面，包括简体、繁体以及 `zh-Hans`、`zh-Hant`、`zh-CN`、`zh-TW`、`zh-HK` 等中文区域和书写系统变体。
- 其他语言统一打开 `/en/` 页面。
- 覆盖新手引导、故障排查、阅读库与更新、存储、隐私、WebView 帮助、下载警告、通知和错误日志中的公开文档入口。
- 将英文 i18n 说明文档中的贡献链接指向英文站。

- Migrate in-app help, onboarding, privacy, and FAQ links from the historical `koharia.app` domain to `koharia.org`.
- Add a centralized documentation URL resolver so individual screens no longer hardcode the domain or locale path.
- Open `/zh/` pages whenever the current app language belongs to the broader Chinese language family, including Simplified, Traditional, `zh-Hans`, `zh-Hant`, `zh-CN`, `zh-TW`, and `zh-HK` variants.
- Open `/en/` pages for all other app languages.
- Apply the behavior to onboarding, troubleshooting, library/update guidance, storage, privacy, WebView help, download warnings, notifications, and generated error logs.
- Point the English i18n documentation contribution link to the English website.

## 原因 / Why

Koharia 的公开网站已迁移到 `koharia.org`，并要求站外入口使用明确的 `/zh/` 或 `/en/` 路径。此前应用内链接固定使用旧域名或中文路径，无法跟随用户选择的 App 语言。

Koharia's public website has moved to `koharia.org`, and external entry points must use an explicit `/zh/` or `/en/` path. The previous in-app URLs used the old domain or a fixed Chinese route and therefore could not follow the user's selected app language.

## 用户影响 / User impact

中文用户会直接进入中文文档；使用其他语言的用户会进入英文文档。链接不依赖网站根路径重定向，也不会因系统语言与 App 语言不同而固定打开错误语言页面。

Chinese-language users are taken directly to Chinese documentation, while all other users are taken to English documentation. Links no longer depend on root redirects and follow the app resource locale used by each screen or background task.

## 验证 / Validation

- `./gradlew.bat spotlessApply`
- 静态检查确认旧文档 URL 常量引用为零。
- 静态检查确认 App 内只保留统一的 `https://koharia.org` 基础域名。
- 按快速开发约定，本次未运行构建。

- `./gradlew.bat spotlessApply`
- Static scan confirmed that legacy documentation URL constants have no remaining references.
- Static scan confirmed that in-app URLs use the centralized `https://koharia.org` base domain.
- A full build was intentionally not run under the current rapid-development workflow.
