### PR TITLE
EPUB 连续滚动章节衔接 / Seamless EPUB chapter flow

### DIFF
--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -1,0 +1,345 @@
+package koharia.epub
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+internal data class EpubContinuousScrollResource(
+    val index: Int,
+    val href: String,
+    val url: String,
+)
+
+/**
+ * Builds a virtualized vertical reading order inside Readium's current resource WebView.
+ *
+ * Readium's scroll mode only scrolls one XHTML resource at a time and keeps resource changes in a
+ * horizontal ViewPager. The script keeps the current XHTML in place, inserts same-origin iframes
+ * for adjacent resources and retains measured placeholders for the rest of the reading order. Only
+ * the resources around the visible section stay live (in addition to Readium's original document),
+ * so long books do not keep every XHTML document in memory. The native bridge receives the visible
+ * resource and its local progression, allowing the existing Locator/progress pipeline to remain
+ * authoritative.
+ */
+internal fun buildEpubContinuousScrollInstallScript(
+    resources: List<EpubContinuousScrollResource>,
+    currentIndex: Int,
+    initialProgression: Double,
+    paragraphIndentScript: String,
+): String {
+    val resourcesJson = JSONArray().apply {
+        resources.forEach { resource ->
+            put(
+                JSONObject().apply {
+                    put("index", resource.index)
+                    put("href", resource.href)
+                    put("url", resource.url)
+                },
+            )
+        }
+    }
+    val indentScriptJson = JSONObject.quote(paragraphIndentScript)
+    val clampedProgression = initialProgression.coerceIn(0.0, 1.0)
+
+    return """
+        (function() {
+            const resources = $resourcesJson;
+            const currentIndex = $currentIndex;
+            const initialProgression = $clampedProgression;
+            const requestedParagraphIndentScript = $indentScriptJson;
+            const existing = window.__kohariaContinuousScroll;
+            if (existing && existing.currentIndex === currentIndex) {
+                existing.refresh(requestedParagraphIndentScript);
+                return 'ready';
+            }
+            if (!document.body || !resources.length || currentIndex < 0 || currentIndex >= resources.length) {
+                return 'unavailable';
+            }
+
+            const scrolling = document.scrollingElement || document.documentElement;
+            const originalScrollTop = scrolling.scrollTop;
+            const viewportHeight = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
+            const measuredHeights = new Map();
+            const liveFrames = new Map();
+            let activeIndex = currentIndex;
+            let locationFrame = 0;
+            let lastLocationSentAt = 0;
+            let paragraphIndentScript = requestedParagraphIndentScript;
+
+            const style = document.createElement('style');
+            style.id = 'koharia-continuous-scroll-style';
+            style.textContent = `
+                html { height: auto !important; min-height: 100% !important; overflow-y: auto !important; }
+                body { height: auto !important; min-height: 100% !important; overflow: visible !important; }
+                #koharia-continuous-before, #koharia-continuous-after {
+                    display: block !important;
+                    width: 100% !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                }
+                .koharia-continuous-resource {
+                    display: block !important;
+                    position: relative !important;
+                    width: 100% !important;
+                    min-width: 0 !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                    border: 0 !important;
+                    overflow: hidden !important;
+                    background: transparent !important;
+                }
+                .koharia-continuous-resource > iframe {
+                    display: block !important;
+                    width: 100% !important;
+                    min-width: 0 !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                    border: 0 !important;
+                    overflow: hidden !important;
+                    background: transparent !important;
+                }
+                .koharia-continuous-marker {
+                    display: block !important;
+                    width: 100% !important;
+                    height: 0 !important;
+                    margin: 0 !important;
+                    padding: 0 !important;
+                    border: 0 !important;
+                }
+            `;
+            (document.head || document.documentElement).appendChild(style);
+
+            const before = document.createElement('div');
+            before.id = 'koharia-continuous-before';
+            const currentStart = document.createElement('div');
+            currentStart.id = 'koharia-continuous-current-start';
+            currentStart.className = 'koharia-continuous-marker';
+            const currentEnd = document.createElement('div');
+            currentEnd.id = 'koharia-continuous-current-end';
+            currentEnd.className = 'koharia-continuous-marker';
+            const after = document.createElement('div');
+            after.id = 'koharia-continuous-after';
+
+            document.body.insertBefore(before, document.body.firstChild);
+            document.body.insertBefore(currentStart, before.nextSibling);
+            document.body.appendChild(currentEnd);
+            document.body.appendChild(after);
+
+            function createPlaceholder(resource) {
+                const section = document.createElement('section');
+                section.className = 'koharia-continuous-resource';
+                section.dataset.resourceIndex = String(resource.index);
+                section.style.height = viewportHeight + 'px';
+                measuredHeights.set(resource.index, viewportHeight);
+                return section;
+            }
+
+            const sections = new Map();
+            for (let index = 0; index < resources.length; index += 1) {
+                if (index === currentIndex) continue;
+                const section = createPlaceholder(resources[index]);
+                sections.set(index, section);
+                if (index < currentIndex) before.appendChild(section);
+                else after.appendChild(section);
+            }
+
+            // Prepending earlier resources must not move the initially restored reading position.
+            scrolling.scrollTop = originalScrollTop + before.getBoundingClientRect().height;
+
+            function sectionBounds(index) {
+                if (index === currentIndex) {
+                    const top = currentStart.getBoundingClientRect().top + scrolling.scrollTop;
+                    const bottom = currentEnd.getBoundingClientRect().top + scrolling.scrollTop;
+                    return { top: top, bottom: Math.max(top + 1, bottom), height: Math.max(1, bottom - top) };
+                }
+                const section = sections.get(index);
+                if (!section) return null;
+                const rect = section.getBoundingClientRect();
+                const top = rect.top + scrolling.scrollTop;
+                return { top: top, bottom: top + rect.height, height: Math.max(1, rect.height) };
+            }
+
+            function updateSectionHeight(index, nextHeight) {
+                const section = sections.get(index);
+                if (!section) return;
+                const safeHeight = Math.max(viewportHeight, Math.ceil(nextHeight || viewportHeight));
+                const oldHeight = measuredHeights.get(index) || viewportHeight;
+                if (Math.abs(safeHeight - oldHeight) < 1) return;
+                const wasAboveViewport = section.getBoundingClientRect().bottom <= 1;
+                measuredHeights.set(index, safeHeight);
+                section.style.height = safeHeight + 'px';
+                const iframe = liveFrames.get(index);
+                if (iframe) iframe.style.height = safeHeight + 'px';
+                if (wasAboveViewport) scrolling.scrollTop += safeHeight - oldHeight;
+            }
+
+            function measureFrame(index, iframe) {
+                try {
+                    const doc = iframe.contentDocument;
+                    if (!doc || !doc.documentElement) return;
+                    doc.documentElement.style.setProperty('height', 'auto', 'important');
+                    doc.documentElement.style.setProperty('overflow', 'hidden', 'important');
+                    if (doc.body) {
+                        doc.body.style.setProperty('height', 'auto', 'important');
+                        doc.body.style.setProperty('overflow', 'hidden', 'important');
+                    }
+                    try { iframe.contentWindow.eval(paragraphIndentScript); } catch (_) {}
+                    const height = Math.max(
+                        doc.documentElement.scrollHeight || 0,
+                        doc.body ? doc.body.scrollHeight || 0 : 0,
+                        viewportHeight,
+                    );
+                    updateSectionHeight(index, height);
+                } catch (_) {
+                    // A publication with mixed origins cannot be stitched safely. Its placeholder
+                    // remains available and native navigation continues to work as a fallback.
+                }
+            }
+
+            function loadSection(index) {
+                if (index === currentIndex || index < 0 || index >= resources.length || liveFrames.has(index)) return;
+                const section = sections.get(index);
+                if (!section) return;
+                const iframe = document.createElement('iframe');
+                iframe.setAttribute('scrolling', 'no');
+                iframe.setAttribute('frameborder', '0');
+                iframe.setAttribute('title', resources[index].href || '');
+                iframe.style.height = (measuredHeights.get(index) || viewportHeight) + 'px';
+                iframe.addEventListener('load', function() {
+                    measureFrame(index, iframe);
+                    try {
+                        const doc = iframe.contentDocument;
+                        const observer = new ResizeObserver(function() { measureFrame(index, iframe); });
+                        observer.observe(doc.documentElement);
+                        if (doc.body) observer.observe(doc.body);
+                        iframe.__kohariaResizeObserver = observer;
+                        Array.from(doc.images || []).forEach(function(image) {
+                            if (!image.complete) image.addEventListener('load', function() { measureFrame(index, iframe); }, { once: true });
+                        });
+                    } catch (_) {}
+                });
+                liveFrames.set(index, iframe);
+                section.replaceChildren(iframe);
+                // A direct iframe URL is treated by Readium's WebViewClient as an internal link
+                // navigation. Fetching through the same resource server keeps Readium's injected
+                // CSS/scripts while srcdoc prevents the horizontal resource pager from taking over.
+                fetch(resources[index].url)
+                    .then(function(response) {
+                        if (!response.ok) throw new Error('HTTP ' + response.status);
+                        return response.text();
+                    })
+                    .then(function(html) {
+                        if (liveFrames.get(index) !== iframe) return;
+                        const escapedUrl = resources[index].url
+                            .replace(/&/g, '&amp;')
+                            .replace(/"/g, '&quot;')
+                            .replace(/</g, '&lt;');
+                        const base = '<base href="' + escapedUrl + '">';
+                        if (/<head[\s>]/i.test(html)) {
+                            html = html.replace(/<head([^>]*)>/i, '<head${'$'}1>' + base);
+                        } else {
+                            html = base + html;
+                        }
+                        iframe.srcdoc = html;
+                    })
+                    .catch(function() {
+                        if (liveFrames.get(index) === iframe) section.replaceChildren();
+                        liveFrames.delete(index);
+                    });
+            }
+
+            function unloadSection(index) {
+                if (index === currentIndex) return;
+                const iframe = liveFrames.get(index);
+                const section = sections.get(index);
+                if (!iframe || !section) return;
+                try {
+                    if (iframe.__kohariaResizeObserver) iframe.__kohariaResizeObserver.disconnect();
+                    iframe.src = 'about:blank';
+                } catch (_) {}
+                section.replaceChildren();
+                liveFrames.delete(index);
+                section.style.height = (measuredHeights.get(index) || viewportHeight) + 'px';
+            }
+
+            function updateWindow(index) {
+                for (let candidate = 0; candidate < resources.length; candidate += 1) {
+                    if (candidate === currentIndex) continue;
+                    if (Math.abs(candidate - index) <= 1) loadSection(candidate);
+                    else unloadSection(candidate);
+                }
+            }
+
+            function visibleResource() {
+                const viewportCenter = scrolling.scrollTop + viewportHeight * 0.5;
+                let bestIndex = activeIndex;
+                let bestDistance = Number.POSITIVE_INFINITY;
+                for (let index = 0; index < resources.length; index += 1) {
+                    const bounds = sectionBounds(index);
+                    if (!bounds) continue;
+                    if (viewportCenter >= bounds.top && viewportCenter < bounds.bottom) return index;
+                    const distance = viewportCenter < bounds.top
+                        ? bounds.top - viewportCenter
+                        : viewportCenter - bounds.bottom;
+                    if (distance < bestDistance) {
+                        bestDistance = distance;
+                        bestIndex = index;
+                    }
+                }
+                return bestIndex;
+            }
+
+            function notifyLocation(force) {
+                locationFrame = 0;
+                const now = performance.now();
+                if (!force && now - lastLocationSentAt < 90) return;
+                lastLocationSentAt = now;
+                const nextIndex = visibleResource();
+                if (nextIndex !== activeIndex) {
+                    activeIndex = nextIndex;
+                    updateWindow(activeIndex);
+                }
+                const bounds = sectionBounds(activeIndex);
+                if (!bounds) return;
+                const localOffset = scrolling.scrollTop - bounds.top;
+                const scrollableHeight = Math.max(1, bounds.height - viewportHeight);
+                const progression = Math.max(0, Math.min(1, localOffset / scrollableHeight));
+                if (window.KohariaContinuousScroll && window.KohariaContinuousScroll.onLocationChanged) {
+                    window.KohariaContinuousScroll.onLocationChanged(activeIndex, progression);
+                }
+            }
+
+            function scheduleLocation() {
+                if (!locationFrame) locationFrame = requestAnimationFrame(function() { notifyLocation(false); });
+            }
+
+            document.addEventListener('scroll', scheduleLocation, { passive: true, capture: true });
+            window.addEventListener('resize', scheduleLocation, { passive: true });
+            updateWindow(currentIndex);
+            window.__kohariaContinuousScroll = {
+                currentIndex: currentIndex,
+                resources: resources,
+                notifyLocation: notifyLocation,
+                refresh: function(nextParagraphIndentScript) {
+                    paragraphIndentScript = nextParagraphIndentScript;
+                    try { window.eval(paragraphIndentScript); } catch (_) {}
+                    const loadedIndexes = Array.from(liveFrames.keys());
+                    loadedIndexes.forEach(unloadSection);
+                    updateWindow(activeIndex);
+                    scheduleLocation();
+                },
+            };
+
+            // Preserve Readium's restored progression even when the resource had not finished its
+            // final layout at the moment the window was inserted.
+            requestAnimationFrame(function() {
+                const currentBounds = sectionBounds(currentIndex);
+                if (currentBounds) {
+                    scrolling.scrollTop = currentBounds.top +
+                        initialProgression * Math.max(0, currentBounds.height - viewportHeight);
+                }
+                notifyLocation(true);
+            });
+            return 'installed';
+        })()
+    """.trimIndent()
+}

