### PR TITLE
优化 EPUB 平板排版与标题缩进 / Improve EPUB tablet layout and heading indentation

### DIFF
--- a/app/src/main/java/koharia/epub/EpubNavigatorConfiguration.kt
+++ b/app/src/main/java/koharia/epub/EpubNavigatorConfiguration.kt
@@ -1,0 +1,26 @@
+package koharia.epub
+
+import org.readium.r2.navigator.epub.EpubNavigatorFragment
+import org.readium.r2.navigator.epub.css.Length
+import org.readium.r2.navigator.epub.css.RsProperties
+import org.readium.r2.shared.ExperimentalReadiumApi
+
+/**
+ * Keeps the visible navigator and the pagination scanner on the same Readium CSS geometry.
+ *
+ * Readium defaults the document body to a 40rem maximum line length. That is effectively
+ * full-width on phones, but leaves a narrow centered column on portrait tablets and can make
+ * chapter headings wrap prematurely. A wider cap lets tablet pages use their reading area while
+ * Readium's page-gutter preference still provides the user-selected horizontal margins.
+ */
+@OptIn(ExperimentalReadiumApi::class)
+internal fun epubNavigatorConfiguration(): EpubNavigatorFragment.Configuration {
+    return EpubNavigatorFragment.Configuration(
+        readiumCssRsProperties = RsProperties(
+            maxLineLength = Length.Rem(EPUB_MAX_LINE_LENGTH_REM),
+        ),
+        shouldApplyInsetsPadding = false,
+    )
+}
+
+private const val EPUB_MAX_LINE_LENGTH_REM = 80.0

--- a/app/src/main/java/koharia/epub/EpubPaginationModels.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationModels.kt
@@ -122,5 +122,5 @@ private fun String.sha256(): String {
         .joinToString("") { byte -> "%02x".format(byte) }
 }
 
-private const val PAGINATION_ALGORITHM_VERSION = 3
+private const val PAGINATION_ALGORITHM_VERSION = 5
 private const val READIUM_VERSION = "3.3.0"

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -98,9 +98,7 @@ internal class EpubPaginationScannerFragment : Fragment() {
                 publicationMetadata = session.publication.metadata,
             ),
             paginationListener = paginationListener,
