### PR TITLE
优化 EPUB 阅读器设置布局 / Refine EPUB reader settings layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Koharia is a Komga-focused Android reader forked from Mihon `0.19.9`. It uses Ko
 - Do not use destructive Git commands, force-push, commit, or push unless explicitly requested.
 - Treat `local.properties`, `keystore.properties`, `*.jks`, API keys, and tokens as secrets. Never print, log, or commit them.
 - Confirm the destination before pushing: `github` targets GitHub, while `origin` targets the self-hosted repository.
+- Pull request titles and descriptions must be written bilingually in Chinese and English.
 
 ### Formatting And Verification
 

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -237,7 +237,19 @@ private fun BrightnessRow(readerPreferences: ReaderPreferences) {
         .collectAsState(readerPreferences.customBrightnessValue.get())
     val followsSystem = !customBrightness
 
-    CompactSettingRow(label = stringResource(MR.strings.epub_reader_brightness)) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = stringResource(MR.strings.epub_reader_brightness),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
         Slider(
             value = brightnessValue.toFloat(),
             onValueChange = { readerPreferences.customBrightnessValue.set(it.roundToInt()) },
@@ -268,15 +280,16 @@ private fun BrightnessRow(readerPreferences: ReaderPreferences) {
                 )
             },
         )
-        Text(
-            text = if (followsSystem || brightnessValue == 0) {
-                stringResource(MR.strings.epub_reader_system_brightness_short)
-            } else {
-                "$brightnessValue%"
-            },
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.widthIn(min = 40.dp),
-        )
+        Spacer(modifier = Modifier.width(8.dp))
+        if (!followsSystem) {
+            Text(
+                text = "$brightnessValue%",
+                style = MaterialTheme.typography.labelMedium,
+                maxLines = 1,
+                modifier = Modifier.widthIn(min = 40.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+        }
         FilterChip(
             selected = followsSystem,
             onClick = {
@@ -478,10 +491,21 @@ fun EpubThemePreference(
         }
     }
 
-    CompactSettingRow(label = stringResource(MR.strings.pref_epub_theme)) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        Text(
+            text = stringResource(MR.strings.pref_epub_theme),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+        )
         Row(
             modifier = Modifier
-                .weight(1f)
+                .fillMaxWidth()
+                .padding(top = 8.dp)
                 .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -1160,8 +1184,9 @@ private fun CompactSettingRow(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.width(64.dp),
+            maxLines = 1,
         )
+        Spacer(modifier = Modifier.width(8.dp))
         content()
     }
 }

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -248,6 +248,8 @@ private fun BrightnessRow(readerPreferences: ReaderPreferences) {
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.widthIn(max = 96.dp),
         )
         Spacer(modifier = Modifier.width(8.dp))
         Slider(
@@ -283,7 +285,11 @@ private fun BrightnessRow(readerPreferences: ReaderPreferences) {
         Spacer(modifier = Modifier.width(8.dp))
         if (!followsSystem) {
             Text(
-                text = "$brightnessValue%",
+                text = if (brightnessValue == 0) {
+                    stringResource(MR.strings.epub_reader_system_brightness_short)
+                } else {
+                    "$brightnessValue%"
+                },
                 style = MaterialTheme.typography.labelMedium,
                 maxLines = 1,
                 modifier = Modifier.widthIn(min = 40.dp),

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -285,11 +285,7 @@ private fun BrightnessRow(readerPreferences: ReaderPreferences) {
         Spacer(modifier = Modifier.width(8.dp))
         if (!followsSystem) {
             Text(
-                text = if (brightnessValue == 0) {
-                    stringResource(MR.strings.epub_reader_system_brightness_short)
-                } else {
-                    "$brightnessValue%"
-                },
+                text = "$brightnessValue%",
                 style = MaterialTheme.typography.labelMedium,
                 maxLines = 1,
                 modifier = Modifier.widthIn(min = 40.dp),


### PR DESCRIPTION
## 修改内容

- 优化 EPUB 阅读器快捷设置面板的英文与中文布局。
- 亮度标题、滑块和“跟随系统”按钮保持同一行，并让标题按文字实际长度占位。
- 统一亮度与字号标题到控件之间的 8dp 间距，减少无意义留白并扩大可操作区域。
- 将背景设置标题与可横向滚动的颜色列表分层显示，避免英文长文本换行或贴近色块。
- 简化跟随系统亮度状态展示，仅在自定义亮度时显示百分比。
- 在 AGENTS.md 中补充 PR 标题和描述必须使用中英双语的协作规则。

## 用户影响

中英文界面下的 EPUB 阅读器设置排列更加稳定，亮度滑块拥有更合理的拖动宽度，字号和背景设置也更紧凑清晰。

## Changes

- Refine the EPUB reader quick-settings layout in both English and Chinese.
- Keep the brightness label, slider, and “Follow system” button on one row while sizing the label to its actual text.
- Use a consistent 8dp gap between brightness/font-size labels and their controls, reducing unused space and improving touch usability.
- Place the background-settings label above the horizontally scrollable color list to prevent wrapping and crowding.
- Simplify brightness status text so percentages are shown only for custom brightness.
- Document the bilingual pull request title and description requirement in AGENTS.md.

## User impact

The EPUB reader settings now remain clear and stable across Chinese and English interfaces, with a wider brightness slider and more compact typography and background controls.

## 检查 / Checks

- `git diff --check`
- 按当前快速开发约定未运行 Gradle 编译 / Gradle compilation was skipped under the current rapid-development workflow.