--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -60,6 +60,7 @@ internal fun buildEpubContinuousScrollInstallScript(
             const viewportHeight = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
             const measuredHeights = new Map();
             const liveFrames = new Map();
+            const failedResources = new Set();
             let activeIndex = currentIndex;
             let locationFrame = 0;
             let lastLocationSentAt = 0;
@@ -205,6 +206,7 @@ internal fun buildEpubContinuousScrollInstallScript(
                 iframe.setAttribute('title', resources[index].href || '');
                 iframe.style.height = (measuredHeights.get(index) || viewportHeight) + 'px';
                 iframe.addEventListener('load', function() {
+                    failedResources.delete(index);
                     measureFrame(index, iframe);
                     try {
                         const doc = iframe.contentDocument;
@@ -244,6 +246,8 @@ internal fun buildEpubContinuousScrollInstallScript(
                     .catch(function() {
                         if (liveFrames.get(index) === iframe) section.replaceChildren();
                         liveFrames.delete(index);
+                        failedResources.add(index);
+                        scheduleLocation();
                     });
             }
 
@@ -297,6 +301,12 @@ internal fun buildEpubContinuousScrollInstallScript(
                 if (nextIndex !== activeIndex) {
                     activeIndex = nextIndex;
                     updateWindow(activeIndex);
+                }
+                if (failedResources.delete(activeIndex)) {
+                    if (window.KohariaContinuousScroll && window.KohariaContinuousScroll.onResourceLoadFailed) {
+                        window.KohariaContinuousScroll.onResourceLoadFailed(activeIndex);
+                    }
+                    return;
                 }
                 const bounds = sectionBounds(activeIndex);
                 if (!bounds) return;

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -3,6 +3,7 @@ package koharia.epub
 import android.content.Context
 import android.os.Bundle
 import android.view.View
+import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
@@ -17,6 +18,7 @@ import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import logcat.LogPriority
@@ -29,6 +31,9 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.RelativeUrl
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
 import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -79,6 +84,9 @@ class EpubReaderFragment : Fragment() {
     private var navigatorInputListener: InputListener? = null
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
+    private var continuousScrollInstallJob: Job? = null
+    private var continuousScrollInstalledHref: String? = null
+    private var continuousScrollLocator: Locator? = null
 
     private val navigatorListener = object : EpubNavigatorFragment.Listener {
         override fun onExternalLinkActivated(url: AbsoluteUrl) {
@@ -111,6 +119,11 @@ class EpubReaderFragment : Fragment() {
         logcat(LogPriority.DEBUG) {
             "EPUB fragment onCreate chapterId=$chapterId hasSession=${session != null}"
         }
+        val navigatorConfiguration = epubNavigatorConfiguration().apply {
+            registerJavascriptInterface(CONTINUOUS_SCROLL_BRIDGE_NAME) {
+                ContinuousScrollJavascriptBridge()
+            }
+        }
         childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
             initialLocator = session.initialLocator,
             initialPreferences = epubPreferencesBridge.toReadiumPreferences(
@@ -119,7 +132,7 @@ class EpubReaderFragment : Fragment() {
             ),
             listener = navigatorListener,
             paginationListener = paginationListener,
-            configuration = epubNavigatorConfiguration(),
+            configuration = navigatorConfiguration,
         ) ?: EpubNavigatorFragment.createDummyFactory()
         super.onCreate(savedInstanceState)
     }
@@ -206,36 +219,45 @@ class EpubReaderFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        clearContinuousScrollState()
         clearNavigatorInputListener()
         super.onDestroyView()
     }
 
     fun goTo(link: Link): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
+        clearContinuousScrollState()
         return navigator.go(link)
     }
 
     fun goTo(locator: Locator): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
         val publication = sessionRepository.get(chapterId)?.publication ?: return false
+        clearContinuousScrollState()
         return navigator.go(publication.toNavigatorLocator(locator))
     }
 
     fun goForward(): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
+        continuousScrollAdjacentLocator(forward = true)?.let { return goTo(it) }
+        clearContinuousScrollState()
         return navigator.goForward()
     }
 
     fun goBackward(): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
+        continuousScrollAdjacentLocator(forward = false)?.let { return goTo(it) }
+        clearContinuousScrollState()
         return navigator.goBackward()
     }
 
     fun submitPreferences(preferences: EpubPreferences) {
         if (!isAdded || view == null) return
+        clearContinuousScrollState()
         paragraphIndentOverrideEnabled = preferences.publisherStyles == false
         navigatorFragment()?.submitPreferences(preferences)
         applyParagraphIndentOverride()
+        scheduleContinuousScrollInstall(readyNavigatorFragment())
         logcat(LogPriority.DEBUG) {
             "EPUB paragraph indent submitted chapterId=$chapterId " +
                 "publisherStyles=${preferences.publisherStyles} " +
@@ -333,7 +355,13 @@ class EpubReaderFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 navigator.currentLocator.collect { locator ->
-                    host?.onLocatorChanged(locator)
+                    val installedHref = continuousScrollInstalledHref
+                    if (installedHref == null || !locator.href.toString().sameEpubResource(installedHref)) {
+                        continuousScrollLocator = null
+                        continuousScrollInstalledHref = null
+                        host?.onLocatorChanged(locator)
+                        scheduleContinuousScrollInstall(navigator, locator)
+                    }
                     applyParagraphIndentOverride()
                 }
             }
@@ -352,7 +380,147 @@ class EpubReaderFragment : Fragment() {
         navigator.viewLifecycleOwnerLiveData.observe(viewLifecycleOwner) { owner ->
             if (owner == null || !isAdded || view == null) return@observe
             host?.onNavigatorReady(this)
+            scheduleContinuousScrollInstall(navigator)
         }
+    }
+
+    private fun scheduleContinuousScrollInstall(
+        navigator: EpubNavigatorFragment?,
+        locator: Locator? = navigator?.currentLocator?.value,
+    ) {
+        continuousScrollInstallJob?.cancel()
+        if (navigator == null || locator == null ||
+            epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL
+        ) {
+            return
+        }
+        continuousScrollInstallJob = viewLifecycleOwner.lifecycleScope.launch {
+            delay(CONTINUOUS_SCROLL_INSTALL_DELAY_MS)
+            if (!isAdded || view == null || readyNavigatorFragment() !== navigator ||
+                epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL
+            ) {
+                return@launch
+            }
+            val session = sessionRepository.get(chapterId) ?: return@launch
+            val currentIndex = session.publication.readingOrder.indexOfFirst {
+                it.href.toString().sameEpubResource(locator.href.toString())
+            }
+            if (currentIndex < 0) return@launch
+            val resources = session.publication.readingOrder.mapIndexedNotNull { index, link ->
+                link.servedUrl(session.publication.baseUrl)?.let { servedUrl ->
+                    EpubContinuousScrollResource(
+                        index = index,
+                        href = link.href.toString(),
+                        url = servedUrl,
+                    )
+                }
+            }
+            if (resources.size != session.publication.readingOrder.size) return@launch
+            val result = runCatching {
+                navigator.evaluateJavascript(
+                    buildEpubContinuousScrollInstallScript(
+                        resources = resources,
+                        currentIndex = currentIndex,
+                        initialProgression = locator.locations.progression ?: 0.0,
+                        paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
+                            APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
+                        } else {
+                            REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT
+                        },
+                    ),
+                )
+            }.getOrNull()
+            if (result == "\"installed\"" || result == "\"ready\"") {
+                continuousScrollInstalledHref = locator.href.toString()
+                continuousScrollLocator = locator
+                logcat(LogPriority.DEBUG) {
+                    "EPUB continuous resource flow installed chapterId=$chapterId " +
+                        "resourceIndex=$currentIndex resources=${resources.size}"
+                }
+            }
+        }
+    }
+
+    private fun clearContinuousScrollState() {
+        continuousScrollInstallJob?.cancel()
+        continuousScrollInstallJob = null
+        continuousScrollInstalledHref = null
+        continuousScrollLocator = null
+    }
+
+    private fun continuousScrollAdjacentLocator(forward: Boolean): Locator? {
+        if (epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL) return null
+        val current = continuousScrollLocator ?: return null
+        val publication = sessionRepository.get(chapterId)?.publication ?: return null
+        val currentIndex = publication.readingOrder.indexOfFirst {
+            it.href.toString().sameEpubResource(current.href.toString())
+        }
+        val targetIndex = currentIndex + if (forward) 1 else -1
+        val target = publication.readingOrder.getOrNull(targetIndex) ?: return null
+        return createContinuousScrollLocator(
+            link = target,
+            progression = if (forward) 0.0 else 1.0,
+            positions = sessionRepository.get(chapterId)?.positionsController?.currentPositions().orEmpty(),
+        )
+    }
+
+    @Suppress("unused")
+    private inner class ContinuousScrollJavascriptBridge {
+        @JavascriptInterface
+        fun onLocationChanged(resourceIndex: Int, progression: Double) {
+            view?.post {
+                if (!isAdded || view == null || continuousScrollInstalledHref == null ||
+                    epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL
+                ) {
+                    return@post
+                }
+                val session = sessionRepository.get(chapterId) ?: return@post
+                val link = session.publication.readingOrder.getOrNull(resourceIndex) ?: return@post
+                val locator = createContinuousScrollLocator(
+                    link = link,
+                    progression = progression.coerceIn(0.0, 1.0),
+                    positions = session.positionsController.currentPositions(),
+                ) ?: return@post
+                continuousScrollLocator = locator
+                host?.onLocatorChanged(locator)
+            }
+        }
+    }
+
+    private fun createContinuousScrollLocator(
+        link: Link,
+        progression: Double,
+        positions: List<Locator>,
+    ): Locator? {
+        val publication = sessionRepository.get(chapterId)?.publication ?: return null
+        val resourcePositions = positions.filter {
+            it.href.toString().sameEpubResource(link.href.toString())
+        }
+        val positionIndex = kotlin.math.ceil(progression * (resourcePositions.size - 1).coerceAtLeast(0)).toInt()
+        val positionLocator = resourcePositions.getOrNull(positionIndex)
+        val baseLocator = publication.locatorFromLink(link) ?: return null
+        return baseLocator.copy(
+            title = link.title ?: positionLocator?.title ?: baseLocator.title,
+            mediaType = link.mediaType ?: MediaType.XHTML,
+            locations = (positionLocator?.locations ?: baseLocator.locations).copy(
+                progression = progression,
+            ),
+            text = positionLocator?.text ?: baseLocator.text,
+        )
+    }
+
+    private fun Link.servedUrl(baseUrl: AbsoluteUrl?): String? {
+        val url: Url = url()
+        return when (url) {
+            is AbsoluteUrl -> url.toString()
+            is RelativeUrl -> (baseUrl ?: READIUM_PACKAGE_BASE_URL).resolve(url).toString()
+        }
+    }
+
+    private fun String.sameEpubResource(other: String): Boolean {
+        val first = substringBefore('#').substringBefore('?').trimStart('/')
+        val second = other.substringBefore('#').substringBefore('?').trimStart('/')
+        return first == second || first.endsWith("/$second") || second.endsWith("/$first")
     }
 
     private fun navigatorFragment(): EpubNavigatorFragment? {
@@ -374,6 +542,9 @@ class EpubReaderFragment : Fragment() {
         private const val NAVIGATOR_TAG = "epub_navigator"
         private const val PAGINATION_SCANNER_TAG = "epub_pagination_scanner"
         private const val PARAGRAPH_INDENT_DEBUG_DELAY_MS = 600L
+        private const val CONTINUOUS_SCROLL_BRIDGE_NAME = "KohariaContinuousScroll"
+        private const val CONTINUOUS_SCROLL_INSTALL_DELAY_MS = 180L
+        private val READIUM_PACKAGE_BASE_URL = AbsoluteUrl("https://readium_package/")!!
         private val PARAGRAPH_INDENT_DEBUG_SCRIPT =
             """
             (function() {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -239,25 +239,35 @@ class EpubReaderFragment : Fragment() {
 
     fun goForward(): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
-        continuousScrollAdjacentLocator(forward = true)?.let { return goTo(it) }
+        navigateContinuousScroll(forward = true)?.let { return it }
         clearContinuousScrollState()
         return navigator.goForward()
     }
 
     fun goBackward(): Boolean {
         val navigator = readyNavigatorFragment() ?: return false
-        continuousScrollAdjacentLocator(forward = false)?.let { return goTo(it) }
+        navigateContinuousScroll(forward = false)?.let { return it }
         clearContinuousScrollState()
         return navigator.goBackward()
     }
 
     fun submitPreferences(preferences: EpubPreferences) {
         if (!isAdded || view == null) return
-        clearContinuousScrollState()
+        val navigator = readyNavigatorFragment()
+        val keepContinuousScrollPosition =
+            preferences.scroll != false &&
+                epubLayoutPreferences.readingMode.get() == EpubLayoutPreferences.ReadingMode.SCROLL
+        if (!keepContinuousScrollPosition) {
+            clearContinuousScrollState()
+        }
         paragraphIndentOverrideEnabled = preferences.publisherStyles == false
-        navigatorFragment()?.submitPreferences(preferences)
+        navigator?.submitPreferences(preferences)
         applyParagraphIndentOverride()
-        scheduleContinuousScrollInstall(readyNavigatorFragment())
+        if (keepContinuousScrollPosition) {
+            // Keep the JS-reported Locator when the visible resource is an adjacent iframe. The
+            // native navigator still points at the XHTML that owns the continuous-scroll window.
+            scheduleContinuousScrollInstall(navigator)
+        }
         logcat(LogPriority.DEBUG) {
             "EPUB paragraph indent submitted chapterId=$chapterId " +
                 "publisherStyles=${preferences.publisherStyles} " +
@@ -407,7 +417,7 @@ class EpubReaderFragment : Fragment() {
             }
             if (currentIndex < 0) return@launch
             val resources = session.publication.readingOrder.mapIndexedNotNull { index, link ->
-                link.servedUrl(session.publication.baseUrl)?.let { servedUrl ->
+                link.readiumServedUrl(session.publication.baseUrl)?.let { servedUrl ->
                     EpubContinuousScrollResource(
                         index = index,
                         href = link.href.toString(),
@@ -431,8 +441,15 @@ class EpubReaderFragment : Fragment() {
                 )
             }.getOrNull()
             if (result == "\"installed\"" || result == "\"ready\"") {
-                continuousScrollInstalledHref = locator.href.toString()
-                continuousScrollLocator = locator
+                if (result == "\"installed\"") {
+                    continuousScrollInstalledHref = locator.href.toString()
+                    continuousScrollLocator = locator
+                } else {
+                    // A preference refresh reuses the existing JS window. Do not replace a newer
+                    // iframe Locator with the stale native Locator for the window's owner XHTML.
+                    continuousScrollInstalledHref = continuousScrollInstalledHref ?: locator.href.toString()
+                    continuousScrollLocator = continuousScrollLocator ?: locator
+                }
                 logcat(LogPriority.DEBUG) {
                     "EPUB continuous resource flow installed chapterId=$chapterId " +
                         "resourceIndex=$currentIndex resources=${resources.size}"
@@ -448,20 +465,27 @@ class EpubReaderFragment : Fragment() {
         continuousScrollLocator = null
     }
 
-    private fun continuousScrollAdjacentLocator(forward: Boolean): Locator? {
-        if (epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL) return null
+    /** Returns null when native navigation should handle the request, otherwise its result. */
+    private fun navigateContinuousScroll(forward: Boolean): Boolean? {
+        if (epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL ||
+            continuousScrollInstalledHref == null
+        ) {
+            return null
+        }
         val current = continuousScrollLocator ?: return null
         val publication = sessionRepository.get(chapterId)?.publication ?: return null
         val currentIndex = publication.readingOrder.indexOfFirst {
             it.href.toString().sameEpubResource(current.href.toString())
         }
+        if (currentIndex < 0) return false
         val targetIndex = currentIndex + if (forward) 1 else -1
-        val target = publication.readingOrder.getOrNull(targetIndex) ?: return null
-        return createContinuousScrollLocator(
+        val target = publication.readingOrder.getOrNull(targetIndex) ?: return false
+        val locator = createContinuousScrollLocator(
             link = target,
             progression = if (forward) 0.0 else 1.0,
             positions = sessionRepository.get(chapterId)?.positionsController?.currentPositions().orEmpty(),
-        )
+        ) ?: return false
+        return goTo(locator)
     }
 
     @Suppress("unused")
@@ -485,6 +509,29 @@ class EpubReaderFragment : Fragment() {
                 host?.onLocatorChanged(locator)
             }
         }
+
+        @JavascriptInterface
+        fun onResourceLoadFailed(resourceIndex: Int) {
+            view?.post {
+                if (!isAdded || view == null || continuousScrollInstalledHref == null ||
+                    epubLayoutPreferences.readingMode.get() != EpubLayoutPreferences.ReadingMode.SCROLL
+                ) {
+                    return@post
+                }
+                val session = sessionRepository.get(chapterId) ?: return@post
+                val link = session.publication.readingOrder.getOrNull(resourceIndex) ?: return@post
+                val locator = createContinuousScrollLocator(
+                    link = link,
+                    progression = 0.0,
+                    positions = session.positionsController.currentPositions(),
+                ) ?: return@post
+                logcat(LogPriority.WARN) {
+                    "EPUB continuous resource load failed chapterId=$chapterId resourceIndex=$resourceIndex; " +
+                        "falling back to native navigation"
+                }
+                goTo(locator)
+            }
+        }
     }
 
     private fun createContinuousScrollLocator(
@@ -496,20 +543,42 @@ class EpubReaderFragment : Fragment() {
         val resourcePositions = positions.filter {
             it.href.toString().sameEpubResource(link.href.toString())
         }
-        val positionIndex = kotlin.math.ceil(progression * (resourcePositions.size - 1).coerceAtLeast(0)).toInt()
-        val positionLocator = resourcePositions.getOrNull(positionIndex)
+        val scaledPosition = progression * (resourcePositions.size - 1).coerceAtLeast(0)
+        val lowerIndex = kotlin.math.floor(scaledPosition).toInt()
+        val lowerLocator = resourcePositions.getOrNull(lowerIndex)
+        val readingOrderIndex = publication.readingOrder.indexOfFirst {
+            it.href.toString().sameEpubResource(link.href.toString())
+        }
+        val resourceStartProgression = resourcePositions.firstOrNull()?.locations?.totalProgression
+        val nextResource = if (readingOrderIndex >= 0) {
+            publication.readingOrder.getOrNull(readingOrderIndex + 1)
+        } else {
+            null
+        }
+        val resourceEndProgression = nextResource?.let { nextLink ->
+            positions.firstOrNull {
+                it.href.toString().sameEpubResource(nextLink.href.toString())
+            }?.locations?.totalProgression
+        } ?: 1.0
+        val interpolatedTotalProgression = resourceStartProgression?.let { start ->
+            start + (resourceEndProgression - start).coerceAtLeast(0.0) * progression
+        }
         val baseLocator = publication.locatorFromLink(link) ?: return null
         return baseLocator.copy(
-            title = link.title ?: positionLocator?.title ?: baseLocator.title,
+            title = link.title ?: lowerLocator?.title ?: baseLocator.title,
             mediaType = link.mediaType ?: MediaType.XHTML,
-            locations = (positionLocator?.locations ?: baseLocator.locations).copy(
+            locations = (lowerLocator?.locations ?: baseLocator.locations).copy(
                 progression = progression,
+                totalProgression = interpolatedTotalProgression
+                    ?: lowerLocator?.locations?.totalProgression
+                    ?: baseLocator.locations.totalProgression,
             ),
-            text = positionLocator?.text ?: baseLocator.text,
+            text = lowerLocator?.text ?: baseLocator.text,
         )
     }
 
-    private fun Link.servedUrl(baseUrl: AbsoluteUrl?): String? {
+    /** Mirrors Readium WebViewServer.linkToServedUrl; requests stay intercepted by Publication.get. */
+    private fun Link.readiumServedUrl(baseUrl: AbsoluteUrl?): String? {
         val url: Url = url()
         return when (url) {
             is AbsoluteUrl -> url.toString()


### PR DESCRIPTION
## 修改内容 / What changed

- 为 EPUB 连续滚动模式增加纵向 reading-order 资源流，使相邻 XHTML 章节能够在上下方向自然衔接。
- 仅保留当前可见章节附近的资源，降低长篇书籍连续阅读时的内存占用。
- 根据当前可见章节合成 Readium Locator，继续支持阅读进度保存、书签和 Komga 进度同步。
- 在字体、间距和出版商样式变化后刷新相邻章节，并让目录、进度条及章节按钮继续使用现有导航逻辑。

- Adds a vertical reading-order resource flow for EPUB continuous scrolling, allowing adjacent XHTML chapters to connect naturally.
- Keeps only resources near the visible chapter alive to limit memory usage for long books.
- Produces Readium Locators from the visible resource so progress persistence, bookmarks, and Komga synchronization remain supported.
- Refreshes adjacent chapters after layout preference changes while preserving existing TOC, progress slider, and chapter navigation behavior.

## 用户体验 / User impact

连续滚动到章节末尾后可以直接继续向下阅读下一章，不再需要左右翻页切换内部章节。

Readers can continue scrolling vertically into the next internal chapter without a horizontal page turn.

## 验证 / Validation

按照当前快速开发约定，本次未运行 Gradle 构建或设备验证。

Gradle and device validation were not run, following the current rapid-development workflow.
