### PR TITLE
修复书库筛选持久化并优化筛选界面 / Fix library filter persistence and UI

### DIFF
--- a/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
@@ -113,7 +113,11 @@ class KomgaApiClient(
 
         val sortCriteria = when (sortIndex) {
             0 -> "relevance"
-            1 -> if (typePath == "series") "metadata.titleSort" else "name"
+            1 -> when (typePath) {
+                "series" -> "metadata.titleSort"
+                "books" -> "metadata.title"
+                else -> "name"
+            }
             2 -> "createdDate"
             3 -> "lastModifiedDate"
             4 -> "random"

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -28,6 +28,7 @@ import koharia.source.komga.ReadingStateGroup
 import koharia.source.komga.SeriesSort
 import koharia.source.komga.TypeSelect
 import koharia.source.komga.UnreadFilter
+import okhttp3.Request
 import tachiyomi.core.common.util.lang.withIOContext
 import java.text.ParseException
 import java.text.SimpleDateFormat
@@ -57,25 +58,29 @@ class KomgaRepository(
         filters: FilterList,
         defaultLibraries: Set<String>,
         cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
-    ) =
-        apiClient.searchRequest(
+    ): Request {
+        val type = filters.searchType()
+        val supportsBookFilters = type != KomgaApiClient.SearchType.READ_LISTS
+        val supportsSeriesFilters = type == KomgaApiClient.SearchType.SERIES
+        return apiClient.searchRequest(
             page = page,
             query = query,
-            type = filters.searchType(),
+            type = type,
             defaultLibraries = defaultLibraries,
             selectedLibraries = filters.selectedLibraries(),
             collectionId = filters.collectionId(),
             sortIndex = filters.sortSelection().first,
             sortAscending = filters.sortSelection().second,
-            readStatuses = filters.readStatuses(),
-            statuses = filters.multiSelectIds("Status"),
-            genres = filters.multiSelectIds("Genres"),
-            tags = filters.multiSelectIds("Tags"),
-            publishers = filters.multiSelectIds("Publishers"),
-            authors = filters.selectedAuthors(),
-            oneshot = filters.oneshot(),
+            readStatuses = filters.readStatuses().takeIf { supportsBookFilters }.orEmpty(),
+            statuses = filters.multiSelectIds("Status").takeIf { supportsSeriesFilters }.orEmpty(),
+            genres = filters.multiSelectIds("Genres").takeIf { supportsSeriesFilters }.orEmpty(),
+            tags = filters.multiSelectIds("Tags").takeIf { supportsBookFilters }.orEmpty(),
+            publishers = filters.multiSelectIds("Publishers").takeIf { supportsSeriesFilters }.orEmpty(),
+            authors = filters.selectedAuthors().takeIf { supportsSeriesFilters }.orEmpty(),
+            oneshot = filters.oneshot().takeIf { supportsSeriesFilters },
             cachePolicy = cachePolicy,
         )
+    }
 
     fun parseMangasPage(response: okhttp3.Response): MangasPage {
         val data = response.use {

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -24,6 +24,7 @@ import koharia.source.komga.KomgaCachePolicy
 import koharia.source.komga.LibraryFilter
 import koharia.source.komga.OneshotFilter
 import koharia.source.komga.ReadFilter
+import koharia.source.komga.ReadingStateGroup
 import koharia.source.komga.SeriesSort
 import koharia.source.komga.TypeSelect
 import koharia.source.komga.UnreadFilter
@@ -216,10 +217,12 @@ private fun FilterList.searchType(): KomgaApiClient.SearchType = when {
     else -> KomgaApiClient.SearchType.SERIES
 }
 
-private fun FilterList.collectionId(): String? =
-    filterIsInstance<CollectionSelect>().firstOrNull()?.collections?.getOrNull(
+private fun FilterList.collectionId(): String? {
+    if (filterIsInstance<TypeSelect>().firstOrNull()?.state != 0) return null
+    return filterIsInstance<CollectionSelect>().firstOrNull()?.collections?.getOrNull(
         filterIsInstance<CollectionSelect>().firstOrNull()?.state ?: 0,
     )?.id
+}
 
 private fun FilterList.sortSelection(): Pair<Int, Boolean> {
     val sort = filterIsInstance<SeriesSort>().firstOrNull()?.state ?: return 0 to true
@@ -228,20 +231,27 @@ private fun FilterList.sortSelection(): Pair<Int, Boolean> {
 
 private fun FilterList.readStatuses(): Set<String> {
     val statuses = mutableSetOf<String>()
-    if (filterIsInstance<UnreadFilter>().firstOrNull()?.state == true) {
+    val readingFilters = filterIsInstance<ReadingStateGroup>().firstOrNull()?.state.orEmpty()
+    if (readingFilters.filterIsInstance<UnreadFilter>().firstOrNull()?.state == true) {
         statuses += setOf("UNREAD", "IN_PROGRESS")
     }
-    if (filterIsInstance<InProgressFilter>().firstOrNull()?.state == true) {
+    if (readingFilters.filterIsInstance<InProgressFilter>().firstOrNull()?.state == true) {
         statuses += "IN_PROGRESS"
     }
-    if (filterIsInstance<ReadFilter>().firstOrNull()?.state == true) {
+    if (readingFilters.filterIsInstance<ReadFilter>().firstOrNull()?.state == true) {
         statuses += "READ"
     }
     return statuses
 }
 
 private fun FilterList.oneshot(): Boolean? =
-    filterIsInstance<OneshotFilter>().firstOrNull()?.state?.takeIf { it }
+    filterIsInstance<ReadingStateGroup>()
+        .firstOrNull()
+        ?.state
+        ?.filterIsInstance<OneshotFilter>()
+        ?.firstOrNull()
+        ?.state
+        ?.takeIf { it }
 
 private fun FilterList.selectedLibraries(): Set<String> =
     filterIsInstance<LibraryFilter>().firstOrNull()?.state?.filter { it.state }?.map { it.id }?.toSet().orEmpty()

--- a/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AdaptiveSheet
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import koharia.source.komga.AuthorGroup
 import koharia.source.komga.CollectionSelect
 import koharia.source.komga.LibraryFilter
 import koharia.source.komga.OneshotFilter
@@ -147,8 +148,8 @@ private fun FilterItem(filter: Filter<*>, filters: FilterList, onUpdate: () -> U
                 selectedIndex = filter.state,
             ) {
                 filter.state = it
-                if (filter is TypeSelect && it != TYPE_SERIES_INDEX) {
-                    filters.filterIsInstance<CollectionSelect>().firstOrNull()?.state = 0
+                if (filter is TypeSelect) {
+                    filters.clearFiltersHiddenFor(it)
                 }
                 onUpdate()
             }
@@ -277,6 +278,29 @@ private fun Filter<*>.isBookFilter(): Boolean {
 
 private fun FilterList.selectedContentType(): Int =
     filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_SERIES_INDEX
+
+private fun FilterList.clearFiltersHiddenFor(type: Int) {
+    if (type == TYPE_SERIES_INDEX) return
+
+    filterIsInstance<CollectionSelect>().firstOrNull()?.state = 0
+    forEach { filter ->
+        when {
+            type == TYPE_READ_LISTS_INDEX && filter is ReadingStateGroup -> filter.clearSelections()
+            type == TYPE_READ_LISTS_INDEX && filter is UriMultiSelectFilter && filter !is LibraryFilter ->
+                filter.clearSelections()
+            type == TYPE_READ_LISTS_INDEX && filter is AuthorGroup -> filter.clearSelections()
+            type == TYPE_BOOKS_INDEX && filter is ReadingStateGroup ->
+                filter.state.filterIsInstance<OneshotFilter>().forEach { it.state = false }
+            type == TYPE_BOOKS_INDEX && filter is UriMultiSelectFilter &&
+                filter !is LibraryFilter && filter.name != "Tags" -> filter.clearSelections()
+            type == TYPE_BOOKS_INDEX && filter is AuthorGroup -> filter.clearSelections()
+        }
+    }
+}
+
+private fun Filter.Group<*>.clearSelections() {
+    state.filterIsInstance<Filter.CheckBox>().forEach { it.state = false }
+}
 
 private const val TYPE_SERIES_INDEX = 0
 private const val TYPE_READ_LISTS_INDEX = 1

--- a/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
@@ -13,11 +13,22 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AdaptiveSheet
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import koharia.source.komga.CollectionSelect
+import koharia.source.komga.LibraryFilter
+import koharia.source.komga.OneshotFilter
+import koharia.source.komga.ReadingStateGroup
+import koharia.source.komga.SeriesSort
+import koharia.source.komga.TypeSelect
+import koharia.source.komga.UriMultiSelectFilter
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.CheckboxItem
@@ -40,7 +51,12 @@ fun KomgaFilterDialog(
     onUpdate: (FilterList) -> Unit,
     onPersistentFilteringChange: (Boolean) -> Unit,
 ) {
-    val updateFilters = { onUpdate(filters) }
+    var filterRevision by remember(filters) { mutableIntStateOf(0) }
+    val updateFilters = {
+        filterRevision += 1
+        onUpdate(filters)
+    }
+    val visibleFilters = remember(filters, filterRevision) { filters.visibleFilters() }
 
     AdaptiveSheet(onDismissRequest = onDismissRequest) {
         LazyColumn {
@@ -71,8 +87,8 @@ fun KomgaFilterDialog(
                 HorizontalDivider()
             }
 
-            items(filters) {
-                FilterItem(it, updateFilters)
+            items(visibleFilters) {
+                FilterItem(it, filters, updateFilters)
             }
 
             item {
@@ -89,7 +105,7 @@ fun KomgaFilterDialog(
 }
 
 @Composable
-private fun FilterItem(filter: Filter<*>, onUpdate: () -> Unit) {
+private fun FilterItem(filter: Filter<*>, filters: FilterList, onUpdate: () -> Unit) {
     when (filter) {
         is Filter.Header -> {
             HeadingItem(komgaFilterLabel(filter.name))
@@ -131,6 +147,9 @@ private fun FilterItem(filter: Filter<*>, onUpdate: () -> Unit) {
                 selectedIndex = filter.state,
             ) {
                 filter.state = it
+                if (filter is TypeSelect && it != TYPE_SERIES_INDEX) {
+                    filters.filterIsInstance<CollectionSelect>().firstOrNull()?.state = 0
+                }
                 onUpdate()
             }
         }
@@ -169,7 +188,10 @@ private fun FilterItem(filter: Filter<*>, onUpdate: () -> Unit) {
                 Column {
                     filter.state
                         .filterIsInstance<Filter<*>>()
-                        .map { FilterItem(filter = it, onUpdate = onUpdate) }
+                        .filter {
+                            filters.selectedContentType() == TYPE_SERIES_INDEX || it !is OneshotFilter
+                        }
+                        .map { FilterItem(filter = it, filters = filters, onUpdate = onUpdate) }
                 }
             }
         }
@@ -193,9 +215,10 @@ private fun komgaFilterLabel(label: String): String {
         "In Progress" -> stringResource(MR.strings.komga_filter_in_progress)
         "Read" -> stringResource(MR.strings.komga_filter_read)
         "Oneshot" -> stringResource(MR.strings.komga_filter_oneshot)
+        "Reading status and type" -> stringResource(MR.strings.komga_filter_reading_status_and_type)
         "Libraries" -> stringResource(MR.strings.komga_filter_libraries)
         "Collection" -> stringResource(MR.strings.komga_filter_collection)
-        "None" -> stringResource(MR.strings.none)
+        "None" -> stringResource(MR.strings.komga_filter_no_collection)
         "Status" -> stringResource(MR.strings.status)
         "Ongoing" -> stringResource(MR.strings.ongoing)
         "Ended" -> stringResource(MR.strings.komga_filter_status_ended)
@@ -213,9 +236,51 @@ private fun komgaFilterLabel(label: String): String {
         "Editor" -> stringResource(MR.strings.komga_filter_author_editor)
         "Translator" -> stringResource(MR.strings.komga_filter_author_translator)
         "Conceptor" -> stringResource(MR.strings.komga_filter_author_conceptor)
+        "Illustrator" -> stringResource(MR.strings.komga_filter_author_illustrator)
+        "Artist" -> stringResource(MR.strings.komga_filter_author_artist)
+        "Author" -> stringResource(MR.strings.author)
+        "Narrator" -> stringResource(MR.strings.komga_filter_author_narrator)
+        "Contributor" -> stringResource(MR.strings.komga_filter_author_contributor)
         else -> label
     }
 }
+
+private fun FilterList.visibleFilters(): List<Filter<*>> {
+    val type = selectedContentType()
+    val hasCollection = (filterIsInstance<CollectionSelect>().firstOrNull()?.state ?: 0) != 0
+    return filter { filter ->
+        when (type) {
+            TYPE_READ_LISTS_INDEX -> filter.isReadListFilter()
+            TYPE_BOOKS_INDEX -> filter.isBookFilter()
+            else -> filter !is SeriesSort || !hasCollection
+        }
+    }
+}
+
+private fun Filter<*>.isReadListFilter(): Boolean {
+    return this is TypeSelect ||
+        this is LibraryFilter ||
+        this is SeriesSort ||
+        this is Filter.Header ||
+        this is Filter.Separator
+}
+
+private fun Filter<*>.isBookFilter(): Boolean {
+    return this is TypeSelect ||
+        this is LibraryFilter ||
+        this is ReadingStateGroup ||
+        (this is UriMultiSelectFilter && name == "Tags") ||
+        this is SeriesSort ||
+        this is Filter.Header ||
+        this is Filter.Separator
+}
+
+private fun FilterList.selectedContentType(): Int =
+    filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_SERIES_INDEX
+
+private const val TYPE_SERIES_INDEX = 0
+private const val TYPE_READ_LISTS_INDEX = 1
+private const val TYPE_BOOKS_INDEX = 2
 
 private fun Int.toTriStateFilter(): TriState {
     return when (this) {

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -320,6 +320,7 @@ class KomgaLibraryScreenModel(
             allowedLibraryIds = currentAllowedLibraryIds(),
             libraryScope = libraryScope,
             currentFilters = state.value.filters,
+            resetLibrarySelection = libraryId == null,
         )
         mutableState.update {
             it.copy(
@@ -434,13 +435,10 @@ class KomgaLibraryScreenModel(
         libraries: List<KomgaClassifiedLibrary>,
     ) {
         if (libraryScope == KomgaLibraryScope.ALL) return
-        // The cached classification can arrive before Komga's filter metadata. Building filters at
-        // that point produces an empty library group which would override the persisted selection.
-        if (!filtersInitialized) return
         val visibleLibraries = libraries
             .filter { it.kind == libraryScope.kind }
             .map { LibraryDto(it.id, it.name) }
-        if (state.value.komgaLibraries == visibleLibraries) return
+        if (filtersInitialized && state.value.komgaLibraries == visibleLibraries) return
         val selectedLibraryId = state.value.selectedKomgaLibraryId
             ?.takeIf { selectedId -> visibleLibraries.any { it.id == selectedId } }
         val filters = komgaSource.buildFilterListForLibrary(
@@ -450,6 +448,7 @@ class KomgaLibraryScreenModel(
             libraryScope = libraryScope,
             currentFilters = currentFiltersForReload(),
             preserveSessionFilters = true,
+            fallbackLibraries = visibleLibraries,
         )
         mutableState.update {
             it.copy(
@@ -461,6 +460,7 @@ class KomgaLibraryScreenModel(
                 isLibraryScopeEmpty = visibleLibraries.isEmpty(),
             )
         }
+        filtersInitialized = true
         komgaSource.saveSessionFilterState(filters, libraryScope)
         refreshSignal.value += 1
     }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -73,22 +73,27 @@ class KomgaLibraryScreenModel(
     val source = sourceManager.getOrStub(sourceId)
     private var komgaSettingsChangeListener: SharedPreferences.OnSharedPreferenceChangeListener? = null
 
+    @Volatile
+    private var filtersInitialized = false
+
     init {
         if (source is CatalogueSource) {
             mutableState.update {
                 var query: String? = null
                 var listing = it.listing
+                val filters = source.getFilterList()
 
                 if (listing is Listing.Search) {
                     query = listing.query
-                    listing = Listing.Search(query, source.getFilterList())
+                    listing = Listing.Search(query, filters)
                 }
 
                 it.copy(
                     listing = listing,
-                    filters = source.getFilterList(),
+                    filters = filters,
                     toolbarQuery = query,
-                    persistentFilteringEnabled = (source as? KomgaSource)?.isPersistentFilteringEnabled() == true,
+                    persistentFilteringEnabled =
+                    (source as? KomgaSource)?.isPersistentFilteringEnabled(libraryScope) == true,
                 )
             }
         }
@@ -152,10 +157,14 @@ class KomgaLibraryScreenModel(
     fun resetFilters() {
         if (source !is CatalogueSource) return
 
-        (source as? KomgaSource)?.resetPersistentFilters()
+        (source as? KomgaSource)?.run {
+            resetPersistentFilters(libraryScope)
+            resetSessionFilterState(libraryScope)
+        }
         val filters = (source as? KomgaSource)?.buildFilterListForLibrary(
             libraryId = state.value.selectedKomgaLibraryId,
             allowedLibraryIds = currentAllowedLibraryIds(),
+            libraryScope = libraryScope,
         ) ?: source.getFilterList()
         mutableState.update { it.copy(filters = filters) }
     }
@@ -183,11 +192,14 @@ class KomgaLibraryScreenModel(
                 filters = (source as? KomgaSource)?.buildFilterListForLibrary(
                     libraryId = state.value.selectedKomgaLibraryId,
                     allowedLibraryIds = currentAllowedLibraryIds(),
+                    libraryScope = libraryScope,
+                    currentFilters = state.value.filters,
                 ) ?: source.getFilterList(),
             )
 
         val nextFilters = filters ?: input.filters
-        (source as? KomgaSource)?.savePersistentFilterState(nextFilters)
+        (source as? KomgaSource)?.saveSessionFilterState(nextFilters, libraryScope)
+        (source as? KomgaSource)?.savePersistentFilterState(nextFilters, libraryScope)
 
         mutableState.update {
             it.copy(
@@ -202,7 +214,7 @@ class KomgaLibraryScreenModel(
 
     fun setPersistentFilteringEnabled(enabled: Boolean) {
         val komgaSource = source as? KomgaSource ?: return
-        komgaSource.setPersistentFilteringEnabled(enabled, state.value.filters)
+        komgaSource.setPersistentFilteringEnabled(enabled, state.value.filters, libraryScope)
         mutableState.update { it.copy(persistentFilteringEnabled = enabled) }
     }
 
@@ -210,7 +222,13 @@ class KomgaLibraryScreenModel(
         if (source !is CatalogueSource) return
 
         if (source is KomgaSource) {
-            val filters = source.buildFilterListForTagSearch(genreName, currentAllowedLibraryIds())
+            val filters = source.buildFilterListForTagSearch(
+                tag = genreName,
+                allowedLibraryIds = currentAllowedLibraryIds(),
+                libraryScope = libraryScope,
+            )
+            source.saveSessionFilterState(filters, libraryScope)
+            source.savePersistentFilterState(filters, libraryScope)
             logcat(LogPriority.DEBUG) {
                 "KomgaLibraryScreenModel.searchGenre: applying Komga tag search tag=$genreName"
             }
@@ -300,6 +318,8 @@ class KomgaLibraryScreenModel(
         val filters = komgaSource.buildFilterListForLibrary(
             libraryId = libraryId,
             allowedLibraryIds = currentAllowedLibraryIds(),
+            libraryScope = libraryScope,
+            currentFilters = state.value.filters,
         )
         mutableState.update {
             it.copy(
@@ -309,6 +329,7 @@ class KomgaLibraryScreenModel(
                 toolbarQuery = null,
             )
         }
+        komgaSource.saveSessionFilterState(filters, libraryScope)
         komgaSource.refreshBrowseRequests()
         refreshSignal.value += 1
     }
@@ -332,7 +353,7 @@ class KomgaLibraryScreenModel(
                     komgaLibraries = persistentListOf(),
                     selectedKomgaLibraryId = null,
                     isRefreshing = false,
-                    persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(),
+                    persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                 )
             }
             refreshSignal.value += 1
@@ -353,6 +374,9 @@ class KomgaLibraryScreenModel(
                 libraryId = selectedLibraryId,
                 preservePersistentFilters = selectedLibraryId == null,
                 allowedLibraryIds = visibleLibraries.idsForScope(),
+                libraryScope = libraryScope,
+                currentFilters = currentFiltersForReload(),
+                preserveSessionFilters = true,
             )
 
             mutableState.update {
@@ -363,9 +387,11 @@ class KomgaLibraryScreenModel(
                     selectedKomgaLibraryId = selectedLibraryId,
                     isLibraryScopeEmpty = libraryScope != KomgaLibraryScope.ALL && visibleLibraries.isEmpty(),
                     toolbarQuery = null,
-                    persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(),
+                    persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                 )
             }
+            filtersInitialized = true
+            komgaSource.saveSessionFilterState(filters, libraryScope)
             if (forceRefresh) {
                 komgaSource.refreshBrowseRequests()
             }
@@ -384,7 +410,7 @@ class KomgaLibraryScreenModel(
                         komgaLibraries = persistentListOf(),
                         selectedKomgaLibraryId = null,
                         toolbarQuery = null,
-                        persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(),
+                        persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                     )
                 }
             }
@@ -408,15 +434,22 @@ class KomgaLibraryScreenModel(
         libraries: List<KomgaClassifiedLibrary>,
     ) {
         if (libraryScope == KomgaLibraryScope.ALL) return
+        // The cached classification can arrive before Komga's filter metadata. Building filters at
+        // that point produces an empty library group which would override the persisted selection.
+        if (!filtersInitialized) return
         val visibleLibraries = libraries
             .filter { it.kind == libraryScope.kind }
             .map { LibraryDto(it.id, it.name) }
+        if (state.value.komgaLibraries == visibleLibraries) return
         val selectedLibraryId = state.value.selectedKomgaLibraryId
             ?.takeIf { selectedId -> visibleLibraries.any { it.id == selectedId } }
         val filters = komgaSource.buildFilterListForLibrary(
             libraryId = selectedLibraryId,
             preservePersistentFilters = selectedLibraryId == null,
             allowedLibraryIds = visibleLibraries.mapTo(linkedSetOf(), LibraryDto::id),
+            libraryScope = libraryScope,
+            currentFilters = currentFiltersForReload(),
+            preserveSessionFilters = true,
         )
         mutableState.update {
             it.copy(
@@ -428,6 +461,7 @@ class KomgaLibraryScreenModel(
                 isLibraryScopeEmpty = visibleLibraries.isEmpty(),
             )
         }
+        komgaSource.saveSessionFilterState(filters, libraryScope)
         refreshSignal.value += 1
     }
 
@@ -445,6 +479,11 @@ class KomgaLibraryScreenModel(
 
     private fun currentAllowedLibraryIds(): Set<String>? {
         return state.value.komgaLibraries.idsForScope()
+    }
+
+    private fun currentFiltersForReload(): FilterList? {
+        if (!filtersInitialized) return null
+        return state.value.listing.filters.takeIf { it.isNotEmpty() }
     }
 
     sealed class Listing(open val query: String?, open val filters: FilterList) {

--- a/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
+++ b/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
@@ -41,6 +41,7 @@ fun KomgaLibraryToolbar(
 ) {
     var selectingDisplayMode by remember { mutableStateOf(false) }
     var selectingServer by remember { mutableStateOf(false) }
+    val canSwitchServer = serverProfiles.size > 1
 
     SearchToolbar(
         navigateUp = navigateUp,
@@ -64,13 +65,15 @@ fun KomgaLibraryToolbar(
                                 onClick = { selectingDisplayMode = true },
                             ),
                         )
-                        add(
-                            AppBar.Action(
-                                title = stringResource(MR.strings.pref_komga_server),
-                                icon = Icons.Outlined.Storage,
-                                onClick = { selectingServer = true },
-                            ),
-                        )
+                        if (canSwitchServer) {
+                            add(
+                                AppBar.Action(
+                                    title = stringResource(MR.strings.pref_komga_server),
+                                    icon = Icons.Outlined.Storage,
+                                    onClick = { selectingServer = true },
+                                ),
+                            )
+                        }
                         if (showFilterAction) {
                             add(
                                 AppBar.Action(
@@ -84,17 +87,19 @@ fun KomgaLibraryToolbar(
                     .build(),
             )
 
-            DropdownMenu(
-                expanded = selectingServer,
-                onDismissRequest = { selectingServer = false },
-            ) {
-                serverProfiles.forEach { profile ->
-                    RadioMenuItem(
-                        text = { Text(text = profile.name) },
-                        isChecked = activeServerId == profile.id,
-                    ) {
-                        selectingServer = false
-                        onServerSelect(profile.id)
+            if (canSwitchServer) {
+                DropdownMenu(
+                    expanded = selectingServer,
+                    onDismissRequest = { selectingServer = false },
+                ) {
+                    serverProfiles.forEach { profile ->
+                        RadioMenuItem(
+                            text = { Text(text = profile.name) },
+                            isChecked = activeServerId == profile.id,
+                        ) {
+                            selectingServer = false
+                            onServerSelect(profile.id)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/koharia/source/komga/KomgaFilters.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaFilters.kt
@@ -29,6 +29,17 @@ class ReadFilter : Filter.CheckBox("Read", false)
 
 class OneshotFilter : Filter.CheckBox("Oneshot", false)
 
+class ReadingStateGroup :
+    Filter.Group<Filter.CheckBox>(
+        "Reading status and type",
+        listOf(
+            UnreadFilter(),
+            InProgressFilter(),
+            ReadFilter(),
+            OneshotFilter(),
+        ),
+    )
+
 class LibraryFilter(
     libraries: List<LibraryDto>,
     defaultLibraries: Set<String>,

--- a/app/src/main/java/koharia/source/komga/KomgaLibraryClassificationManager.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaLibraryClassificationManager.kt
@@ -91,7 +91,10 @@ class KomgaLibraryClassificationManager(
                 name = library.name,
             )
         }
-        serializedSnapshots.set((existingSnapshots + refreshedSnapshots).encodeSnapshots())
+        val updatedSnapshots = (existingSnapshots + refreshedSnapshots).encodeSnapshots()
+        if (updatedSnapshots != serializedSnapshots.get()) {
+            serializedSnapshots.set(updatedSnapshots)
+        }
     }
 
     fun setKind(serverId: Long, libraryId: String, kind: KomgaLibraryKind) {

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -290,7 +290,11 @@ class KomgaSource(
     }
 
     fun isPersistentFilteringEnabled(libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL): Boolean {
-        return preferences.getBoolean(persistentFilteringEnabledKey(libraryScope), false)
+        val scopedKey = persistentFilteringEnabledKey(libraryScope)
+        if (libraryScope != KomgaLibraryScope.ALL && !preferences.contains(scopedKey)) {
+            return preferences.getBoolean(PREF_PERSISTENT_FILTERS_ENABLED, false)
+        }
+        return preferences.getBoolean(scopedKey, false)
     }
 
     fun setPersistentFilteringEnabled(
@@ -666,8 +670,10 @@ class KomgaSource(
         libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
         currentFilters: FilterList? = null,
         preserveSessionFilters: Boolean = false,
+        fallbackLibraries: List<LibraryDto>? = null,
+        resetLibrarySelection: Boolean = false,
     ): FilterList {
-        val filters = getFilterList()
+        val filters = getFilterList().withFallbackLibraries(fallbackLibraries)
         val currentState = currentFilters
             ?.takeIf { it.isNotEmpty() }
             ?.toPersistentFilterState()
@@ -700,6 +706,9 @@ class KomgaSource(
         scopedFilters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.let { options ->
             when {
                 libraryId != null -> options.forEach { option -> option.state = option.id == libraryId }
+                resetLibrarySelection -> options.forEach { option ->
+                    option.state = allowedLibraryIds != null || option.id in defaultLibraries
+                }
                 allowedLibraryIds != null && options.none { it.state } -> options.forEach { it.state = true }
             }
         }
@@ -891,6 +900,19 @@ private fun FilterList.restrictLibraries(allowedLibraryIds: Set<String>?): Filte
                         .map { LibraryDto(id = it.id, name = it.name) },
                     defaultLibraries = selectedLibraryIds,
                 )
+            } else {
+                filter
+            }
+        },
+    )
+}
+
+private fun FilterList.withFallbackLibraries(fallbackLibraries: List<LibraryDto>?): FilterList {
+    if (fallbackLibraries.isNullOrEmpty()) return this
+    return FilterList(
+        map { filter ->
+            if (filter is LibraryFilter && filter.state.isEmpty()) {
+                LibraryFilter(fallbackLibraries, emptySet())
             } else {
                 filter
             }

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -245,10 +245,6 @@ class KomgaSource(
         fetchFilterOptions()
 
         val filters = mutableListOf<Filter<*>>(
-            UnreadFilter(),
-            InProgressFilter(),
-            ReadFilter(),
-            OneshotFilter(),
             TypeSelect(),
             CollectionSelect(
                 buildList {
@@ -257,6 +253,7 @@ class KomgaSource(
                 },
             ),
             LibraryFilter(libraries, defaultLibraries),
+            ReadingStateGroup(),
             UriMultiSelectFilter(
                 "Status",
                 listOf("Ongoing", "Ended", "Abandoned", "Hiatus").map {
@@ -292,44 +289,94 @@ class KomgaSource(
         }
     }
 
-    fun isPersistentFilteringEnabled(): Boolean {
-        return preferences.getBoolean(PREF_PERSISTENT_FILTERS_ENABLED, false)
+    fun isPersistentFilteringEnabled(libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL): Boolean {
+        return preferences.getBoolean(persistentFilteringEnabledKey(libraryScope), false)
     }
 
-    fun setPersistentFilteringEnabled(enabled: Boolean, filters: FilterList) {
+    fun setPersistentFilteringEnabled(
+        enabled: Boolean,
+        filters: FilterList,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+    ) {
         preferences.edit()
-            .putBoolean(PREF_PERSISTENT_FILTERS_ENABLED, enabled)
+            .putBoolean(persistentFilteringEnabledKey(libraryScope), enabled)
             .apply()
 
         if (enabled) {
-            savePersistentFilterState(filters)
+            savePersistentFilterState(filters, libraryScope)
         } else {
             preferences.edit()
-                .remove(PREF_PERSISTENT_FILTERS_STATE)
+                .remove(persistentFilterStateKey(libraryScope))
                 .apply()
         }
     }
 
-    fun resetPersistentFilters() {
+    fun resetPersistentFilters(libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL) {
+        val editor = preferences.edit()
+        if (libraryScope == KomgaLibraryScope.ALL) {
+            editor.remove(PREF_PERSISTENT_FILTERS_STATE)
+        } else {
+            // A scoped default prevents the legacy unscoped state from being restored again.
+            editor.putString(
+                persistentFilterStateKey(libraryScope),
+                json.encodeToString(defaultLibraryPersistentFilterState()),
+            )
+        }
+        editor.apply()
+    }
+
+    fun savePersistentFilterState(
+        filters: FilterList,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+    ) {
+        if (!isPersistentFilteringEnabled(libraryScope)) return
+
         preferences.edit()
-            .remove(PREF_PERSISTENT_FILTERS_STATE)
+            .putString(
+                persistentFilterStateKey(libraryScope),
+                json.encodeToString(filters.toPersistentFilterState()),
+            )
             .apply()
     }
 
-    fun savePersistentFilterState(filters: FilterList) {
-        if (!isPersistentFilteringEnabled()) return
-
-        preferences.edit()
-            .putString(PREF_PERSISTENT_FILTERS_STATE, json.encodeToString(filters.toPersistentFilterState()))
-            .apply()
+    fun saveSessionFilterState(
+        filters: FilterList,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+    ) {
+        synchronized(sessionFilterStates) {
+            sessionFilterStates[libraryScope] = filters.toPersistentFilterState()
+        }
     }
 
-    private fun applyPersistentFilterState(filters: FilterList) {
-        val saved = preferences.getString(PREF_PERSISTENT_FILTERS_STATE, null)
+    fun resetSessionFilterState(libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL) {
+        synchronized(sessionFilterStates) {
+            sessionFilterStates.remove(libraryScope)
+        }
+    }
+
+    private fun applyPersistentFilterState(
+        filters: FilterList,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+    ): Boolean {
+        val scopedState = preferences.getString(persistentFilterStateKey(libraryScope), null)
+        val legacyState = if (libraryScope != KomgaLibraryScope.ALL) {
+            preferences.getString(PREF_PERSISTENT_FILTERS_STATE, null)
+        } else {
+            null
+        }
+        val saved = (scopedState ?: legacyState)
             ?.let { runCatching { json.decodeFromString<PersistentFilterState>(it) }.getOrNull() }
-            ?: return
+            ?: return false
 
-        filters.forEach { filter ->
+        if (scopedState != null && libraryScope != KomgaLibraryScope.ALL) {
+            filters.resetFilterState()
+        }
+        filters.applyPersistentFilterState(saved)
+        return true
+    }
+
+    private fun FilterList.applyPersistentFilterState(saved: PersistentFilterState) {
+        forEach { filter ->
             when (filter) {
                 is Filter.CheckBox -> saved.checkBoxes[filter.name]?.let { filter.state = it }
                 is Filter.Select<*> -> saved.selects[filter.name]?.let { index ->
@@ -343,13 +390,36 @@ class KomgaSource(
                     }
                 }
                 is Filter.Group<*> -> {
-                    val selected = saved.groups[filter.name] ?: return@forEach
+                    val selected = saved.groups[filter.name]
                     filter.state
                         .filterIsInstance<Filter.CheckBox>()
-                        .forEach { it.state = it.persistentOptionKey() in selected }
+                        .forEach { option ->
+                            option.state = if (selected != null) {
+                                option.persistentOptionKey() in selected
+                            } else {
+                                // Preserve filters saved before standalone checkboxes were grouped in the UI.
+                                saved.checkBoxes[option.name] ?: option.state
+                            }
+                        }
                 }
                 else -> {}
             }
+        }
+    }
+
+    private fun persistentFilterStateKey(libraryScope: KomgaLibraryScope): String {
+        return when (libraryScope) {
+            KomgaLibraryScope.ALL -> PREF_PERSISTENT_FILTERS_STATE
+            KomgaLibraryScope.COMIC -> PREF_PERSISTENT_FILTERS_STATE_COMIC
+            KomgaLibraryScope.BOOK -> PREF_PERSISTENT_FILTERS_STATE_BOOK
+        }
+    }
+
+    private fun persistentFilteringEnabledKey(libraryScope: KomgaLibraryScope): String {
+        return when (libraryScope) {
+            KomgaLibraryScope.ALL -> PREF_PERSISTENT_FILTERS_ENABLED
+            KomgaLibraryScope.COMIC -> PREF_PERSISTENT_FILTERS_ENABLED_COMIC
+            KomgaLibraryScope.BOOK -> PREF_PERSISTENT_FILTERS_ENABLED_BOOK
         }
     }
 
@@ -593,25 +663,54 @@ class KomgaSource(
         libraryId: String?,
         preservePersistentFilters: Boolean = false,
         allowedLibraryIds: Set<String>? = null,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+        currentFilters: FilterList? = null,
+        preserveSessionFilters: Boolean = false,
     ): FilterList {
-        val filters = getFilterList().restrictLibraries(allowedLibraryIds)
-        if (libraryId == null && preservePersistentFilters && isPersistentFilteringEnabled()) {
-            if (allowedLibraryIds == null) return filters
+        val filters = getFilterList()
+        val currentState = currentFilters
+            ?.takeIf { it.isNotEmpty() }
+            ?.toPersistentFilterState()
+        val sessionState = if (preserveSessionFilters) {
+            synchronized(sessionFilterStates) { sessionFilterStates[libraryScope] }
+        } else {
+            null
         }
+        val hasPreservedState = when {
+            currentState != null -> {
+                filters.applyPersistentFilterState(currentState)
+                true
+            }
+            sessionState != null -> {
+                filters.applyPersistentFilterState(sessionState)
+                true
+            }
+            preservePersistentFilters && isPersistentFilteringEnabled(libraryScope) -> {
+                applyPersistentFilterState(filters, libraryScope)
+            }
+            else -> false
+        }
+        val scopedFilters = filters.restrictLibraries(allowedLibraryIds)
 
-        filters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.forEach { option ->
-            option.state = if (libraryId == null) {
-                allowedLibraryIds != null || option.state
-            } else {
-                option.id == libraryId
+        if (!hasPreservedState) {
+            scopedFilters.resetFilterState()
+            scopedFilters.filterIsInstance<TypeSelect>().firstOrNull()?.state = 0
+            scopedFilters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(1, true)
+        }
+        scopedFilters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.let { options ->
+            when {
+                libraryId != null -> options.forEach { option -> option.state = option.id == libraryId }
+                allowedLibraryIds != null && options.none { it.state } -> options.forEach { it.state = true }
             }
         }
-        filters.filterIsInstance<TypeSelect>().firstOrNull()?.state = 0
-        filters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(1, true)
-        return filters
+        return scopedFilters
     }
 
-    fun buildFilterListForTagSearch(tag: String, allowedLibraryIds: Set<String>? = null): FilterList {
+    fun buildFilterListForTagSearch(
+        tag: String,
+        allowedLibraryIds: Set<String>? = null,
+        libraryScope: KomgaLibraryScope = KomgaLibraryScope.ALL,
+    ): FilterList {
         val targetGroup = when {
             tags.any { it.equals(tag, true) } -> "Tags"
             genres.any { it.equals(tag, true) } -> "Genres"
@@ -619,14 +718,15 @@ class KomgaSource(
         }
         Log.d("KomgaSource", "buildFilterListForTagSearch: tag=$tag targetGroup=$targetGroup")
 
-        val filters = getFilterList()
-            .restrictLibraries(allowedLibraryIds)
+        val filters = buildFilterListForLibrary(
+            libraryId = null,
+            preservePersistentFilters = true,
+            allowedLibraryIds = allowedLibraryIds,
+            libraryScope = libraryScope,
+            preserveSessionFilters = true,
+        )
             .withSelectedMultiOption(targetGroup, tag)
-        if (allowedLibraryIds != null) {
-            filters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.forEach { it.state = true }
-        }
         filters.filterIsInstance<TypeSelect>().firstOrNull()?.state = 0
-        filters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(1, true)
         return filters
     }
 
@@ -636,6 +736,7 @@ class KomgaSource(
     private var tags = emptySet<String>()
     private var publishers = emptySet<String>()
     private var authors = emptyMap<String, List<koharia.komga.api.dto.AuthorDto>>()
+    private val sessionFilterStates = mutableMapOf<KomgaLibraryScope, PersistentFilterState>()
 
     private var fetchFilterStatus = FetchFilterStatus.NOT_FETCHED
     private var fetchFiltersAttempts = 0
@@ -725,6 +826,13 @@ private data class PersistentSortState(
     val ascending: Boolean,
 )
 
+private fun defaultLibraryPersistentFilterState(): PersistentFilterState {
+    return PersistentFilterState(
+        selects = mapOf("Search for" to 0),
+        sorts = mapOf("Sort" to PersistentSortState(index = 1, ascending = true)),
+    )
+}
+
 private enum class FetchFilterStatus {
     NOT_FETCHED,
     FETCHING,
@@ -774,11 +882,14 @@ private fun FilterList.restrictLibraries(allowedLibraryIds: Set<String>?): Filte
     return FilterList(
         map { filter ->
             if (filter is LibraryFilter) {
+                val selectedLibraryIds = filter.state
+                    .filter { it.state && it.id in allowedLibraryIds }
+                    .mapTo(linkedSetOf(), UriMultiSelectOption::id)
                 LibraryFilter(
                     libraries = filter.state
                         .filter { it.id in allowedLibraryIds }
                         .map { LibraryDto(id = it.id, name = it.name) },
-                    defaultLibraries = emptySet(),
+                    defaultLibraries = selectedLibraryIds,
                 )
             } else {
                 filter
@@ -819,6 +930,21 @@ private fun FilterList.toPersistentFilterState(): PersistentFilterState {
     )
 }
 
+private fun FilterList.resetFilterState() {
+    forEach { filter ->
+        when (filter) {
+            is Filter.CheckBox -> filter.state = false
+            is Filter.Select<*> -> filter.state = 0
+            is Filter.Sort -> filter.state = null
+            is Filter.Group<*> ->
+                filter.state
+                    .filterIsInstance<Filter.CheckBox>()
+                    .forEach { it.state = false }
+            else -> {}
+        }
+    }
+}
+
 private fun Filter.CheckBox.persistentOptionKey(): String {
     return when (this) {
         is UriMultiSelectOption -> id
@@ -840,7 +966,11 @@ private const val PREF_DEFAULT_LIBRARIES = "Default libraries"
 private const val PREF_CHAPTER_NAME_TEMPLATE = "Chapter name template"
 private const val PREF_CHAPTER_NAME_TEMPLATE_DEFAULT = "{number} - {title} ({size})"
 private const val PREF_PERSISTENT_FILTERS_ENABLED = "Persistent filters enabled"
+private const val PREF_PERSISTENT_FILTERS_ENABLED_COMIC = "Persistent filters enabled comic"
+private const val PREF_PERSISTENT_FILTERS_ENABLED_BOOK = "Persistent filters enabled book"
 private const val PREF_PERSISTENT_FILTERS_STATE = "Persistent filters state"
+private const val PREF_PERSISTENT_FILTERS_STATE_COMIC = "Persistent filters state comic"
+private const val PREF_PERSISTENT_FILTERS_STATE_BOOK = "Persistent filters state book"
 
 private fun PreferenceScreen.addEditTextPreference(
     title: String,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -265,10 +265,10 @@
     <string name="komga_pref_chapter_name_template_dialog">Supported placeholders:\n- {title}\n- {seriesTitle}\n- {number}\n- {createdDate}\n- {releaseDate}\n- {size}\n- {sizeBytes}</string>
     <string name="komga_filter_fetch_failed">Failed to fetch filtering options from the server</string>
     <string name="komga_filter_fetch_hint">Press \"Reset\" to show filtering options</string>
-    <string name="komga_filter_search_for">Search for</string>
+    <string name="komga_filter_search_for">Content type</string>
     <string name="komga_filter_series">Series</string>
     <string name="komga_filter_read_lists">Read lists</string>
-    <string name="komga_filter_books">Books</string>
+    <string name="komga_filter_books">Single books</string>
     <string name="komga_filter_sort_relevance">Relevance</string>
     <string name="komga_filter_sort_alphabetically">Alphabetically</string>
     <string name="komga_filter_sort_date_added">Date added</string>
@@ -276,8 +276,10 @@
     <string name="komga_filter_in_progress">In progress</string>
     <string name="komga_filter_read">Read</string>
     <string name="komga_filter_oneshot">Oneshot</string>
+    <string name="komga_filter_reading_status_and_type">Reading status and type</string>
     <string name="komga_filter_libraries">Libraries</string>
-    <string name="komga_filter_collection">Collection</string>
+    <string name="komga_filter_collection">Series collection</string>
+    <string name="komga_filter_no_collection">Any</string>
     <string name="komga_filter_status_ended">Ended</string>
     <string name="komga_filter_status_abandoned">Abandoned</string>
     <string name="komga_filter_genres">Genres</string>
@@ -292,6 +294,10 @@
     <string name="komga_filter_author_editor">Editor</string>
     <string name="komga_filter_author_translator">Translator</string>
     <string name="komga_filter_author_conceptor">Conceptor</string>
+    <string name="komga_filter_author_illustrator">Illustrator</string>
+    <string name="komga_filter_author_artist">Artist</string>
+    <string name="komga_filter_author_narrator">Narrator</string>
+    <string name="komga_filter_author_contributor">Contributor</string>
     <string name="komga_filter_persist">Persist filters</string>
 
     <string name="pref_appearance_summary">Theme, date &amp; time format</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -98,10 +98,10 @@
     <string name="komga_pref_chapter_name_template_dialog">支持的占位符：\n- {title}\n- {seriesTitle}\n- {number}\n- {createdDate}\n- {releaseDate}\n- {size}\n- {sizeBytes}</string>
     <string name="komga_filter_fetch_failed">从服务器获取筛选选项失败</string>
     <string name="komga_filter_fetch_hint">点击“重置”后显示筛选选项</string>
-    <string name="komga_filter_search_for">搜索类型</string>
+    <string name="komga_filter_search_for">显示内容</string>
     <string name="komga_filter_series">系列</string>
     <string name="komga_filter_read_lists">阅读列表</string>
-    <string name="komga_filter_books">图书</string>
+    <string name="komga_filter_books">单本文件</string>
     <string name="komga_filter_sort_relevance">相关性</string>
     <string name="komga_filter_sort_alphabetically">名称</string>
     <string name="komga_filter_sort_date_added">添加时间</string>
@@ -109,8 +109,10 @@
     <string name="komga_filter_in_progress">继续阅读</string>
     <string name="komga_filter_read">已读</string>
     <string name="komga_filter_oneshot">单行本</string>
+    <string name="komga_filter_reading_status_and_type">阅读状态与类型</string>
     <string name="komga_filter_libraries">书库</string>
-    <string name="komga_filter_collection">合集</string>
+    <string name="komga_filter_collection">系列合集</string>
+    <string name="komga_filter_no_collection">不限</string>
     <string name="komga_filter_status_ended">完结</string>
     <string name="komga_filter_status_abandoned">已放弃</string>
     <string name="komga_filter_genres">题材</string>
@@ -125,6 +127,10 @@
     <string name="komga_filter_author_editor">主编</string>
     <string name="komga_filter_author_translator">翻译者</string>
     <string name="komga_filter_author_conceptor">原案</string>
+    <string name="komga_filter_author_illustrator">插画师</string>
+    <string name="komga_filter_author_artist">画师</string>
+    <string name="komga_filter_author_narrator">旁白</string>
+    <string name="komga_filter_author_contributor">贡献者</string>
     <string name="komga_filter_persist">持久化筛选</string>
     <string name="pref_library_columns">每行数目</string>
     <string name="portrait">竖屏</string>


### PR DESCRIPTION
## 修改内容 / What changed

- 为漫画与书籍书架分别保存筛选开关、筛选条件和会话状态，避免两个分区互相影响。
- 修复进入作品详情后返回、刷新书架以及重启应用时筛选条件丢失的问题。
- 修复启动阶段库分类缓存早于服务器筛选元数据返回时，已保存的书库选择被临时默认状态覆盖的问题。
- 将阅读状态与单行本选项归入统一分组，并根据系列、阅读列表和单本文件动态显示适用的筛选项。
- 完善筛选项与作者角色的中英文文案，并修正单本文件的排序字段。
- 仅在存在多个服务器配置时显示服务器切换按钮。

- Persist filter switches, selections, and session state independently for comic and book shelves.
- Preserve filters when returning from details, refreshing the shelf, and restarting the app.
- Prevent cached library classification from overriding persisted library selections before server filter metadata is ready.
- Group reading status and one-shot options, and show only filters relevant to series, read lists, or single books.
- Improve English and Chinese filter labels and correct single-book sorting.
- Hide the server switch action when only one server profile exists.

## 原因 / Root cause

启动时，缓存的库分类可能先于 Komga 筛选元数据返回。旧流程会在书库选项尚未建立时保存一个不完整的临时筛选状态，随后该状态以更高优先级覆盖已持久化的书库选择，并被范围保护逻辑补成全选。

During startup, cached library classification could arrive before Komga filter metadata. The previous flow saved an incomplete temporary filter state without library options, which later took precedence over persisted selections and was normalized to all libraries.

## 用户影响 / User impact

书库筛选现在能在重启和页面跳转后稳定恢复，漫画与书籍分区互不干扰，筛选界面也更简洁、易理解。

Library filters now restore reliably across restarts and navigation, remain isolated between comic and book shelves, and present a clearer filtering interface.

## 验证 / Checks

- `spotlessApply`
- `:app:compileDebugKotlin`
- `git diff --check`
