### PR TITLE
优化图片型 EPUB 的阅读器路由 / Optimize image-based EPUB reader routing

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -120,6 +120,8 @@ class KomgaApi(
                             url = "$baseUrl/api/v1/books/${book.id}",
                             readProgress = book.readProgress,
                             isEpub = book.media?.mediaProfile == "EPUB",
+                            isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
+                                (book.media?.pagesCount ?: 0) > 0,
                         )
                     }
             }
@@ -143,6 +145,8 @@ class KomgaApi(
                     completed = book.readProgress?.completed ?: false,
                     readDate = book.readProgress?.readDate,
                     isEpub = book.media?.mediaProfile == "EPUB",
+                    isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
+                        (book.media?.pagesCount ?: 0) > 0,
                     fileHash = book.fileHash,
                     fileLastModified = book.fileLastModified,
                     sizeBytes = book.sizeBytes,
@@ -176,6 +180,8 @@ class KomgaApi(
                                 url = "$baseUrl/api/v1/books/${book.id}",
                                 readProgress = book.readProgress,
                                 isEpub = book.media?.mediaProfile == "EPUB",
+                                isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
+                                    (book.media?.pagesCount ?: 0) > 0,
                             )
                         }
                 }
@@ -264,6 +270,7 @@ class KomgaApi(
         val url: String,
         val readProgress: BookReadProgressDto?,
         val isEpub: Boolean = false,
+        val isDivinaCompatibleEpub: Boolean = false,
     )
 
     data class BookProgressSnapshot(
@@ -273,6 +280,7 @@ class KomgaApi(
         val completed: Boolean,
         val readDate: String?,
         val isEpub: Boolean,
+        val isDivinaCompatibleEpub: Boolean,
         val fileHash: String?,
         val fileLastModified: String?,
         val sizeBytes: Long,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -120,8 +120,7 @@ class KomgaApi(
                             url = "$baseUrl/api/v1/books/${book.id}",
                             readProgress = book.readProgress,
                             isEpub = book.media?.mediaProfile == "EPUB",
-                            isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
-                                (book.media?.pagesCount ?: 0) > 0,
+                            isDivinaCompatibleEpub = book.media?.isDivinaCompatibleEpub == true,
                         )
                     }
             }
@@ -145,8 +144,7 @@ class KomgaApi(
                     completed = book.readProgress?.completed ?: false,
                     readDate = book.readProgress?.readDate,
                     isEpub = book.media?.mediaProfile == "EPUB",
-                    isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
-                        (book.media?.pagesCount ?: 0) > 0,
+                    isDivinaCompatibleEpub = book.media?.isDivinaCompatibleEpub == true,
                     fileHash = book.fileHash,
                     fileLastModified = book.fileLastModified,
                     sizeBytes = book.sizeBytes,
@@ -180,8 +178,7 @@ class KomgaApi(
                                 url = "$baseUrl/api/v1/books/${book.id}",
                                 readProgress = book.readProgress,
                                 isEpub = book.media?.mediaProfile == "EPUB",
-                                isDivinaCompatibleEpub = book.media?.epubDivinaCompatible == true &&
-                                    (book.media?.pagesCount ?: 0) > 0,
+                                isDivinaCompatibleEpub = book.media?.isDivinaCompatibleEpub == true,
                             )
                         }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaModels.kt
@@ -115,7 +115,11 @@ data class PageWrapperDto<T>(
 data class BookMediaDto(
     val mediaProfile: String = "",
     val pagesCount: Int = 0,
-)
+    val epubDivinaCompatible: Boolean = false,
+) {
+    val isDivinaCompatibleEpub: Boolean
+        get() = mediaProfile == "EPUB" && epubDivinaCompatible && pagesCount > 0
+}
 
 @Serializable
 data class BookDto(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.data.track.komga
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaSource
 import logcat.LogPriority
@@ -167,14 +168,17 @@ class KomgaProgressSyncService(
                     )
                 }
 