-            configuration = EpubNavigatorFragment.Configuration(
-                shouldApplyInsetsPadding = false,
-            ),
+            configuration = epubNavigatorConfiguration(),
         ) ?: EpubNavigatorFragment.createDummyFactory()
         super.onCreate(savedInstanceState)
     }

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -40,13 +40,14 @@ internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
             if (isStructuralParagraph) {
                 paragraph.setAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE', '');
                 Array.from(paragraph.children).forEach(function(child) {
+                    if (child.tagName.toLowerCase() !== 'span') return;
                     var childStyle = window.getComputedStyle(child);
-                    var paragraphStyle = window.getComputedStyle(paragraph);
                     var horizontalPadding = parseFloat(childStyle.paddingLeft) + parseFloat(childStyle.paddingRight);
-                    var hasOrphanedPadding = child.tagName.toLowerCase() === 'span' &&
-                        childStyle.display === 'inline' && horizontalPadding > 0 &&
-                        childStyle.backgroundColor === 'rgba(0, 0, 0, 0)' &&
-                        childStyle.color === paragraphStyle.color;
+                    var hasTransparentBackground =
+                        childStyle.backgroundColor === 'rgba(0, 0, 0, 0)' ||
+                        childStyle.backgroundColor === 'transparent';
+                    var hasOrphanedPadding = childStyle.display === 'inline' && horizontalPadding > 0 &&
+                        hasTransparentBackground && childStyle.color === computed.color;
                     if (hasOrphanedPadding) {
                         child.setAttribute('$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE', '');
                     }

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -1,8 +1,17 @@
 package koharia.epub
 
 internal const val EPUB_PARAGRAPH_INDENT_STYLE_ID = "koharia-paragraph-indent"
+internal const val EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE = "data-koharia-no-paragraph-indent"
+internal const val EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE = "data-koharia-orphaned-inline-padding"
+
+// Readium's paragraph preference targets every <p>. A higher-specificity exception keeps
+// paragraph-shaped headings, signatures and media containers from inheriting body indentation.
 internal const val EPUB_PARAGRAPH_INDENT_CSS =
-    "p { text-indent: var(--USER__paraIndent, 2rem) !important; }"
+    "html:root:root:root p:not([$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE]) { " +
+        "text-indent: var(--USER__paraIndent, 2rem) !important; " +
+        "} html:root:root:root p[$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE] { text-indent: 0 !important; } " +
+        "html:root:root:root [$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE] { " +
+        "padding: 0 !important; vertical-align: baseline !important; }"
 
 internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
     """(function() {
@@ -14,6 +23,36 @@ internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
             (document.head || document.documentElement).appendChild(style);
         }
         style.textContent = '$EPUB_PARAGRAPH_INDENT_CSS';
+        Array.from(document.querySelectorAll('[$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE]')).forEach(function(element) {
+            element.removeAttribute('$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE');
+        });
+        Array.from(document.querySelectorAll('p')).forEach(function(paragraph) {
+            paragraph.removeAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE');
+            var computed = window.getComputedStyle(paragraph);
+            var textAlign = (computed.textAlign || '').toLowerCase();
+            var role = (paragraph.getAttribute('role') || '').toLowerCase();
+            var epubType = (paragraph.getAttribute('epub:type') || '').toLowerCase();
+            var hasOnlyMedia = paragraph.textContent.trim() === '' &&
+                paragraph.querySelector('img, svg, picture, video, audio, figure, table');
+            var isStructuralParagraph =
+                textAlign === 'center' || textAlign === 'right' || textAlign === 'end' ||
+                role === 'heading' || epubType.indexOf('title') !== -1 || hasOnlyMedia;
+            if (isStructuralParagraph) {
+                paragraph.setAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE', '');
+                Array.from(paragraph.children).forEach(function(child) {
+                    var childStyle = window.getComputedStyle(child);
+                    var paragraphStyle = window.getComputedStyle(paragraph);
+                    var horizontalPadding = parseFloat(childStyle.paddingLeft) + parseFloat(childStyle.paddingRight);
+                    var hasOrphanedPadding = child.tagName.toLowerCase() === 'span' &&
+                        childStyle.display === 'inline' && horizontalPadding > 0 &&
+                        childStyle.backgroundColor === 'rgba(0, 0, 0, 0)' &&
+                        childStyle.color === paragraphStyle.color;
+                    if (hasOrphanedPadding) {
+                        child.setAttribute('$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE', '');
+                    }
+                });
+            }
+        });
         return true;
     })()"""
 
@@ -21,6 +60,12 @@ internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
     """(function() {
         var style = document.getElementById('$EPUB_PARAGRAPH_INDENT_STYLE_ID');
         if (style) style.remove();
+        Array.from(document.querySelectorAll('p[$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE]')).forEach(function(paragraph) {
+            paragraph.removeAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE');
+        });
+        Array.from(document.querySelectorAll('[$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE]')).forEach(function(element) {
+            element.removeAttribute('$EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE');
+        });
         return true;
     })()"""
 

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -119,9 +119,7 @@ class EpubReaderFragment : Fragment() {
             ),
             listener = navigatorListener,
             paginationListener = paginationListener,
-            configuration = EpubNavigatorFragment.Configuration(
-                shouldApplyInsetsPadding = false,
-            ),
+            configuration = epubNavigatorConfiguration(),
         ) ?: EpubNavigatorFragment.createDummyFactory()
         super.onCreate(savedInstanceState)
     }

--- a/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
@@ -52,7 +52,7 @@ class EpubLayoutPreferences(
         preferenceStore.getEnum("epub_layout_font_family", FontFamily.ORIGINAL)
 
     val publisherStyles: Preference<Boolean> =
-        preferenceStore.getBoolean("epub_layout_publisher_styles", false)
+        preferenceStore.getBoolean("epub_layout_publisher_styles", true)
 
     val readWithVolumeKeys: Preference<Boolean> =
         preferenceStore.getBoolean("epub_layout_volume_keys", true)

--- a/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
@@ -23,13 +23,13 @@ class EpubReaderPreferenceDefaultsTest {
     }
 
     @Test
-    fun `EPUB typography defaults to standard spacing without publisher styles`() {
+    fun `EPUB typography defaults to standard spacing with publisher styles`() {
         val preferences = EpubLayoutPreferences(InMemoryPreferenceStore())
 
         assertEquals(EpubLayoutPreferences.SpacingMode.STANDARD, preferences.spacingMode.get())
         assertEquals(1.7f, preferences.lineHeight.get())
         assertEquals(0.05f, preferences.paragraphSpacing.get())
-        assertFalse(preferences.publisherStyles.get())
+        assertTrue(preferences.publisherStyles.get())
     }
 
     @Test


### PR DESCRIPTION
## 中文

### 修改内容

- 放宽 Readium 在平板上的正文宽度上限，使 EPUB 内容更充分利用左右阅读区域，同时保留用户设置的页边距。
- 统一可见阅读器与隐藏分页器的排版参数，保证显示结果与视觉页数计算一致。
- 关闭出版商样式时，仅对正文段落应用统一首行缩进，避免章节标题、右对齐署名和纯媒体段落被错误缩进。
- 清理标题装饰颜色被移除后残留的无意义内边距，修正标题文字间距和位置。
- 将出版商样式改为默认开启；已有用户明确保存的设置不会被覆盖。
- 更新分页算法版本，使旧布局生成的分页缓存自动失效。

### 原因与影响

Readium 默认将正文最大行宽限制为 `40rem`，在平板上会形成明显的左右留白。同时，统一首行缩进此前会作用于所有 `<p>` 元素，覆盖部分书籍标题原有的零缩进样式。本次修改改善平板阅读空间利用率，并确保正文缩进不会破坏结构性内容的排版。

### 检查

- `spotlessApply`
- `:app:compileDebugKotlin`
- `EpubReaderPreferenceDefaultsTest`

## English

### Changes

- Increase Readium's maximum content width on tablets so EPUB pages use more of the available reading area while preserving user-configured margins.
- Share the same layout configuration between the visible navigator and the hidden pagination scanner.
- Apply uniform first-line indentation only to body paragraphs when publisher styles are disabled, excluding headings, right-aligned signatures, and media-only paragraphs.
- Remove orphaned inline padding left behind when decorative publisher colors are suppressed.
- Enable publisher styles by default without overriding an existing explicit user preference.
- Invalidate pagination caches created with the previous layout geometry.

### Why

Readium's default `40rem` line-width cap creates excessive side whitespace on tablets. The previous global paragraph rule also overrode zero-indent styles on title paragraphs. These changes improve tablet space usage and keep structural content aligned correctly.

### Checks

- `spotlessApply`
- `:app:compileDebugKotlin`
- `EpubReaderPreferenceDefaultsTest`