-            val shouldUpdatePage = !remote.isEpub &&
+            val usesPageProgress = !remote.isEpub ||
+                remote.isDivinaCompatibleEpub ||
+                KomgaChapterMemo.canOpenEpubAsPages(localChapter.memo)
+            val shouldUpdatePage = usesPageProgress &&
                 newLastPageRead != localChapter.lastPageRead
 
             if (newRead != localChapter.read || shouldUpdatePage) {
                 chapterUpdates += ChapterUpdate(
                     id = localChapter.id,
                     read = newRead,
-                    lastPageRead = newLastPageRead.takeUnless { remote.isEpub },
+                    lastPageRead = newLastPageRead.takeIf { usesPageProgress },
                 )
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -156,7 +156,8 @@ class KomgaProgressSyncService(
             }
             matchedChapterCount++
             val newRead = remoteProgress.completed
-            val newLastPageRead = ((remoteProgress.page ?: 1) - 1).coerceAtLeast(0).toLong()
+            val newLastPageRead = remoteProgress.page
+                ?.let { (it - 1).coerceAtLeast(0).toLong() }
 
             remoteProgress.readDate
                 ?.let(::parseReadDate)
@@ -172,6 +173,7 @@ class KomgaProgressSyncService(
                 remote.isDivinaCompatibleEpub ||
                 KomgaChapterMemo.canOpenEpubAsPages(localChapter.memo)
             val shouldUpdatePage = usesPageProgress &&
+                newLastPageRead != null &&
                 newLastPageRead != localChapter.lastPageRead
 
             if (newRead != localChapter.read || shouldUpdatePage) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgress.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/MangaRemoteProgress.kt
@@ -11,6 +11,7 @@ data class MangaRemoteProgressConflict(
     val remotePageIndex: Int,
     val remoteTotalPages: Int,
     val remoteVersion: String,
+    val migratesLegacyEpubProgress: Boolean = false,
 ) {
     val localPercent: Int
         get() = pageProgressPercent(localPageIndex, localTotalPages)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -40,6 +40,9 @@ import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
+import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.epub.progress.EpubPageProgress
+import koharia.epub.progress.KomgaEpubProgressSyncService
 import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
@@ -103,7 +106,9 @@ class ReaderViewModel @JvmOverloads constructor(
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
     globalLibraryPreferences: LibraryPreferences = Injekt.get(),
     private val komgaProgressSyncService: KomgaProgressSyncService = Injekt.get(),
-    scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
+    private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
+    private val getEpubProgress: GetEpubProgress = Injekt.get(),
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) : ViewModel() {
 
     val readerPreferences: ReaderPreferences =
@@ -308,10 +313,13 @@ class ReaderViewModel @JvmOverloads constructor(
                     val source = sourceManager.getOrStub(manga.source)
                     loader = ChapterLoader(context, downloadManager, downloadProvider, manga, source)
 
+                    val initialChapter = chapterList.first { chapterId == it.chapter.id }
+                    val initialPageIndex = chapterPageIndex.takeIf { it >= 0 }
+                        ?: restoreDivinaEpubPage(initialChapter)
                     loadChapter(
                         loader = loader!!,
-                        chapter = chapterList.first { chapterId == it.chapter.id },
-                        initialPageIndex = chapterPageIndex.takeIf { it >= 0 },
+                        chapter = initialChapter,
+                        initialPageIndex = initialPageIndex,
                     )
                     Result.success(true)
                 } else {
@@ -521,7 +529,7 @@ class ReaderViewModel @JvmOverloads constructor(
             "MangaStartup: remote progress check complete chapterId=$chapterId " +
                 "found=${remote != null}"
         }
-        if (remote == null || remote.isEpub) return
+        if (remote == null) return
 
         val oldMemo = chapter.memo
         val oldPublicationVersion = KomgaChapterMemo.publicationVersion(oldMemo)
@@ -532,9 +540,11 @@ class ReaderViewModel @JvmOverloads constructor(
             fileLastModified = remote.fileLastModified,
             sizeBytes = remote.sizeBytes,
             fileName = remote.fileName,
-            isEpub = false,
+            isEpub = remote.isEpub,
+            epubDivinaCompatible = remote.isDivinaCompatibleEpub.takeIf { remote.isEpub },
             pagesCount = remote.totalPages,
         )
+        val opensAsImagePages = remote.isEpub && KomgaChapterMemo.canOpenEpubAsPages(updatedMemo)
         val newPublicationVersion = KomgaChapterMemo.publicationVersion(updatedMemo)
         val publicationMetadataInitialized = oldPublicationVersion == null && newPublicationVersion != null
         val publicationChanged = hasPublicationChanged(oldPublicationVersion, newPublicationVersion)
@@ -555,6 +565,7 @@ class ReaderViewModel @JvmOverloads constructor(
             chapter.memo = updatedMemo
             updateChapter.await(ChapterUpdate(id = chapterId, memo = updatedMemo))
         }
+        if (remote.isEpub && !opensAsImagePages) return
 
         if (publicationChanged || pageCountChanged) {
             val refreshedPages = try {
@@ -590,18 +601,48 @@ class ReaderViewModel @JvmOverloads constructor(
         }
         if (getCurrentChapter() !== readerChapter) return
 
+        val legacyEpubProgress = if (opensAsImagePages && remote.pageIndex == null && !remote.completed) {
+            runCatching {
+                komgaEpubProgressSyncService.pullProgression(manga.source, remote.url).progression
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "MangaStartup: failed to read legacy EPUB progression chapterId=$chapterId"
+                }
+            }.getOrNull()
+        } else {
+            null
+        }
         val remotePageIndex = remote.pageIndex
-            ?: if (remote.completed && pages.isNotEmpty()) pages.lastIndex else return
+            ?: if (remote.completed && pages.isNotEmpty()) {
+                pages.lastIndex
+            } else {
+                EpubPageProgress.pageIndex(
+                    progression = legacyEpubProgress?.locator?.locations?.totalProgression,
+                    totalPages = pages.size,
+                ) ?: return
+            }
         if (remotePageIndex !in pages.indices) return
         val localPageIndex = readerChapter.requestedPage.coerceIn(0, pages.lastIndex)
-        if (remotePageIndex == localPageIndex) return
+        val migratesLegacyEpubProgress = legacyEpubProgress != null
+        if (remotePageIndex == localPageIndex) {
+            if (migratesLegacyEpubProgress) {
+                komgaProgressSyncService.pushPageProgress(
+                    sourceId = manga.source,
+                    chapterUrl = chapter.url,
+                    pageIndex = localPageIndex,
+                    totalPages = pages.size,
+                )
+            }
+            return
+        }
 
         val remoteVersion = listOf(
             chapterId,
-            remote.readDate.orEmpty(),
+            remote.readDate ?: legacyEpubProgress?.modifiedAt?.time?.toString().orEmpty(),
             remotePageIndex,
-            remote.totalPages,
+            remote.totalPages.takeIf { it > 0 } ?: pages.size,
             remote.completed,
+            if (migratesLegacyEpubProgress) "legacy-epub" else "page",
         ).joinToString(separator = ":")
         val shouldShow = synchronized(remoteProgressVersionsHandled) {
             remoteProgressVersionsHandled.add(remoteVersion)
@@ -617,9 +658,39 @@ class ReaderViewModel @JvmOverloads constructor(
                     remotePageIndex = remotePageIndex,
                     remoteTotalPages = remote.totalPages.takeIf { count -> count > 0 } ?: pages.size,
                     remoteVersion = remoteVersion,
+                    migratesLegacyEpubProgress = migratesLegacyEpubProgress,
                 ),
             )
         }
+    }
+
+    private suspend fun restoreDivinaEpubPage(readerChapter: ReaderChapter): Int? {
+        val chapter = readerChapter.chapter
+        if (!isDivinaEpub(readerChapter) || KomgaChapterMemo.isEpubPageProgressMigrated(chapter.memo)) return null
+        val chapterId = chapter.id ?: return null
+        val totalPages = KomgaChapterMemo.pagesCount(chapter.memo) ?: return null
+        val migratedPage = if (chapter.last_page_read > 0) {
+            null
+        } else {
+            EpubPageProgress.pageIndex(getEpubProgress.await(chapterId)?.progression, totalPages)
+        }
+        if (!incognitoMode) {
+            val migratedMemo = KomgaChapterMemo.markEpubPageProgressMigrated(chapter.memo)
+            chapter.memo = migratedMemo
+            migratedPage?.let { chapter.last_page_read = it }
+            updateChapter.await(
+                ChapterUpdate(
+                    id = chapterId,
+                    lastPageRead = migratedPage?.toLong(),
+                    memo = migratedMemo,
+                ),
+            )
+        }
+        return migratedPage
+    }
+
+    private fun isDivinaEpub(readerChapter: ReaderChapter): Boolean {
+        return KomgaChapterMemo.canOpenEpubAsPages(readerChapter.chapter.memo)
     }
 
     fun keepLocalProgress() {
@@ -658,6 +729,14 @@ class ReaderViewModel @JvmOverloads constructor(
                         lastPageRead = conflict.remotePageIndex.toLong(),
                     ),
                 )
+                if (conflict.migratesLegacyEpubProgress) {
+                    komgaProgressSyncService.pushPageProgress(
+                        sourceId = manga?.source ?: return@launchNonCancellable,
+                        chapterUrl = currentChapter.chapter.url,
+                        pageIndex = targetPage.index,
+                        totalPages = pages.size,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -108,7 +108,11 @@ class ChapterLoader(
                 downloadManager,
                 downloadProvider,
             )
-            completeEpubCache != null -> CompleteEpubCachePageLoader(completeEpubCache, epubCacheManager)
+            completeEpubCache != null -> CompleteEpubCachePageLoader(
+                file = completeEpubCache,
+                cacheManager = epubCacheManager,
+                expectedPageCount = checkNotNull(KomgaChapterMemo.pagesCount(dbChapter.memo)),
+            )
             source is HttpSource -> HttpPageLoader(chapter, source)
             source is StubSource -> error(context.stringResource(MR.strings.source_not_installed, source.toString()))
             else -> error(context.stringResource(MR.strings.loader_not_implemented_error))

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -6,10 +6,13 @@ import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import koharia.epub.cache.EpubCacheManager
 import koharia.epub.cache.EpubCachePolicy
 import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CancellationException
+import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
@@ -45,10 +48,12 @@ class ChapterLoader(
         withIOContext {
             logcat { "Loading pages for ${chapter.chapter.name}" }
             try {
-                val loader = getPageLoader(chapter)
+                val initialLoader = getPageLoader(chapter)
+                chapter.pageLoader = initialLoader
+                val (loader, loadedPages) = loadPagesWithCacheFallback(chapter, initialLoader)
                 chapter.pageLoader = loader
 
-                val pages = loader.getPages()
+                val pages = loadedPages
                     .onEach { it.chapter = chapter }
 
                 if (pages.isEmpty()) {
@@ -70,6 +75,44 @@ class ChapterLoader(
                 throw e
             }
         }
+    }
+
+    private suspend fun loadPagesWithCacheFallback(
+        chapter: ReaderChapter,
+        initialLoader: PageLoader,
+    ): Pair<PageLoader, List<ReaderPage>> {
+        val pages = try {
+            initialLoader.getPages()
+        } catch (error: Throwable) {
+            if (error is CancellationException || initialLoader !is CompleteEpubCachePageLoader ||
+                source !is HttpSource
+            ) {
+                throw error
+            }
+            logcat(LogPriority.WARN, error) {
+                "Unable to read cached EPUB pages; falling back to the network"
+            }
+            return loadPagesFromNetwork(chapter, initialLoader, source)
+        }
+
+        if (pages.isEmpty() && initialLoader is CompleteEpubCachePageLoader && source is HttpSource) {
+            logcat(LogPriority.WARN) {
+                "Cached EPUB pages were rejected; falling back to the network"
+            }
+            return loadPagesFromNetwork(chapter, initialLoader, source)
+        }
+        return initialLoader to pages
+    }
+
+    private suspend fun loadPagesFromNetwork(
+        chapter: ReaderChapter,
+        cacheLoader: CompleteEpubCachePageLoader,
+        httpSource: HttpSource,
+    ): Pair<PageLoader, List<ReaderPage>> {
+        cacheLoader.recycle()
+        val networkLoader = HttpPageLoader(chapter, httpSource)
+        chapter.pageLoader = networkLoader
+        return networkLoader to networkLoader.getPages()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/ChapterLoader.kt
@@ -6,12 +6,19 @@ import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
+import koharia.epub.cache.EpubCacheManager
+import koharia.epub.cache.EpubCachePolicy
+import koharia.komga.download.KomgaChapterMemo
+import koharia.source.komga.KomgaSource
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.source.model.StubSource
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+import java.io.File
 
 /**
  * Loader used to retrieve the [PageLoader] for a given chapter.
@@ -22,6 +29,7 @@ class ChapterLoader(
     private val downloadProvider: DownloadProvider,
     private val manga: Manga,
     private val source: Source,
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
 ) {
 
     /**
@@ -84,12 +92,13 @@ class ChapterLoader(
             manga.source,
             skipCache = true,
         )
+        val completeEpubCache = if (!isDownloaded) findCompleteEpubCache(dbChapter) else null
         logcat {
             "KohariaOfflineDebug: chapter loader selected " +
                 "mangaId=${manga.id} mangaTitle=${manga.title} " +
                 "chapterId=${dbChapter.id} chapterName=${dbChapter.name} " +
                 "chapterUrl=${dbChapter.url} source=${source.name} " +
-                "downloadedOnDisk=$isDownloaded"
+                "downloadedOnDisk=$isDownloaded completeEpubCache=${completeEpubCache != null}"
         }
         return when {
             isDownloaded -> DownloadPageLoader(
@@ -99,9 +108,23 @@ class ChapterLoader(
                 downloadManager,
                 downloadProvider,
             )
+            completeEpubCache != null -> CompleteEpubCachePageLoader(completeEpubCache, epubCacheManager)
             source is HttpSource -> HttpPageLoader(chapter, source)
             source is StubSource -> error(context.stringResource(MR.strings.source_not_installed, source.toString()))
             else -> error(context.stringResource(MR.strings.loader_not_implemented_error))
         }
+    }
+
+    private fun findCompleteEpubCache(chapter: eu.kanade.tachiyomi.data.database.models.Chapter): File? {
+        val komgaSource = source as? KomgaSource ?: return null
+        if (!KomgaChapterMemo.canOpenEpubAsPages(chapter.memo)) return null
+        val fingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
+        val publicationKey = EpubCachePolicy.publicationKey(
+            fileHash = fingerprint?.fileHash,
+            fileLastModified = KomgaChapterMemo.fileLastModified(chapter.memo),
+            sizeBytes = fingerprint?.sizeBytes ?: 0L,
+            fallback = "book:${chapter.id}:${chapter.url}",
+        )
+        return epubCacheManager.completeBookFile(komgaSource.id, publicationKey)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CompleteEpubCachePageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CompleteEpubCachePageLoader.kt
@@ -5,12 +5,15 @@ import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
 import koharia.core.archive.ArchiveReader
 import koharia.core.archive.EpubReader
 import koharia.epub.cache.EpubCacheManager
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
 import java.io.File
 
 /** Uses the independent EPUB book cache without exposing it as a manual download. */
 internal class CompleteEpubCachePageLoader(
     private val file: File,
     private val cacheManager: EpubCacheManager,
+    private val expectedPageCount: Int,
 ) : PageLoader() {
 
     private var delegate: EpubPageLoader? = null
@@ -30,8 +33,24 @@ internal class CompleteEpubCachePageLoader(
             releaseLease()
             throw error
         }
-        delegate = loader
-        return loader.getPages()
+        return try {
+            val pages = loader.getPages()
+            if (pages.size != expectedPageCount) {
+                logcat(LogPriority.WARN) {
+                    "Cached EPUB page list rejected expected=$expectedPageCount actual=${pages.size}"
+                }
+                loader.recycle()
+                releaseLease()
+                emptyList()
+            } else {
+                delegate = loader
+                pages
+            }
+        } catch (error: Throwable) {
+            loader.recycle()
+            releaseLease()
+            throw error
+        }
     }
 
     override suspend fun loadPage(page: ReaderPage) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CompleteEpubCachePageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/CompleteEpubCachePageLoader.kt
@@ -1,0 +1,53 @@
+package eu.kanade.tachiyomi.ui.reader.loader
+
+import android.os.ParcelFileDescriptor
+import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import koharia.core.archive.ArchiveReader
+import koharia.core.archive.EpubReader
+import koharia.epub.cache.EpubCacheManager
+import java.io.File
+
+/** Uses the independent EPUB book cache without exposing it as a manual download. */
+internal class CompleteEpubCachePageLoader(
+    private val file: File,
+    private val cacheManager: EpubCacheManager,
+) : PageLoader() {
+
+    private var delegate: EpubPageLoader? = null
+    private var leaseAcquired = false
+
+    override var isLocal: Boolean = true
+
+    override suspend fun getPages(): List<ReaderPage> {
+        delegate?.let { return it.getPages() }
+        cacheManager.acquire(file)
+        leaseAcquired = true
+        val loader = try {
+            val archive = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+                .use { descriptor -> ArchiveReader(descriptor) }
+            EpubPageLoader(EpubReader(archive))
+        } catch (error: Throwable) {
+            releaseLease()
+            throw error
+        }
+        delegate = loader
+        return loader.getPages()
+    }
+
+    override suspend fun loadPage(page: ReaderPage) {
+        delegate?.loadPage(page)
+    }
+
+    override fun recycle() {
+        super.recycle()
+        delegate?.recycle()
+        delegate = null
+        releaseLease()
+    }
+
+    private fun releaseLease() {
+        if (!leaseAcquired) return
+        leaseAcquired = false
+        cacheManager.release(file)
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderLauncher.kt
@@ -57,10 +57,13 @@ class EpubReaderLauncher @JvmOverloads constructor(
                     mangaId = mangaId,
                     chapterId = chapterId,
                 )
-                if (resolution.isNativeSupported) {
-                    EpubReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId, resolution)
-                } else {
-                    ReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId)
+                when {
+                    resolution.shouldOpenAsPages ->
+                        ReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId)
+                    resolution.isNativeSupported ->
+                        EpubReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId, resolution)
+                    else ->
+                        ReaderActivity.newIntent(context, mangaId, chapterId, resolution.sourceId)
                 }
             }.getOrElse { error ->
                 logcat(LogPriority.WARN, error) {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -330,7 +330,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     .takeUnless { resolvedCompleteCache && cachedBookFile == null }
                 val preferredLocalUri = reusableResolvedLocalUri ?: downloadedUri ?: cachedBookUri
                 val needsRemoteDetails = !hasLauncherResolution &&
-                    (memoIsEpub == null || (memoIsEpub && memoIsDivinaCompatible == null))
+                    !KomgaChapterMemo.hasCompleteEpubClassification(chapter.memo)
                 val bookDetails = if (needsRemoteDetails) {
                     runCatching { source.getBookDetails(chapter.url) }
                         .getOrNull()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -314,6 +314,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
                 val memoFingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
                 val memoIsEpub = KomgaChapterMemo.isEpub(chapter.memo)
+                val memoIsDivinaCompatible = KomgaChapterMemo.isEpubDivinaCompatible(chapter.memo)
+                val memoPagesCount = KomgaChapterMemo.pagesCount(chapter.memo) ?: 0
                 val memoBookUrl = memoFingerprint?.bookUrl
                     ?: chapter.url.substringBefore('#').removeSuffix("/")
                 val remotePublicationKey = EpubCachePolicy.publicationKey(
@@ -328,13 +330,23 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     .takeUnless { resolvedCompleteCache && cachedBookFile == null }
                 val preferredLocalUri = reusableResolvedLocalUri ?: downloadedUri ?: cachedBookUri
                 val needsRemoteDetails = !hasLauncherResolution &&
-                    (preferredLocalUri == null || memoIsEpub == null)
+                    (memoIsEpub == null || (memoIsEpub && memoIsDivinaCompatible == null))
                 val bookDetails = if (needsRemoteDetails) {
                     runCatching { source.getBookDetails(chapter.url) }
                         .getOrNull()
                         ?.takeIf { it.isEpub }
                 } else {
                     null
+                }
+                if (bookDetails != null) {
+                    val updatedMemo = KomgaChapterMemo.mergeInto(
+                        existing = chapter.memo,
+                        baseUrl = source.baseUrl.trimEnd('/'),
+                        book = bookDetails,
+                    )
+                    if (updatedMemo != chapter.memo) {
+                        updateChapter.await(ChapterUpdate(id = chapter.id, memo = updatedMemo))
+                    }
                 }
                 val remoteBookUrl = when {
                     hasLauncherResolution -> resolvedRemoteBookUrl
@@ -347,7 +359,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                 } else {
                     bookDetails?.media?.let { media ->
                         media.isDivinaCompatibleEpub && media.pagesCount > 0
-                    } == true
+                    } ?: (memoIsEpub == true && memoIsDivinaCompatible == true && memoPagesCount > 0)
                 }
 
                 check(preferredLocalUri != null || remoteBookUrl != null) {

--- a/app/src/main/java/koharia/epub/progress/EpubPageProgress.kt
+++ b/app/src/main/java/koharia/epub/progress/EpubPageProgress.kt
@@ -1,0 +1,12 @@
+package koharia.epub.progress
+
+import kotlin.math.roundToInt
+
+internal object EpubPageProgress {
+
+    fun pageIndex(progression: Double?, totalPages: Int): Int? {
+        if (progression == null || totalPages <= 0) return null
+        if (totalPages == 1) return 0
+        return (progression.coerceIn(0.0, 1.0) * (totalPages - 1)).roundToInt()
+    }
+}

--- a/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
@@ -70,6 +70,8 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
 
         val memoFingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
         val memoIsEpub = KomgaChapterMemo.isEpub(chapter.memo)
+        val memoIsDivinaCompatible = KomgaChapterMemo.isEpubDivinaCompatible(chapter.memo)
+        val memoPagesCount = KomgaChapterMemo.pagesCount(chapter.memo) ?: 0
         val memoBookUrl = memoFingerprint?.bookUrl
             ?: chapter.url.substringBefore('#').removeSuffix("/")
         val remotePublicationKey = EpubCachePolicy.publicationKey(
@@ -87,7 +89,10 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             else -> null
         }
 
-        val remoteLookup = if (memoIsEpub != null || localUri != null || !application.isOnline()) {
+        val needsRemoteClassification = memoIsEpub == null ||
+            (memoIsEpub && memoIsDivinaCompatible == null)
+        val willRequestRemoteClassification = needsRemoteClassification && application.isOnline()
+        val remoteLookup = if (!willRequestRemoteClassification) {
             Result.success(null)
         } else {
             runCatching { source.getBookDetails(chapter.url) }
@@ -117,7 +122,9 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             else -> null
         }
 
-        val isDivinaCompatible = remoteBook?.media?.isDivinaCompatibleEpub == true
+        val isDivinaCompatible = remoteBook?.media?.let { media ->
+            media.isDivinaCompatibleEpub && media.pagesCount > 0
+        } ?: (memoIsEpub == true && memoIsDivinaCompatible == true && memoPagesCount > 0)
 
         val preferredOpenSource = when {
             localUri != null -> EpubOpenRequest.OpenSource.LOCAL
@@ -162,7 +169,8 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
         )
         logcat {
             "MangaStartup: reader route resolved chapterId=${chapter.id} " +
-                "memoType=$memoIsEpub metadataRequested=${memoIsEpub == null && localUri == null} " +
+                "memoType=$memoIsEpub memoDivina=$memoIsDivinaCompatible " +
+                "metadataRequested=$willRequestRemoteClassification divina=${resolution.shouldOpenAsPages} " +
                 "nativeEpub=${resolution.isNativeSupported}"
         }
         resolution
@@ -191,6 +199,9 @@ data class EpubReaderSupportResolution(
 
     val isNativeSupported: Boolean
         get() = preferredOpenSource != null
+
+    val shouldOpenAsPages: Boolean
+        get() = isNativeSupported && isDivinaCompatible
 
     fun toOpenRequest(): EpubOpenRequest? {
         val openSource = preferredOpenSource ?: return null

--- a/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
+++ b/app/src/main/java/koharia/epub/service/EpubReaderSupportResolver.kt
@@ -89,8 +89,7 @@ class EpubReaderSupportResolver @JvmOverloads constructor(
             else -> null
         }
 
-        val needsRemoteClassification = memoIsEpub == null ||
-            (memoIsEpub && memoIsDivinaCompatible == null)
+        val needsRemoteClassification = !KomgaChapterMemo.hasCompleteEpubClassification(chapter.memo)
         val willRequestRemoteClassification = needsRemoteClassification && application.isOnline()
         val remoteLookup = if (!willRequestRemoteClassification) {
             Result.success(null)

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -31,6 +31,7 @@ object KomgaChapterMemo {
     const val ISBN = "isbn"
     const val IS_EPUB = "isEpub"
     const val EPUB_DIVINA_COMPATIBLE = "epubDivinaCompatible"
+    const val EPUB_PAGE_PROGRESS_MIGRATED = "epubPageProgressMigrated"
     const val FILE_LAST_MODIFIED = "fileLastModified"
     const val FILE_NAME = "fileName"
     const val PAGES_COUNT = "pagesCount"
@@ -119,6 +120,7 @@ object KomgaChapterMemo {
         sizeBytes: Long,
         fileName: String?,
         isEpub: Boolean,
+        epubDivinaCompatible: Boolean? = null,
         pagesCount: Int,
     ): JsonObject {
         return buildJsonObject {
@@ -129,6 +131,7 @@ object KomgaChapterMemo {
             if (sizeBytes > 0L) put(SIZE_BYTES, sizeBytes)
             fileName?.takeIf(String::isNotBlank)?.let { put(FILE_NAME, it) }
             put(IS_EPUB, isEpub)
+            epubDivinaCompatible?.let { put(EPUB_DIVINA_COMPATIBLE, it) }
             if (pagesCount > 0) put(PAGES_COUNT, pagesCount)
         }
     }
@@ -153,6 +156,27 @@ object KomgaChapterMemo {
 
     fun isEpubDivinaCompatible(memo: JsonObject): Boolean? =
         memo[EPUB_DIVINA_COMPATIBLE]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
+
+    fun hasCompleteEpubClassification(memo: JsonObject): Boolean {
+        val isEpub = isEpub(memo) ?: return false
+        if (!isEpub) return true
+        val isDivinaCompatible = isEpubDivinaCompatible(memo) ?: return false
+        return !isDivinaCompatible || pagesCount(memo) != null
+    }
+
+    fun canOpenEpubAsPages(memo: JsonObject): Boolean {
+        return isEpub(memo) == true &&
+            isEpubDivinaCompatible(memo) == true &&
+            pagesCount(memo) != null
+    }
+
+    fun isEpubPageProgressMigrated(memo: JsonObject): Boolean =
+        memo[EPUB_PAGE_PROGRESS_MIGRATED]?.jsonPrimitive?.content?.toBooleanStrictOrNull() == true
+
+    fun markEpubPageProgressMigrated(memo: JsonObject): JsonObject = buildJsonObject {
+        memo.forEach { (key, value) -> put(key, value) }
+        put(EPUB_PAGE_PROGRESS_MIGRATED, true)
+    }
 
     fun fileLastModified(memo: JsonObject): String? = memo.string(FILE_LAST_MODIFIED)
 

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -30,6 +30,7 @@ object KomgaChapterMemo {
     const val NUMBER_SORT = "numberSort"
     const val ISBN = "isbn"
     const val IS_EPUB = "isEpub"
+    const val EPUB_DIVINA_COMPATIBLE = "epubDivinaCompatible"
     const val FILE_LAST_MODIFIED = "fileLastModified"
     const val FILE_NAME = "fileName"
     const val PAGES_COUNT = "pagesCount"
@@ -54,6 +55,7 @@ object KomgaChapterMemo {
         return buildJsonObject {
             fingerprint.forEach { (key, value) -> put(key, value) }
             put(IS_EPUB, book.isEpub)
+            put(EPUB_DIVINA_COMPATIBLE, book.media.epubDivinaCompatible)
             if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
             if (book.name.isNotBlank()) put(FILE_NAME, book.name)
             if (book.media.pagesCount > 0) put(PAGES_COUNT, book.media.pagesCount)
@@ -148,6 +150,9 @@ object KomgaChapterMemo {
     }
 
     fun isEpub(memo: JsonObject): Boolean? = memo[IS_EPUB]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
+
+    fun isEpubDivinaCompatible(memo: JsonObject): Boolean? =
+        memo[EPUB_DIVINA_COMPATIBLE]?.jsonPrimitive?.content?.toBooleanStrictOrNull()
 
     fun fileLastModified(memo: JsonObject): String? = memo.string(FILE_LAST_MODIFIED)
 

--- a/app/src/test/java/koharia/epub/progress/EpubPageProgressTest.kt
+++ b/app/src/test/java/koharia/epub/progress/EpubPageProgressTest.kt
@@ -1,0 +1,12 @@
+package koharia.epub.progress
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EpubPageProgressTest {
+
+    @Test
+    fun `legacy progression maps to an image page once`() {
+        assertEquals(2, EpubPageProgress.pageIndex(progression = 0.5, totalPages = 5))
+    }
+}

--- a/app/src/test/java/koharia/epub/service/EpubReaderSupportResolutionTest.kt
+++ b/app/src/test/java/koharia/epub/service/EpubReaderSupportResolutionTest.kt
@@ -1,0 +1,46 @@
+package koharia.epub.service
+
+import koharia.epub.model.EpubOpenRequest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubReaderSupportResolutionTest {
+
+    @Test
+    fun `divina compatible epub opens with page reader`() {
+        val resolution = EpubReaderSupportResolution(
+            mangaId = 1,
+            chapterId = 2,
+            isDivinaCompatible = true,
+            preferredOpenSource = EpubOpenRequest.OpenSource.REMOTE,
+        )
+
+        assertTrue(resolution.shouldOpenAsPages)
+    }
+
+    @Test
+    fun `regular epub stays in native epub reader`() {
+        val resolution = EpubReaderSupportResolution(
+            mangaId = 1,
+            chapterId = 2,
+            isDivinaCompatible = false,
+            preferredOpenSource = EpubOpenRequest.OpenSource.REMOTE,
+        )
+
+        assertFalse(resolution.shouldOpenAsPages)
+        assertTrue(resolution.isNativeSupported)
+    }
+
+    @Test
+    fun `unsupported publication cannot be routed as pages by epub classification`() {
+        val resolution = EpubReaderSupportResolution(
+            mangaId = 1,
+            chapterId = 2,
+            isDivinaCompatible = true,
+            preferredOpenSource = null,
+        )
+
+        assertFalse(resolution.shouldOpenAsPages)
+    }
+}

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -1,5 +1,8 @@
 package koharia.komga.download
 
+import koharia.komga.api.dto.BookDto
+import koharia.komga.api.dto.BookMetadataDto
+import koharia.komga.api.dto.MediaDto
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -8,6 +11,38 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class KomgaChapterMemoTest {
+
+    @Test
+    fun `book memo keeps epub page compatibility classification`() {
+        val book = BookDto(
+            id = "book-id",
+            name = "comic.epub",
+            fileLastModified = "2026-07-22T00:00:00Z",
+            media = MediaDto(
+                mediaType = "application/epub+zip",
+                mediaProfile = "EPUB",
+                epubDivinaCompatible = true,
+                pagesCount = 42,
+            ),
+            metadata = BookMetadataDto(title = "Image EPUB"),
+        )
+
+        val memo = KomgaChapterMemo.buildMemo("https://komga.test", book)
+
+        assertEquals(true, KomgaChapterMemo.isEpub(memo))
+        assertEquals(true, KomgaChapterMemo.isEpubDivinaCompatible(memo))
+        assertEquals(42, KomgaChapterMemo.pagesCount(memo))
+    }
+
+    @Test
+    fun `legacy memo without page compatibility remains unknown`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.IS_EPUB, true)
+            put(KomgaChapterMemo.PAGES_COUNT, 42)
+        }
+
+        assertEquals(null, KomgaChapterMemo.isEpubDivinaCompatible(memo))
+    }
 
     @Test
     fun `publication version prefers file hash`() {

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -42,6 +42,45 @@ class KomgaChapterMemoTest {
         }
 
         assertEquals(null, KomgaChapterMemo.isEpubDivinaCompatible(memo))
+        assertEquals(false, KomgaChapterMemo.hasCompleteEpubClassification(memo))
+    }
+
+    @Test
+    fun `divina classification remains incomplete until page count is available`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.IS_EPUB, true)
+            put(KomgaChapterMemo.EPUB_DIVINA_COMPATIBLE, true)
+        }
+
+        assertEquals(false, KomgaChapterMemo.hasCompleteEpubClassification(memo))
+        assertEquals(false, KomgaChapterMemo.canOpenEpubAsPages(memo))
+    }
+
+    @Test
+    fun `regular epub classification does not require image page count`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.IS_EPUB, true)
+            put(KomgaChapterMemo.EPUB_DIVINA_COMPATIBLE, false)
+        }
+
+        assertEquals(true, KomgaChapterMemo.hasCompleteEpubClassification(memo))
+        assertEquals(false, KomgaChapterMemo.canOpenEpubAsPages(memo))
+    }
+
+    @Test
+    fun `image epub page progress migration is recorded in memo`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.IS_EPUB, true)
+            put(KomgaChapterMemo.EPUB_DIVINA_COMPATIBLE, true)
+            put(KomgaChapterMemo.PAGES_COUNT, 42)
+        }
+
+        assertEquals(false, KomgaChapterMemo.isEpubPageProgressMigrated(memo))
+
+        val migrated = KomgaChapterMemo.markEpubPageProgressMigrated(memo)
+
+        assertEquals(true, KomgaChapterMemo.isEpubPageProgressMigrated(migrated))
+        assertEquals(42, KomgaChapterMemo.pagesCount(migrated))
     }
 
     @Test

--- a/core/archive/src/main/kotlin/koharia/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/koharia/core/archive/EpubReader.kt
@@ -6,6 +6,7 @@ import org.jsoup.parser.Parser
 import java.io.Closeable
 import java.io.File
 import java.io.InputStream
+import java.net.URLDecoder
 
 /**
  * Wrapper over ArchiveReader to load files in epub format.
@@ -24,9 +25,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         return reader.getInputStream(entryName)
     }
 
-    /**
-     * Returns the path of all the images found in the epub file.
-     */
+    /** Returns the single image represented by each spine item of a Divina-compatible EPUB. */
     fun getImagesFromPages(): List<String> {
         val ref = getPackageHref()
         val doc = getPackageDocument(ref)
@@ -56,38 +55,48 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         return getInputStream(ref)!!.use { Jsoup.parse(it, null, "", Parser.xmlParser()) }
     }
 
-    /**
-     * Returns all the pages from the epub.
-     */
-    private fun getPagesFromDocument(document: Document): List<String> {
-        val pages = document.select("manifest > item")
-            .filter { node -> "application/xhtml+xml" == node.attr("media-type") }
-            .associateBy { it.attr("id") }
+    private fun getPagesFromDocument(document: Document): List<ManifestItem> {
+        val manifest = document.select("*|manifest > *|item")
+            .associate { item ->
+                item.attr("id") to ManifestItem(
+                    href = item.attr("href"),
+                    mediaType = item.attr("media-type"),
+                )
+            }
 
-        val spine = document.select("spine > itemref").map { it.attr("idref") }
-        return spine.mapNotNull { pages[it] }.map { it.attr("href") }
+        return document.select("*|spine > *|itemref")
+            .mapNotNull { itemRef -> manifest[itemRef.attr("idref")] }
     }
 
-    /**
-     * Returns all the images contained in every page from the epub.
-     */
-    private fun getImagesFromPages(pages: List<String>, packageHref: String): List<String> {
-        val result = mutableListOf<String>()
+    private fun getImagesFromPages(pages: List<ManifestItem>, packageHref: String): List<String> {
+        if (pages.isEmpty()) return emptyList()
         val basePath = getParentDirectory(packageHref)
+        val result = ArrayList<String>(pages.size)
         pages.forEach { page ->
-            val entryPath = resolveZipPath(basePath, page)
-            val document = getInputStream(entryPath)!!.use { Jsoup.parse(it, null, "") }
-            val imageBasePath = getParentDirectory(entryPath)
-
-            document.allElements.forEach {
-                when (it.tagName()) {
-                    "img" -> result.add(resolveZipPath(imageBasePath, it.attr("src")))
-                    "image" -> result.add(resolveZipPath(imageBasePath, it.attr("xlink:href")))
-                }
+            val entryPath = resolveZipPath(basePath, URLDecoder.decode(page.href, Charsets.UTF_8.name()))
+            if (page.mediaType.startsWith("image/", ignoreCase = true)) {
+                result += entryPath
+                return@forEach
             }
+
+            val document = getInputStream(entryPath)?.use { Jsoup.parse(it, null, "") }
+                ?: return emptyList()
+            val imageBasePath = getParentDirectory(entryPath)
+            val imagePaths = buildList {
+                document.select("img[src]")
+                    .mapTo(this) { image -> image.attr("src") }
+                document.select("svg > image")
+                    .mapNotNullTo(this) { image ->
+                        image.attr("xlink:href").ifBlank { image.attr("href") }.ifBlank { null }
+                    }
+            }
+                .map { imageHref -> resolveZipPath(imageBasePath, imageHref) }
+                .distinct()
+            if (imagePaths.size != 1) return emptyList()
+            result += imagePaths.single()
         }
 
-        return result
+        return result.takeIf { it.size == pages.size }.orEmpty()
     }
 
     /**
@@ -133,4 +142,9 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
             ""
         }
     }
+
+    private data class ManifestItem(
+        val href: String,
+        val mediaType: String,
+    )
 }

--- a/core/archive/src/main/kotlin/koharia/core/archive/EpubReader.kt
+++ b/core/archive/src/main/kotlin/koharia/core/archive/EpubReader.kt
@@ -73,7 +73,7 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         val basePath = getParentDirectory(packageHref)
         val result = ArrayList<String>(pages.size)
         pages.forEach { page ->
-            val entryPath = resolveZipPath(basePath, URLDecoder.decode(page.href, Charsets.UTF_8.name()))
+            val entryPath = resolveZipPath(basePath, decodePathHref(page.href))
             if (page.mediaType.startsWith("image/", ignoreCase = true)) {
                 result += entryPath
                 return@forEach
@@ -97,6 +97,11 @@ class EpubReader(private val reader: ArchiveReader) : Closeable by reader {
         }
 
         return result.takeIf { it.size == pages.size }.orEmpty()
+    }
+
+    /** Decodes percent escapes without applying form semantics where a literal '+' means a space. */
+    private fun decodePathHref(href: String): String {
+        return URLDecoder.decode(href.replace("+", "%2B"), Charsets.UTF_8.name())
     }
 
     /**


### PR DESCRIPTION
## 修改内容 / Changes

- 根据 Komga 的 `mediaProfile`、`epubDivinaCompatible` 与 `pagesCount` 稳定区分普通 EPUB 和图片页兼容 EPUB。
- 图片页兼容 EPUB 默认使用漫画分页阅读器打开，普通 EPUB 继续使用 Readium 阅读器。
- 将 EPUB 图片页兼容标记保存到章节 memo，避免后续打开时重复请求服务器或丢失类型判断。
- 兼容旧章节数据：联网时仅补查一次缺失的分类信息并回写；离线且无法判断时保守使用 EPUB 阅读器。
- 补充章节 memo 持久化和阅读器路由相关单元测试。

## 用户影响 / User impact

图片式、扫描式 EPUB 可以直接获得漫画阅读器的分页体验，普通可重排 EPUB 的阅读方式保持不变。旧数据会在首次联网打开时自动补齐，不需要数据库迁移。

Image-based and scanned EPUB files now open directly in the comic page reader, while regular reflowable EPUB books continue to use Readium. Existing data is upgraded progressively on first online open without a database migration.

## 检查 / Checks

- `git diff --check`
- 按当前快速开发约定未运行 Gradle 编译；提交后由 CI 执行构建与测试。
