### PR TITLE
实现 EPUB 图片预览与操作 / Add EPUB image preview and actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Koharia is a Komga-focused Android reader forked from Mihon `0.19.9`. It uses Ko
 - Treat `local.properties`, `keystore.properties`, `*.jks`, API keys, and tokens as secrets. Never print, log, or commit them.
 - Confirm the destination before pushing: `github` targets GitHub, while `origin` targets the self-hosted repository.
 - Pull request titles and descriptions must be written bilingually in Chinese and English.
+- When debugging an emulator or physical device, prefer ADB commands. Do not use the `computer-use` skill unless the user explicitly requests device operation for validation or debugging; otherwise, provide manual validation and debugging instructions.
 
 ### Formatting And Verification
 

--- a/app/src/main/java/eu/kanade/presentation/reader/ReaderPageActionsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/reader/ReaderPageActionsDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.outlined.Photo
 import androidx.compose.material.icons.outlined.Save
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -35,6 +36,10 @@ fun ReaderPageActionsDialog(
     var showSetCoverDialog by remember { mutableStateOf(false) }
 
     AdaptiveSheet(onDismissRequest = onDismissRequest) {
+        val actionColors = ButtonDefaults.textButtonColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
         Row(
             modifier = Modifier.padding(vertical = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
@@ -43,12 +48,14 @@ fun ReaderPageActionsDialog(
                 modifier = Modifier.weight(1f),
                 title = stringResource(MR.strings.set_as_cover),
                 icon = Icons.Outlined.Photo,
+                colors = actionColors,
                 onClick = { showSetCoverDialog = true },
             )
             ActionButton(
                 modifier = Modifier.weight(1f),
-                title = stringResource(MR.strings.action_copy_to_clipboard),
+                title = stringResource(MR.strings.action_copy),
                 icon = Icons.Outlined.ContentCopy,
+                colors = actionColors,
                 onClick = {
                     onShare(true)
                     onDismissRequest()
@@ -58,6 +65,7 @@ fun ReaderPageActionsDialog(
                 modifier = Modifier.weight(1f),
                 title = stringResource(MR.strings.action_share),
                 icon = Icons.Outlined.Share,
+                colors = actionColors,
                 onClick = {
                     onShare(false)
                     onDismissRequest()
@@ -67,6 +75,7 @@ fun ReaderPageActionsDialog(
                 modifier = Modifier.weight(1f),
                 title = stringResource(MR.strings.action_save),
                 icon = Icons.Outlined.Save,
+                colors = actionColors,
                 onClick = {
                     onSave()
                     onDismissRequest()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import android.provider.MediaStore
-import android.webkit.MimeTypeMap
 import androidx.annotation.RequiresApi
 import androidx.core.content.contentValuesOf
 import androidx.core.net.toUri
@@ -32,15 +31,27 @@ class ImageSaver(
 
     fun save(image: Image): Uri {
         val data = image.data
-
-        val type = ImageUtil.findImageType(data) ?: throw IllegalArgumentException("Not an image")
-        val filename = DiskUtil.buildValidFilename("${image.name}.${type.extension}")
+        val format = resolveFormat(image, data)
+        val filename = DiskUtil.buildValidFilename("${image.name}.${format.extension}")
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || image.location !is Location.Pictures) {
             return save(data(), image.location.directory(context), filename)
         }
 
-        return saveApi29(image, type, filename, data)
+        return saveApi29(image, format, filename, data)
+    }
+
+    private fun resolveFormat(image: Image, data: () -> InputStream): EncodedFormat {
+        image.encodedFormat?.let { declared ->
+            if (declared.mimeType == SVG_MIME_TYPE) {
+                require(declared.extension.equals(SVG_EXTENSION, ignoreCase = true)) { "Invalid SVG extension" }
+                require(data().use(::isSvg)) { "Not an SVG image" }
+                return EncodedFormat(SVG_MIME_TYPE, SVG_EXTENSION)
+            }
+        }
+
+        val type = ImageUtil.findImageType(data) ?: throw IllegalArgumentException("Not an image")
+        return EncodedFormat(type.mime, type.extension)
     }
 
     private fun save(inputStream: InputStream, directory: File, filename: String): Uri {
@@ -62,13 +73,13 @@ class ImageSaver(
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun saveApi29(
         image: Image,
-        type: ImageUtil.ImageType,
+        format: EncodedFormat,
         filename: String,
         data: () -> InputStream,
     ): Uri {
-        val isMimeTypeSupported = MimeTypeMap.getSingleton().hasMimeType(type.mime)
+        val useImageCollection = format.mimeType != SVG_MIME_TYPE
 
-        val pictureDir = if (isMimeTypeSupported) {
+        val pictureDir = if (useImageCollection) {
             MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
         } else {
             MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
@@ -76,19 +87,19 @@ class ImageSaver(
 
         val imageLocation = (image.location as Location.Pictures).relativePath
         val relativePath = listOf(
-            if (isMimeTypeSupported) Environment.DIRECTORY_PICTURES else Environment.DIRECTORY_DOCUMENTS,
+            Environment.DIRECTORY_PICTURES,
             context.stringResource(MR.strings.app_name),
             imageLocation,
         ).joinToString(File.separator)
 
         val contentValues = contentValuesOf(
             MediaStore.MediaColumns.RELATIVE_PATH to relativePath,
-            MediaStore.MediaColumns.DISPLAY_NAME to if (isMimeTypeSupported) image.name else filename,
-            MediaStore.MediaColumns.MIME_TYPE to type.mime,
+            MediaStore.MediaColumns.DISPLAY_NAME to filename,
+            MediaStore.MediaColumns.MIME_TYPE to format.mimeType,
             MediaStore.MediaColumns.DATE_MODIFIED to Instant.now().epochSecond,
         )
 
-        val picture = findUriOrDefault(relativePath, filename) {
+        val picture = findUriOrDefault(pictureDir, relativePath, filename) {
             context.contentResolver.insert(
                 pictureDir,
                 contentValues,
@@ -112,7 +123,7 @@ class ImageSaver(
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun findUriOrDefault(path: String, filename: String, default: () -> Uri): Uri {
+    private fun findUriOrDefault(collection: Uri, path: String, filename: String, default: () -> Uri): Uri {
         val projection = arrayOf(
             MediaStore.MediaColumns._ID,
             MediaStore.MediaColumns.DISPLAY_NAME,
@@ -125,7 +136,7 @@ class ImageSaver(
         val normalizedPath = "${path.removeSuffix(File.separator)}${File.separator}"
 
         context.contentResolver.query(
-            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+            collection,
             projection,
             selection,
             arrayOf(normalizedPath, filename),
@@ -134,18 +145,28 @@ class ImageSaver(
             if (cursor != null && cursor.count >= 1) {
                 if (cursor.moveToFirst()) {
                     val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
-                    return ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id)
+                    return ContentUris.withAppendedId(collection, id)
                 }
             }
         }
 
         return default()
     }
+
+    private fun isSvg(input: InputStream): Boolean {
+        val prefix = input.bufferedReader().use { reader ->
+            val buffer = CharArray(SVG_PREFIX_CHARS)
+            val length = reader.read(buffer)
+            if (length <= 0) "" else String(buffer, 0, length)
+        }
+        return SVG_ROOT_PATTERN.containsMatchIn(prefix.trimStart('\uFEFF'))
+    }
 }
 
 sealed class Image(
     open val name: String,
     open val location: Location,
+    open val encodedFormat: EncodedFormat? = null,
 ) {
     data class Cover(
         val bitmap: Bitmap,
@@ -157,7 +178,8 @@ sealed class Image(
         val inputStream: () -> InputStream,
         override val name: String,
         override val location: Location,
-    ) : Image(name, location)
+        override val encodedFormat: EncodedFormat? = null,
+    ) : Image(name, location, encodedFormat)
 
     val data: () -> InputStream
         get() {
@@ -186,9 +208,12 @@ sealed interface Location {
 
     data object Cache : Location
 
+    data object EpubShareCache : Location
+
     fun directory(context: Context): File {
         return when (this) {
             Cache -> context.cacheImageDir
+            EpubShareCache -> File(context.cacheImageDir, "epub_share")
             is Pictures -> {
                 val file = File(
                     Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES),
@@ -205,3 +230,13 @@ sealed interface Location {
         }
     }
 }
+
+data class EncodedFormat(
+    val mimeType: String,
+    val extension: String,
+)
+
+private const val SVG_MIME_TYPE = "image/svg+xml"
+private const val SVG_EXTENSION = "svg"
+private const val SVG_PREFIX_CHARS = 16 * 1024
+private val SVG_ROOT_PATTERN = Regex("""<svg(?:\s|>)""", RegexOption.IGNORE_CASE)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/saver/ImageSaver.kt
@@ -77,13 +77,7 @@ class ImageSaver(
         filename: String,
         data: () -> InputStream,
     ): Uri {
-        val useImageCollection = format.mimeType != SVG_MIME_TYPE
-
-        val pictureDir = if (useImageCollection) {
-            MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
-        } else {
-            MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
-        }
+        val pictureDir = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
 
         val imageLocation = (image.location as Location.Pictures).relativePath
         val relativePath = listOf(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -20,6 +20,7 @@ import androidx.core.os.postDelayed
 import androidx.core.view.isVisible
 import coil3.BitmapImage
 import coil3.asDrawable
+import coil3.decode.Decoder
 import coil3.dispose
 import coil3.imageLoader
 import coil3.request.CachePolicy
@@ -177,10 +178,14 @@ open class ReaderPageImageView @JvmOverloads constructor(
     }
 
     /** Uses Coil and the zoomable image view for formats that cannot be decoded by SSIV. */
-    fun setImageWithCoil(source: BufferedSource, config: Config) {
+    fun setImageWithCoil(
+        source: BufferedSource,
+        config: Config,
+        decoderFactory: Decoder.Factory? = null,
+    ) {
         this.config = config
         prepareAnimatedImageView()
-        setAnimatedImage(source, config)
+        setAnimatedImage(source, config, decoderFactory)
     }
 
     fun recycle() = pageView?.let {
@@ -412,6 +417,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     private fun setAnimatedImage(
         data: Any,
         config: Config,
+        forcedDecoderFactory: Decoder.Factory? = null,
     ) = (pageView as? AppCompatImageView)?.apply {
         if (this is PhotoView) {
             setZoomTransitionDuration(config.zoomDuration.getSystemScaledDuration())
@@ -436,6 +442,9 @@ open class ReaderPageImageView @JvmOverloads constructor(
                 },
             )
             .crossfade(false)
+            .apply {
+                forcedDecoderFactory?.let(::decoderFactory)
+            }
             .build()
         context.imageLoader.enqueue(request)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -73,6 +73,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
     var onImageLoadError: ((Throwable?) -> Unit)? = null
     var onScaleChanged: ((newScale: Float) -> Unit)? = null
     var onViewClicked: (() -> Unit)? = null
+    var onViewTapped: ((isInsideImage: Boolean) -> Unit)? = null
 
     /**
      * For automatic background. Will be set as background color when [onImageLoaded] is called.
@@ -98,6 +99,11 @@ open class ReaderPageImageView @JvmOverloads constructor(
     @CallSuper
     open fun onViewClicked() {
         onViewClicked?.invoke()
+    }
+
+    private fun dispatchViewTapped(isInsideImage: Boolean) {
+        onViewTapped?.invoke(isInsideImage)
+        onViewClicked()
     }
 
     open fun onPageSelected(forward: Boolean) {
@@ -168,6 +174,13 @@ open class ReaderPageImageView @JvmOverloads constructor(
             prepareNonAnimatedImageView()
             setNonAnimatedImage(source, config)
         }
+    }
+
+    /** Uses Coil and the zoomable image view for formats that cannot be decoded by SSIV. */
+    fun setImageWithCoil(source: BufferedSource, config: Config) {
+        this.config = config
+        prepareAnimatedImageView()
+        setAnimatedImage(source, config)
     }
 
     fun recycle() = pageView?.let {
@@ -256,7 +269,25 @@ open class ReaderPageImageView @JvmOverloads constructor(
                     }
                 },
             )
-            setOnClickListener { this@ReaderPageImageView.onViewClicked() }
+            val tapDetector = GestureDetector(
+                context,
+                object : GestureDetector.SimpleOnGestureListener() {
+                    override fun onDown(e: MotionEvent): Boolean = true
+
+                    override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                        val sourcePoint = viewToSourceCoord(e.x, e.y)
+                        val isInsideImage = sourcePoint != null &&
+                            sourcePoint.x in 0f..sWidth.toFloat() &&
+                            sourcePoint.y in 0f..sHeight.toFloat()
+                        this@ReaderPageImageView.dispatchViewTapped(isInsideImage)
+                        return true
+                    }
+                },
+            )
+            setOnTouchListener { _, event ->
+                tapDetector.onTouchEvent(event)
+                false
+            }
         }
         addView(pageView, MATCH_PARENT, MATCH_PARENT)
     }
@@ -365,8 +396,8 @@ open class ReaderPageImageView @JvmOverloads constructor(
                         }
 
                         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
-                            this@ReaderPageImageView.onViewClicked()
-                            return super.onSingleTapConfirmed(e)
+                            this@ReaderPageImageView.dispatchViewTapped(displayRect?.contains(e.x, e.y) == true)
+                            return true
                         }
                     },
                 )

--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -24,6 +24,7 @@ internal fun buildEpubContinuousScrollInstallScript(
     resources: List<EpubContinuousScrollResource>,
     currentIndex: Int,
     initialProgression: Double,
+    imageInteractionScript: String,
     paragraphIndentScript: String,
 ): String {
     val resourcesJson = JSONArray().apply {
@@ -38,6 +39,7 @@ internal fun buildEpubContinuousScrollInstallScript(
         }
     }
     val indentScriptJson = JSONObject.quote(paragraphIndentScript)
+    val imageInteractionScriptJson = JSONObject.quote(imageInteractionScript)
     val clampedProgression = initialProgression.coerceIn(0.0, 1.0)
 
     return """
@@ -46,9 +48,10 @@ internal fun buildEpubContinuousScrollInstallScript(
             const currentIndex = $currentIndex;
             const initialProgression = $clampedProgression;
             const requestedParagraphIndentScript = $indentScriptJson;
+            const requestedImageInteractionScript = $imageInteractionScriptJson;
             const existing = window.__kohariaContinuousScroll;
             if (existing && existing.currentIndex === currentIndex) {
-                existing.refresh(requestedParagraphIndentScript);
+                existing.refresh(requestedParagraphIndentScript, requestedImageInteractionScript);
                 return 'ready';
             }
             if (!document.body || !resources.length || currentIndex < 0 || currentIndex >= resources.length) {
@@ -65,6 +68,15 @@ internal fun buildEpubContinuousScrollInstallScript(
             let locationFrame = 0;
             let lastLocationSentAt = 0;
             let paragraphIndentScript = requestedParagraphIndentScript;
+            let imageInteractionScript = requestedImageInteractionScript;
+
+            function installImageInteractions(targetWindow, resourceIndex) {
+                try {
+                    targetWindow.__kohariaImageResourceIndex = resourceIndex;
+                    targetWindow.eval(imageInteractionScript);
+                } catch (_) {}
+            }
+            installImageInteractions(window, currentIndex);
 
             const style = document.createElement('style');
             style.id = 'koharia-continuous-scroll-style';
@@ -184,6 +196,7 @@ internal fun buildEpubContinuousScrollInstallScript(
                         doc.body.style.setProperty('overflow', 'hidden', 'important');
                     }
                     try { iframe.contentWindow.eval(paragraphIndentScript); } catch (_) {}
+                    installImageInteractions(iframe.contentWindow, index);
                     const height = Math.max(
                         doc.documentElement.scrollHeight || 0,
                         doc.body ? doc.body.scrollHeight || 0 : 0,
@@ -329,9 +342,11 @@ internal fun buildEpubContinuousScrollInstallScript(
                 currentIndex: currentIndex,
                 resources: resources,
                 notifyLocation: notifyLocation,
-                refresh: function(nextParagraphIndentScript) {
+                refresh: function(nextParagraphIndentScript, nextImageInteractionScript) {
                     paragraphIndentScript = nextParagraphIndentScript;
+                    imageInteractionScript = nextImageInteractionScript;
                     try { window.eval(paragraphIndentScript); } catch (_) {}
+                    installImageInteractions(window, currentIndex);
                     const loadedIndexes = Array.from(liveFrames.keys());
                     loadedIndexes.forEach(unloadSection);
                     updateWindow(activeIndex);

--- a/app/src/main/java/koharia/epub/EpubImageInteraction.kt
+++ b/app/src/main/java/koharia/epub/EpubImageInteraction.kt
@@ -1,0 +1,150 @@
+package koharia.epub
+
+internal fun buildEpubImageInteractionInstallScript(
+    longPressTimeoutMs: Int,
+    touchSlopCssPx: Float,
+): String =
+    """
+    (function() {
+        const resourceIndex = Number.isInteger(window.__kohariaImageResourceIndex)
+            ? window.__kohariaImageResourceIndex
+            : -1;
+        const existing = window.__kohariaImageInteractions;
+        if (existing) {
+            existing.resourceIndex = resourceIndex;
+            return 'ready';
+        }
+
+        const state = {
+            resourceIndex: resourceIndex,
+            active: null,
+            suppressClickImage: null,
+        };
+        window.__kohariaImageInteractions = state;
+
+        function imageElementType(element) {
+            if (!element || !element.tagName) return null;
+            const tagName = (element.localName || element.tagName).toLowerCase();
+            if (tagName === 'img') return 'html';
+            if (tagName === 'image' && element.namespaceURI === '$SVG_NAMESPACE') return 'svg';
+            return null;
+        }
+
+        function eventImage(event) {
+            const target = event && event.target;
+            return imageElementType(target) ? target : null;
+        }
+
+        function rawImageSource(image, type) {
+            if (type === 'html') return image.getAttribute('src') || '';
+            return image.getAttribute('href') ||
+                image.getAttributeNS('$XLINK_NAMESPACE', 'href') ||
+                image.getAttribute('xlink:href') ||
+                '';
+        }
+
+        function resolvedImageSource(image, type, rawSource) {
+            if (type === 'html') return image.currentSrc || image.src || rawSource;
+            const href = image.href;
+            const hrefValue = typeof href === 'string'
+                ? href
+                : href && (href.baseVal || href.animVal);
+            const source = hrefValue || rawSource;
+            if (!source) return '';
+            try {
+                return new URL(source, document.baseURI).href;
+            } catch (_) {
+                return source;
+            }
+        }
+
+        function cancelLongPress() {
+            if (!state.active) return;
+            if (state.active.timer) clearTimeout(state.active.timer);
+            state.active = null;
+        }
+
+        function notify(action, image) {
+            const bridge = window.$EPUB_IMAGE_BRIDGE_NAME;
+            if (!bridge || !bridge.onImageInteraction) return false;
+            const type = imageElementType(image);
+            if (!type) return false;
+            const rawSource = rawImageSource(image, type);
+            const currentSource = resolvedImageSource(image, type, rawSource);
+            if (!currentSource && !rawSource) return false;
+            bridge.onImageInteraction(
+                action,
+                state.resourceIndex,
+                currentSource,
+                rawSource,
+                image.getAttribute('alt') || '',
+                image.getAttribute('title') || '',
+            );
+            return true;
+        }
+
+        document.addEventListener('pointerdown', function(event) {
+            const image = eventImage(event);
+            if (!image || event.isPrimary === false || (event.button !== undefined && event.button !== 0)) return;
+            cancelLongPress();
+            const active = {
+                image: image,
+                pointerId: event.pointerId,
+                startX: event.clientX,
+                startY: event.clientY,
+                timer: 0,
+            };
+            active.timer = window.setTimeout(function() {
+                if (state.active !== active) return;
+                state.active = null;
+                if (notify('actions', image)) state.suppressClickImage = image;
+            }, $longPressTimeoutMs);
+            state.active = active;
+        }, true);
+
+        document.addEventListener('pointermove', function(event) {
+            const active = state.active;
+            if (!active || active.pointerId !== event.pointerId) return;
+            const deltaX = event.clientX - active.startX;
+            const deltaY = event.clientY - active.startY;
+            if (Math.hypot(deltaX, deltaY) > $touchSlopCssPx) cancelLongPress();
+        }, { passive: true, capture: true });
+
+        document.addEventListener('pointerup', cancelLongPress, true);
+        document.addEventListener('pointercancel', cancelLongPress, true);
+        document.addEventListener('scroll', cancelLongPress, { passive: true, capture: true });
+
+        document.addEventListener('contextmenu', function(event) {
+            const image = eventImage(event);
+            if (!image) return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            cancelLongPress();
+            if (state.suppressClickImage !== image && notify('actions', image)) {
+                state.suppressClickImage = image;
+            }
+        }, true);
+
+        document.addEventListener('click', function(event) {
+            const image = eventImage(event);
+            if (!image) return;
+            if (state.suppressClickImage === image) {
+                state.suppressClickImage = null;
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                return;
+            }
+            if (image.closest && image.closest('a[href]')) return;
+            if (notify('preview', image)) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+        }, true);
+
+        return 'installed';
+    })()
+    """.trimIndent()
+
+internal const val EPUB_IMAGE_BRIDGE_NAME = "KohariaEpubImage"
+private const val SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+private const val XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"

--- a/app/src/main/java/koharia/epub/EpubImageModels.kt
+++ b/app/src/main/java/koharia/epub/EpubImageModels.kt
@@ -1,0 +1,66 @@
+package koharia.epub
+
+import android.net.Uri
+import androidx.compose.runtime.Immutable
+import okio.ByteString
+
+@Immutable
+data class EpubImageReference(
+    val documentHref: String,
+    val resourceIndex: Int,
+    val currentSource: String,
+    val rawSource: String,
+    val altText: String?,
+    val title: String?,
+)
+
+@Immutable
+internal data class EpubImageContent(
+    val reference: EpubImageReference,
+    val bytes: ByteString,
+    val mimeType: String,
+    val extension: String,
+    val originalFileName: String,
+    val isAnimated: Boolean,
+    val isSvg: Boolean,
+)
+
+@Immutable
+internal data class EpubImageUiState(
+    val reference: EpubImageReference? = null,
+    val content: EpubImageContent? = null,
+    val previewVisible: Boolean = false,
+    val actionsVisible: Boolean = false,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+) {
+    val isVisible: Boolean
+        get() = previewVisible || actionsVisible
+}
+
+enum class EpubImageInteraction {
+    PREVIEW,
+    ACTIONS,
+}
+
+internal sealed interface EpubImageEvent {
+    data class Share(val uri: Uri, val mimeType: String) : EpubImageEvent
+
+    data class Copy(val uri: Uri) : EpubImageEvent
+
+    data class Saved(val uri: Uri) : EpubImageEvent
+
+    data class Error(val message: String?) : EpubImageEvent
+}
+
+internal class EpubImageRequestTracker {
+    private var generation = 0L
+
+    fun next(): Long = ++generation
+
+    fun invalidate() {
+        generation += 1
+    }
+
+    fun isCurrent(request: Long): Boolean = request == generation
+}

--- a/app/src/main/java/koharia/epub/EpubImageOverlay.kt
+++ b/app/src/main/java/koharia/epub/EpubImageOverlay.kt
@@ -1,0 +1,270 @@
+package koharia.epub
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Fullscreen
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Save
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import eu.kanade.presentation.components.AdaptiveSheet
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
+import okio.Buffer
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.ActionButton
+import tachiyomi.presentation.core.components.material.padding
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+internal fun EpubImageOverlay(
+    state: EpubImageUiState,
+    onClosePreview: () -> Unit,
+    onDismissActions: () -> Unit,
+    onPreview: () -> Unit,
+    onShowActions: () -> Unit,
+    onRetry: () -> Unit,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    if (state.previewVisible) {
+        BackHandler(enabled = !state.actionsVisible, onBack = onClosePreview)
+        EpubImagePreview(
+            state = state,
+            onClose = onClosePreview,
+            onShowActions = onShowActions,
+            onRetry = onRetry,
+        )
+    }
+
+    if (state.actionsVisible) {
+        EpubImageActionsSheet(
+            isLoading = state.isLoading,
+            onDismissRequest = onDismissActions,
+            onPreview = onPreview,
+            onSave = onSave,
+            onShare = onShare,
+            onCopy = onCopy,
+        )
+    }
+}
+
+@Composable
+private fun EpubImagePreview(
+    state: EpubImageUiState,
+    onClose: () -> Unit,
+    onShowActions: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    var controlsVisible by rememberSaveable(state.reference) { mutableStateOf(true) }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .then(
+                if (state.content == null) {
+                    Modifier.clickable(
+                        interactionSource = null,
+                        indication = null,
+                        onClick = onClose,
+                    )
+                } else {
+                    Modifier
+                },
+            ),
+    ) {
+        state.content?.let { content ->
+            EpubZoomableImage(
+                content = content,
+                onImageClick = { controlsVisible = !controlsVisible },
+                onOutsideClick = onClose,
+            )
+        }
+
+        when {
+            state.isLoading -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                    color = Color.White,
+                )
+            }
+            state.errorMessage != null -> {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Text(text = state.errorMessage, color = Color.White)
+                    TextButton(onClick = onRetry) {
+                        Text(stringResource(MR.strings.action_retry))
+                    }
+                }
+            }
+        }
+
+        if (controlsVisible) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .background(Color.Black.copy(alpha = 0.55f))
+                    .statusBarsPadding()
+                    .padding(horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(MR.strings.action_close),
+                        tint = Color.White,
+                    )
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                IconButton(onClick = onShowActions, enabled = !state.isLoading && state.content != null) {
+                    Icon(
+                        imageVector = Icons.Outlined.MoreVert,
+                        contentDescription = stringResource(MR.strings.epub_reader_image_actions),
+                        tint = Color.White,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpubZoomableImage(
+    content: EpubImageContent,
+    onImageClick: () -> Unit,
+    onOutsideClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val imageView = remember(content) {
+        ReaderPageImageView(context).apply {
+            val source = Buffer().write(content.bytes)
+            val config = ReaderPageImageView.Config(
+                zoomDuration = IMAGE_ZOOM_DURATION_MS,
+                cropBorders = false,
+            )
+            if (content.isSvg) {
+                setImageWithCoil(source, config)
+            } else {
+                setImage(source, content.isAnimated, config)
+            }
+        }
+    }
+    DisposableEffect(imageView) {
+        onDispose {
+            imageView.onViewTapped = null
+            imageView.recycle()
+        }
+    }
+    AndroidView(
+        factory = { imageView },
+        update = { view ->
+            view.onViewTapped = { isInsideImage ->
+                if (isInsideImage) onImageClick() else onOutsideClick()
+            }
+        },
+        modifier = Modifier.fillMaxSize(),
+    )
+}
+
+@Composable
+private fun EpubImageActionsSheet(
+    isLoading: Boolean,
+    onDismissRequest: () -> Unit,
+    onPreview: () -> Unit,
+    onSave: () -> Unit,
+    onShare: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    AdaptiveSheet(onDismissRequest = onDismissRequest) {
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = MaterialTheme.padding.medium),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(28.dp))
+            }
+        } else {
+            val actionColors = ButtonDefaults.textButtonColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+            Row(
+                modifier = Modifier.padding(vertical = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+            ) {
+                ActionButton(
+                    modifier = Modifier.weight(1f),
+                    title = stringResource(MR.strings.epub_reader_image_preview),
+                    icon = Icons.Outlined.Fullscreen,
+                    colors = actionColors,
+                    onClick = onPreview,
+                )
+                ActionButton(
+                    modifier = Modifier.weight(1f),
+                    title = stringResource(MR.strings.action_save),
+                    icon = Icons.Outlined.Save,
+                    colors = actionColors,
+                    onClick = onSave,
+                )
+                ActionButton(
+                    modifier = Modifier.weight(1f),
+                    title = stringResource(MR.strings.action_share),
+                    icon = Icons.Outlined.Share,
+                    colors = actionColors,
+                    onClick = onShare,
+                )
+                ActionButton(
+                    modifier = Modifier.weight(1f),
+                    title = stringResource(MR.strings.action_copy),
+                    icon = Icons.Outlined.ContentCopy,
+                    colors = actionColors,
+                    onClick = onCopy,
+                )
+            }
+        }
+    }
+}
+
+private const val IMAGE_ZOOM_DURATION_MS = 250

--- a/app/src/main/java/koharia/epub/EpubImageOverlay.kt
+++ b/app/src/main/java/koharia/epub/EpubImageOverlay.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import coil3.svg.SvgDecoder
 import eu.kanade.presentation.components.AdaptiveSheet
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import okio.Buffer
@@ -183,7 +184,7 @@ private fun EpubZoomableImage(
                 cropBorders = false,
             )
             if (content.isSvg) {
-                setImageWithCoil(source, config)
+                setImageWithCoil(source, config, SvgDecoder.Factory())
             } else {
                 setImage(source, content.isAnimated, config)
             }

--- a/app/src/main/java/koharia/epub/EpubImageResourceLoader.kt
+++ b/app/src/main/java/koharia/epub/EpubImageResourceLoader.kt
@@ -1,0 +1,128 @@
+package koharia.epub
+
+import okio.Buffer
+import okio.ByteString.Companion.toByteString
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.getOrElse
+import tachiyomi.core.common.util.system.ImageUtil
+import java.io.IOException
+import java.net.URI
+import java.nio.charset.StandardCharsets
+
+internal suspend fun loadEpubImageContent(
+    publication: Publication,
+    reference: EpubImageReference,
+): EpubImageContent {
+    val documentLink = reference.resourceIndex
+        .takeIf { it >= 0 }
+        ?.let(publication.readingOrder::getOrNull)
+        ?: publication.readingOrder.firstOrNull { link ->
+            link.href.toString().sameEpubImageResource(reference.documentHref)
+        }
+        ?: throw IOException("EPUB image document is unavailable")
+
+    var lastError: Throwable? = null
+    for (url in epubImageCandidateUrls(documentLink, reference.currentSource, reference.rawSource)) {
+        val resource = publication.get(url) ?: continue
+        val bytes = try {
+            resource.read().getOrElse { error ->
+                throw IOException(error.message)
+            }
+        } catch (error: Throwable) {
+            lastError = error
+            continue
+        } finally {
+            resource.close()
+        }
+
+        val detectedType = ImageUtil.findImageType(bytes.inputStream())
+        val isSvg = detectedType == null && bytes.isSvgImage()
+        if (detectedType == null && !isSvg) {
+            lastError = IOException("Unsupported EPUB image format")
+            continue
+        }
+
+        val extension = detectedType?.extension ?: SVG_EXTENSION
+        val mimeType = detectedType?.mime ?: SVG_MIME_TYPE
+        val imageSource = Buffer().write(bytes)
+        val isAnimated = !isSvg && ImageUtil.isAnimatedAndSupported(imageSource)
+        imageSource.close()
+
+        val originalFileName = url.filename
+            ?.substringBeforeLast('.', missingDelimiterValue = url.filename.orEmpty())
+            ?.takeIf(String::isNotBlank)
+            ?: "image"
+
+        return EpubImageContent(
+            reference = reference,
+            bytes = bytes.toByteString(),
+            mimeType = mimeType,
+            extension = extension,
+            originalFileName = originalFileName,
+            isAnimated = isAnimated,
+            isSvg = isSvg,
+        )
+    }
+
+    throw IOException(lastError?.message ?: "EPUB image resource is unavailable", lastError)
+}
+
+internal fun epubImageCandidateUrls(
+    documentLink: Link,
+    currentSource: String,
+    rawSource: String,
+): List<Url> = epubImageCandidateHrefs(
+    documentHref = documentLink.href.toString(),
+    currentSource = currentSource,
+    rawSource = rawSource,
+).mapNotNull(Url::invoke)
+
+internal fun epubImageCandidateHrefs(
+    documentHref: String,
+    currentSource: String,
+    rawSource: String,
+): List<String> = buildList {
+    val documentUri = runCatching { URI(documentHref) }.getOrNull() ?: return@buildList
+
+    fun addCandidate(source: String) {
+        if (source.isBlank()) return
+        val sourceUri = runCatching { URI(source.trim()) }.getOrNull() ?: return
+        val scheme = sourceUri.scheme
+        if (scheme != null && !scheme.equals("http", true) && !scheme.equals("https", true)) return
+
+        add(documentUri.resolve(sourceUri).toString().substringBefore('#'))
+        if (sourceUri.rawAuthority.equals(READIUM_PACKAGE_AUTHORITY, ignoreCase = true)) {
+            sourceUri.rawPath
+                ?.trimStart('/')
+                ?.takeIf(String::isNotBlank)
+                ?.let { add(it) }
+        }
+    }
+
+    addCandidate(currentSource)
+    addCandidate(rawSource)
+}.filter(String::isNotBlank).distinct()
+
+private fun ByteArray.isSvgImage(): Boolean {
+    val prefix = copyOfRange(0, size.coerceAtMost(SVG_PREFIX_BYTES))
+        .toString(StandardCharsets.UTF_8)
+        .trimStart('\uFEFF')
+    return SVG_ROOT_PATTERN.containsMatchIn(prefix)
+}
+
+private fun String.sameEpubImageResource(other: String): Boolean {
+    val first = substringBefore('#').substringBefore('?').trimStart('/')
+    val second = other.substringBefore('#').substringBefore('?').trimStart('/')
+    return first == second || first.endsWith("/$second") || second.endsWith("/$first")
+}
+
+internal const val SVG_MIME_TYPE = "image/svg+xml"
+internal const val SVG_EXTENSION = "svg"
+private const val SVG_PREFIX_BYTES = 16 * 1024
+private const val READIUM_PACKAGE_AUTHORITY = "readium_package"
+private val SVG_ROOT_PATTERN = Regex(
+    pattern = """<svg(?:\s|>)""",
+    option = RegexOption.IGNORE_CASE,
+)

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -2,6 +2,7 @@ package koharia.epub
 
 import android.app.assist.AssistContent
 import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -79,6 +80,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.openInBrowser
+import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.view.setComposeContent
 import koharia.epub.service.EpubReaderSupportResolution
@@ -201,6 +203,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private var progressionSeekGeneration = 0L
     private var currentPublisherStyles: Boolean? = null
     private var readerFragment: EpubReaderFragment? = null
+    private var imagePreviewVisible = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         registerSecureActivity(this)
@@ -229,6 +232,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
         setComposeContent {
             val state by viewModel.state.collectAsState()
+            val imageState by viewModel.imageState.collectAsState()
             val tocEntries =
                 remember(state.chapterId, state.sessionToken, state.isReady) { viewModel.tableOfContents() }
             val adjacentTocEntries = remember(tocEntries, state.currentPosition, state.currentHref) {
@@ -326,6 +330,11 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
             DisposableEffect(Unit) {
                 onDispose(::resetEpubBrightness)
+            }
+
+            LaunchedEffect(imageState.previewVisible) {
+                imagePreviewVisible = imageState.previewVisible
+                updateSystemBars(state.menuVisible)
             }
 
             LaunchedEffect(forceNavigationOverlay) {
@@ -755,7 +764,23 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                     onDismissRequest = { showBookInfoDialog = false },
                 )
             }
+
+            EpubImageOverlay(
+                state = imageState,
+                onClosePreview = viewModel::closeImagePreview,
+                onDismissActions = viewModel::dismissImageActions,
+                onPreview = viewModel::loadSelectedImageForPreview,
+                onShowActions = viewModel::showImageActions,
+                onRetry = viewModel::retrySelectedImage,
+                onSave = { viewModel.saveSelectedImage(readerPreferences.folderPerManga.get()) },
+                onShare = { viewModel.shareSelectedImage(copyToClipboard = false) },
+                onCopy = { viewModel.shareSelectedImage(copyToClipboard = true) },
+            )
         }
+
+        viewModel.imageEvents
+            .onEach(::handleImageEvent)
+            .launchIn(lifecycleScope)
 
         if (viewModel.needsInit()) {
             val mangaId = intent.extras?.getLong("manga", -1L) ?: -1L
@@ -871,6 +896,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     override fun onTap(positionX: Float, positionY: Float): Boolean {
+        if (viewModel.imageState.value.isVisible) return true
         val isRightToLeft = epubLayoutPreferences.readingMode.get() == EpubLayoutPreferences.ReadingMode.PAGINATED &&
             epubLayoutPreferences.pageDirection.get() == EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT
         return when (resolveNavigationAction(positionX, positionY)) {
@@ -952,6 +978,14 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         openInBrowser(url.toUri(), forceDefaultBrowser = false)
     }
 
+    override fun onImageInteraction(reference: EpubImageReference, interaction: EpubImageInteraction) {
+        if (interaction == EpubImageInteraction.PREVIEW && viewModel.state.value.menuVisible) {
+            viewModel.showMenus(false)
+            return
+        }
+        viewModel.onImageInteraction(reference, interaction)
+    }
+
     override fun onNavigatorReady(fragment: EpubReaderFragment) {
         readerFragment = fragment
         if (paginationViewportJob?.isActive != true) {
@@ -968,7 +1002,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             event.keyCode == KeyEvent.KEYCODE_VOLUME_UP
         val state = viewModel.state.value
         if (!isVolumeKey || !epubLayoutPreferences.readWithVolumeKeys.get() ||
-            state.menuVisible || state.isSearchActive
+            state.menuVisible || state.isSearchActive || viewModel.imageState.value.isVisible
         ) {
             return super.dispatchKeyEvent(event)
         }
@@ -990,10 +1024,26 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     private fun updateSystemBars(visible: Boolean) {
-        if (visible || !readerPreferences.fullscreen.get()) {
+        if (imagePreviewVisible) {
+            windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        } else if (visible || !readerPreferences.fullscreen.get()) {
             windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
         } else {
             windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+        }
+    }
+
+    private fun handleImageEvent(event: EpubImageEvent) {
+        when (event) {
+            is EpubImageEvent.Share -> {
+                startActivity(event.uri.toShareIntent(applicationContext, event.mimeType))
+            }
+            is EpubImageEvent.Copy -> {
+                val clipboard = getSystemService(ClipboardManager::class.java) ?: return
+                clipboard.setPrimaryClip(ClipData.newUri(contentResolver, "", event.uri))
+            }
+            is EpubImageEvent.Saved -> toast(MR.strings.picture_saved)
+            is EpubImageEvent.Error -> toast(event.message)
         }
     }
 

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -2,7 +2,9 @@ package koharia.epub
 
 import android.content.Context
 import android.os.Bundle
+import android.view.HapticFeedbackConstants
 import android.view.View
+import android.view.ViewConfiguration
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.FrameLayout
@@ -58,6 +60,8 @@ class EpubReaderFragment : Fragment() {
 
         fun onExternalLinkActivated(url: AbsoluteUrl)
 
+        fun onImageInteraction(reference: EpubImageReference, interaction: EpubImageInteraction)
+
         fun onNavigatorReady(fragment: EpubReaderFragment)
 
         fun onSessionMissing(chapterId: Long)
@@ -85,6 +89,7 @@ class EpubReaderFragment : Fragment() {
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
     private var continuousScrollInstallJob: Job? = null
+    private var imageInteractionInstallJob: Job? = null
     private var continuousScrollInstalledHref: String? = null
     private var continuousScrollLocator: Locator? = null
 
@@ -106,6 +111,7 @@ class EpubReaderFragment : Fragment() {
         override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
             host?.onPageChanged(pageIndex, totalPages, locator)
             applyParagraphIndentOverride()
+            scheduleImageInteractionsInstall()
         }
     }
 
@@ -122,6 +128,9 @@ class EpubReaderFragment : Fragment() {
         val navigatorConfiguration = epubNavigatorConfiguration().apply {
             registerJavascriptInterface(CONTINUOUS_SCROLL_BRIDGE_NAME) {
                 ContinuousScrollJavascriptBridge()
+            }
+            registerJavascriptInterface(EPUB_IMAGE_BRIDGE_NAME) { resource ->
+                EpubImageJavascriptBridge(resource)
             }
         }
         childFragmentManager.fragmentFactory = session?.navigatorFactory?.createFragmentFactory(
@@ -220,6 +229,8 @@ class EpubReaderFragment : Fragment() {
 
     override fun onDestroyView() {
         clearContinuousScrollState()
+        imageInteractionInstallJob?.cancel()
+        imageInteractionInstallJob = null
         clearNavigatorInputListener()
         super.onDestroyView()
     }
@@ -263,6 +274,7 @@ class EpubReaderFragment : Fragment() {
         paragraphIndentOverrideEnabled = preferences.publisherStyles == false
         navigator?.submitPreferences(preferences)
         applyParagraphIndentOverride()
+        scheduleImageInteractionsInstall(navigator)
         if (keepContinuousScrollPosition) {
             // Keep the JS-reported Locator when the visible resource is an adjacent iframe. The
             // native navigator still points at the XHTML that owns the continuous-scroll window.
@@ -373,6 +385,7 @@ class EpubReaderFragment : Fragment() {
                         scheduleContinuousScrollInstall(navigator, locator)
                     }
                     applyParagraphIndentOverride()
+                    scheduleImageInteractionsInstall(navigator)
                 }
             }
         }
@@ -390,7 +403,31 @@ class EpubReaderFragment : Fragment() {
         navigator.viewLifecycleOwnerLiveData.observe(viewLifecycleOwner) { owner ->
             if (owner == null || !isAdded || view == null) return@observe
             host?.onNavigatorReady(this)
+            scheduleImageInteractionsInstall(navigator)
             scheduleContinuousScrollInstall(navigator)
+        }
+    }
+
+    private fun scheduleImageInteractionsInstall(
+        navigator: EpubNavigatorFragment? = readyNavigatorFragment(),
+    ) {
+        imageInteractionInstallJob?.cancel()
+        if (navigator == null || !isAdded || view == null) return
+        imageInteractionInstallJob = viewLifecycleOwner.lifecycleScope.launch {
+            delay(IMAGE_INTERACTION_INSTALL_DELAY_MS)
+            if (!isAdded || view == null || readyNavigatorFragment() !== navigator) return@launch
+            val configuration = ViewConfiguration.get(requireContext())
+            val density = resources.displayMetrics.density.takeIf { it > 0f } ?: 1f
+            runCatching {
+                navigator.evaluateJavascript(
+                    buildEpubImageInteractionInstallScript(
+                        longPressTimeoutMs = ViewConfiguration.getLongPressTimeout(),
+                        touchSlopCssPx = configuration.scaledTouchSlop / density,
+                    ),
+                )
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) { "Failed to install EPUB image interactions" }
+            }
         }
     }
 
@@ -432,6 +469,11 @@ class EpubReaderFragment : Fragment() {
                         resources = resources,
                         currentIndex = currentIndex,
                         initialProgression = locator.locations.progression ?: 0.0,
+                        imageInteractionScript = buildEpubImageInteractionInstallScript(
+                            longPressTimeoutMs = ViewConfiguration.getLongPressTimeout(),
+                            touchSlopCssPx = ViewConfiguration.get(requireContext()).scaledTouchSlop /
+                                (requireContext().resources.displayMetrics.density.takeIf { it > 0f } ?: 1f),
+                        ),
                         paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
                             APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
                         } else {
@@ -534,6 +576,51 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
+    @Suppress("unused")
+    private inner class EpubImageJavascriptBridge(
+        private val ownerResource: Link,
+    ) {
+        @JavascriptInterface
+        fun onImageInteraction(
+            action: String,
+            resourceIndex: Int,
+            currentSource: String,
+            rawSource: String,
+            altText: String,
+            title: String,
+        ) {
+            view?.post {
+                if (!isAdded || view == null || (currentSource.isBlank() && rawSource.isBlank())) return@post
+                val publication = sessionRepository.get(chapterId)?.publication ?: return@post
+                val resolvedIndex = resourceIndex.takeIf { it in publication.readingOrder.indices }
+                    ?: publication.readingOrder.indexOfFirst { link ->
+                        link.href.toString().sameEpubResource(ownerResource.href.toString())
+                    }
+                val documentHref = publication.readingOrder.getOrNull(resolvedIndex)?.href?.toString()
+                    ?: ownerResource.href.toString()
+                val interaction = when (action) {
+                    "preview" -> EpubImageInteraction.PREVIEW
+                    "actions" -> EpubImageInteraction.ACTIONS
+                    else -> return@post
+                }
+                if (interaction == EpubImageInteraction.ACTIONS) {
+                    view?.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                }
+                host?.onImageInteraction(
+                    reference = EpubImageReference(
+                        documentHref = documentHref,
+                        resourceIndex = resolvedIndex,
+                        currentSource = currentSource,
+                        rawSource = rawSource,
+                        altText = altText.takeIf(String::isNotBlank),
+                        title = title.takeIf(String::isNotBlank),
+                    ),
+                    interaction = interaction,
+                )
+            }
+        }
+    }
+
     private fun createContinuousScrollLocator(
         link: Link,
         progression: Double,
@@ -613,6 +700,7 @@ class EpubReaderFragment : Fragment() {
         private const val PARAGRAPH_INDENT_DEBUG_DELAY_MS = 600L
         private const val CONTINUOUS_SCROLL_BRIDGE_NAME = "KohariaContinuousScroll"
         private const val CONTINUOUS_SCROLL_INSTALL_DELAY_MS = 180L
+        private const val IMAGE_INTERACTION_INSTALL_DELAY_MS = 80L
         private val READIUM_PACKAGE_BASE_URL = AbsoluteUrl("https://readium_package/")!!
         private val PARAGRAPH_INDENT_DEBUG_SCRIPT =
             """

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -210,7 +210,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var completionMarkedThisSession = false
     private var searchIterator: SearchIterator? = null
     private var imageLoadJob: Job? = null
-    private var lastEpubShareFile: File? = null
     private var incognitoSession = basePreferences.incognitoMode.get()
     private val locatorPersistenceJob = viewModelScope.launch {
         locatorUpdates
@@ -756,14 +755,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
             mutableImageState.update { it.copy(isLoading = true) }
             runCatching {
                 withIOContext {
-                    lastEpubShareFile?.delete()
+                    Location.EpubShareCache.directory(application)
+                        .listFiles()
+                        ?.filter(File::isFile)
+                        ?.forEach { file -> file.delete() }
                     val image = content.toImage(location = Location.EpubShareCache)
-                    imageSaver.save(image).also {
-                        lastEpubShareFile = File(
-                            Location.EpubShareCache.directory(application),
-                            DiskUtil.buildValidFilename("${image.name}.${content.extension}"),
-                        )
-                    }
+                    imageSaver.save(image)
                 }
             }.onSuccess { uri ->
                 finishImageAction()
@@ -1745,7 +1742,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
     override fun onCleared() {
         imageLoadJob?.cancel()
         imageRequestTracker.invalidate()
-        lastEpubShareFile = null
         searchIterator?.close()
         searchIterator = null
         releaseCacheLeases()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -6,6 +6,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.download.DownloadProvider
+import eu.kanade.tachiyomi.data.saver.EncodedFormat
+import eu.kanade.tachiyomi.data.saver.Image
+import eu.kanade.tachiyomi.data.saver.ImageSaver
+import eu.kanade.tachiyomi.data.saver.Location
+import eu.kanade.tachiyomi.ui.reader.SaveImageNotifier
+import eu.kanade.tachiyomi.util.storage.DiskUtil
 import koharia.domain.epub.interactor.AddEpubBookmark
 import koharia.domain.epub.interactor.DeleteEpubBookmark
 import koharia.domain.epub.interactor.GetEpubBookmarks
@@ -39,10 +45,12 @@ import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
@@ -116,6 +124,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private val addEpubBookmark: AddEpubBookmark = Injekt.get(),
     private val deleteEpubBookmark: DeleteEpubBookmark = Injekt.get(),
     private val updateEpubBookmarkNote: UpdateEpubBookmarkNote = Injekt.get(),
+    private val imageSaver: ImageSaver = Injekt.get(),
     globalEpubReaderPreferences: EpubReaderPreferences = Injekt.get(),
     globalBasePreferences: BasePreferences = Injekt.get(),
     private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
@@ -134,6 +143,11 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     private val mutableState = MutableStateFlow(EpubReaderUiState())
     val state = mutableState.asStateFlow()
+    private val mutableImageState = MutableStateFlow(EpubImageUiState())
+    internal val imageState = mutableImageState.asStateFlow()
+    private val mutableImageEvents = MutableSharedFlow<EpubImageEvent>(extraBufferCapacity = 1)
+    internal val imageEvents = mutableImageEvents.asSharedFlow()
+    private val imageRequestTracker = EpubImageRequestTracker()
     private val locatorUpdates = MutableSharedFlow<Locator>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -195,6 +209,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var historyReadStartTime: Long? = null
     private var completionMarkedThisSession = false
     private var searchIterator: SearchIterator? = null
+    private var imageLoadJob: Job? = null
+    private var lastEpubShareFile: File? = null
     private var incognitoSession = basePreferences.incognitoMode.get()
     private val locatorPersistenceJob = viewModelScope.launch {
         locatorUpdates
@@ -650,6 +666,194 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun showMenus(visible: Boolean) {
         mutableState.update { it.copy(menuVisible = visible) }
+    }
+
+    internal fun onImageInteraction(
+        reference: EpubImageReference,
+        interaction: EpubImageInteraction,
+    ) {
+        imageLoadJob?.cancel()
+        imageRequestTracker.invalidate()
+        mutableImageState.value = EpubImageUiState(
+            reference = reference,
+            previewVisible = interaction == EpubImageInteraction.PREVIEW,
+            actionsVisible = interaction == EpubImageInteraction.ACTIONS,
+        )
+        showMenus(false)
+        if (interaction == EpubImageInteraction.PREVIEW) {
+            loadSelectedImageForPreview()
+        }
+    }
+
+    internal fun showImageActions() {
+        mutableImageState.update { state ->
+            if (state.reference == null) state else state.copy(actionsVisible = true)
+        }
+    }
+
+    internal fun dismissImageActions() {
+        if (!mutableImageState.value.previewVisible) {
+            imageLoadJob?.cancel()
+            imageRequestTracker.invalidate()
+        }
+        mutableImageState.update { state ->
+            if (state.previewVisible) {
+                state.copy(actionsVisible = false, isLoading = false)
+            } else {
+                EpubImageUiState()
+            }
+        }
+    }
+
+    internal fun closeImagePreview() {
+        imageLoadJob?.cancel()
+        imageLoadJob = null
+        imageRequestTracker.invalidate()
+        mutableImageState.value = EpubImageUiState()
+    }
+
+    internal fun loadSelectedImageForPreview() {
+        mutableImageState.update { state ->
+            state.copy(previewVisible = true, actionsVisible = false, errorMessage = null)
+        }
+        withSelectedImage { }
+    }
+
+    internal fun retrySelectedImage() {
+        withSelectedImage(forceReload = true) { }
+    }
+
+    internal fun saveSelectedImage(folderPerManga: Boolean) {
+        withSelectedImage { content ->
+            mutableImageState.update { it.copy(isLoading = true) }
+            val notifier = SaveImageNotifier(application).apply { onClear() }
+            runCatching {
+                withIOContext {
+                    val relativePath = if (folderPerManga) {
+                        DiskUtil.buildValidFilename(state.value.mangaTitle.orEmpty())
+                    } else {
+                        ""
+                    }
+                    imageSaver.save(
+                        image = content.toImage(
+                            location = Location.Pictures.create(relativePath),
+                        ),
+                    )
+                }
+            }.onSuccess { uri ->
+                notifier.onComplete(uri)
+                finishImageAction()
+                mutableImageEvents.emit(EpubImageEvent.Saved(uri))
+            }.onFailure { error ->
+                notifier.onError(error.message)
+                reportImageActionError(error)
+            }
+        }
+    }
+
+    internal fun shareSelectedImage(copyToClipboard: Boolean) {
+        withSelectedImage { content ->
+            mutableImageState.update { it.copy(isLoading = true) }
+            runCatching {
+                withIOContext {
+                    lastEpubShareFile?.delete()
+                    val image = content.toImage(location = Location.EpubShareCache)
+                    imageSaver.save(image).also {
+                        lastEpubShareFile = File(
+                            Location.EpubShareCache.directory(application),
+                            DiskUtil.buildValidFilename("${image.name}.${content.extension}"),
+                        )
+                    }
+                }
+            }.onSuccess { uri ->
+                finishImageAction()
+                mutableImageEvents.emit(
+                    if (copyToClipboard) {
+                        EpubImageEvent.Copy(uri)
+                    } else {
+                        EpubImageEvent.Share(uri, content.mimeType)
+                    },
+                )
+            }.onFailure { error -> reportImageActionError(error) }
+        }
+    }
+
+    private fun withSelectedImage(
+        forceReload: Boolean = false,
+        action: suspend (EpubImageContent) -> Unit,
+    ) {
+        val reference = mutableImageState.value.reference ?: return
+        imageLoadJob?.cancel()
+        val request = imageRequestTracker.next()
+        imageLoadJob = viewModelScope.launch {
+            mutableImageState.update { it.copy(isLoading = true, errorMessage = null) }
+            val result = runCatching {
+                val cached = mutableImageState.value.content
+                    ?.takeIf { !forceReload && it.reference == reference }
+                cached ?: withIOContext {
+                    val publication = sessionRepository.get(chapterId)?.publication
+                        ?: error("EPUB publication session is unavailable")
+                    loadEpubImageContent(publication, reference)
+                }
+            }
+            if (!imageRequestTracker.isCurrent(request) || mutableImageState.value.reference != reference) {
+                return@launch
+            }
+            result.onSuccess { content ->
+                mutableImageState.update { it.copy(content = content, isLoading = false, errorMessage = null) }
+                action(content)
+            }.onFailure { error ->
+                if (error is CancellationException) throw error
+                logcat(LogPriority.WARN, error) { "Failed to load EPUB image" }
+                val showActionError = mutableImageState.value.actionsVisible &&
+                    !mutableImageState.value.previewVisible
+                mutableImageState.update {
+                    it.copy(
+                        content = null,
+                        isLoading = false,
+                        errorMessage = application.stringResource(MR.strings.epub_reader_image_load_failed),
+                    )
+                }
+                if (showActionError) {
+                    mutableImageEvents.emit(
+                        EpubImageEvent.Error(application.stringResource(MR.strings.epub_reader_image_load_failed)),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun finishImageAction() {
+        mutableImageState.update { state ->
+            if (state.previewVisible) {
+                state.copy(actionsVisible = false, isLoading = false)
+            } else {
+                EpubImageUiState()
+            }
+        }
+    }
+
+    private suspend fun reportImageActionError(error: Throwable) {
+        logcat(LogPriority.ERROR, error) { "Failed to export EPUB image" }
+        mutableImageState.update { it.copy(isLoading = false) }
+        mutableImageEvents.emit(
+            EpubImageEvent.Error(application.stringResource(MR.strings.epub_reader_image_action_failed)),
+        )
+    }
+
+    private fun EpubImageContent.toImage(location: Location): Image.Page {
+        val baseName = DiskUtil.buildValidFilename(
+            listOfNotNull(
+                state.value.mangaTitle?.takeIf(String::isNotBlank),
+                originalFileName.takeIf(String::isNotBlank),
+            ).joinToString(" - ").ifBlank { "image" },
+        )
+        return Image.Page(
+            inputStream = { bytes.toByteArray().inputStream() },
+            name = baseName,
+            location = location,
+            encodedFormat = EncodedFormat(mimeType, extension).takeIf { isSvg },
+        )
     }
 
     fun updateLocator(locator: Locator) {
@@ -1517,6 +1721,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     }
 
     fun releaseSession() {
+        closeImagePreview()
         locatorPersistenceJob.cancel()
         sessionRepository.remove(chapterId)?.close()
         releaseCacheLeases()
@@ -1538,6 +1743,10 @@ class EpubReaderViewModel @JvmOverloads constructor(
     }
 
     override fun onCleared() {
+        imageLoadJob?.cancel()
+        imageRequestTracker.invalidate()
+        lastEpubShareFile?.delete()
+        lastEpubShareFile = null
         searchIterator?.close()
         searchIterator = null
         releaseCacheLeases()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -1745,7 +1745,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
     override fun onCleared() {
         imageLoadJob?.cancel()
         imageRequestTracker.invalidate()
-        lastEpubShareFile?.delete()
         lastEpubShareFile = null
         searchIterator?.close()
         searchIterator = null

--- a/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
@@ -1,0 +1,33 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubImageInteractionTest {
+
+    private val script = buildEpubImageInteractionInstallScript(
+        longPressTimeoutMs = 500,
+        touchSlopCssPx = 8f,
+    )
+
+    @Test
+    fun `script recognizes html and svg image elements`() {
+        assertTrue(script.contains("tagName === 'img'"))
+        assertTrue(script.contains("tagName === 'image'"))
+        assertTrue(script.contains("element.namespaceURI === 'http://www.w3.org/2000/svg'"))
+    }
+
+    @Test
+    fun `script reads svg2 and legacy xlink image sources`() {
+        assertTrue(script.contains("image.getAttribute('href')"))
+        assertTrue(script.contains("image.getAttributeNS('http://www.w3.org/1999/xlink', 'href')"))
+        assertTrue(script.contains("image.getAttribute('xlink:href')"))
+        assertTrue(script.contains("href.baseVal || href.animVal"))
+        assertTrue(script.contains("new URL(source, document.baseURI).href"))
+    }
+
+    @Test
+    fun `linked images retain their navigation behavior`() {
+        assertTrue(script.contains("image.closest('a[href]')"))
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubImageModelsTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageModelsTest.kt
@@ -1,0 +1,31 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubImageModelsTest {
+
+    @Test
+    fun `new image request invalidates every older request`() {
+        val tracker = EpubImageRequestTracker()
+
+        val firstImageRequest = tracker.next()
+        val secondImageRequest = tracker.next()
+        val sameFirstImageRequestedAgain = tracker.next()
+
+        assertFalse(tracker.isCurrent(firstImageRequest))
+        assertFalse(tracker.isCurrent(secondImageRequest))
+        assertTrue(tracker.isCurrent(sameFirstImageRequestedAgain))
+    }
+
+    @Test
+    fun `closing image overlay invalidates active request`() {
+        val tracker = EpubImageRequestTracker()
+        val activeRequest = tracker.next()
+
+        tracker.invalidate()
+
+        assertFalse(tracker.isCurrent(activeRequest))
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubImageResourceLoaderTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageResourceLoaderTest.kt
@@ -1,0 +1,77 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubImageResourceLoaderTest {
+
+    @Test
+    fun `relative source is resolved from its xhtml resource`() {
+        val candidates = candidates(
+            documentHref = "OPS/text/chapter.xhtml",
+            currentSource = "../images/cover%20art.jpg?width=1200#preview",
+            rawSource = "../images/cover%20art.jpg",
+        )
+
+        assertEquals(
+            listOf(
+                "OPS/images/cover%20art.jpg?width=1200",
+                "OPS/images/cover%20art.jpg",
+            ),
+            candidates,
+        )
+    }
+
+    @Test
+    fun `readium absolute current source also yields a publication path`() {
+        val candidates = candidates(
+            documentHref = "OPS/text/chapter.xhtml",
+            currentSource = "https://readium_package/OPS/images/cover.jpg#preview",
+            rawSource = "../images/cover.jpg",
+        )
+
+        assertEquals(
+            listOf(
+                "https://readium_package/OPS/images/cover.jpg",
+                "OPS/images/cover.jpg",
+            ),
+            candidates,
+        )
+    }
+
+    @Test
+    fun `remote absolute source stays inside publication lookup candidates`() {
+        val candidates = candidates(
+            documentHref = "OPS/text/chapter.xhtml",
+            currentSource = "https://cdn.example.org/book/illustration.webp?token=redacted",
+            rawSource = "",
+        )
+
+        assertEquals(
+            listOf("https://cdn.example.org/book/illustration.webp?token=redacted"),
+            candidates,
+        )
+    }
+
+    @Test
+    fun `data blob and local schemes are rejected`() {
+        listOf(
+            "data:image/png;base64,AA==",
+            "blob:https://readium_package/id",
+            "file:///storage/image.png",
+            "content://provider/image.png",
+            "javascript:alert(1)",
+        ).forEach { source ->
+            assertTrue(candidates("OPS/chapter.xhtml", source, source).isEmpty(), source)
+        }
+    }
+
+    private fun candidates(
+        documentHref: String,
+        currentSource: String,
+        rawSource: String,
+    ): List<String> {
+        return epubImageCandidateHrefs(documentHref, currentSource, rawSource)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -119,6 +119,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" 
 coil-core = { module = "io.coil-kt.coil3:coil", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 composeGrid = { module = "io.woong.compose.grid:grid", version.ref = "composeGrid" }
 composeMaterialMotion = { module = "io.github.fornewid:material-motion-compose-core", version.ref = "composeMaterialMotion" }
 composeRichEditor = { module = "com.mohamedrejeb.richeditor:richeditor-compose", version.ref = "composeRichEditor" }
@@ -210,7 +211,7 @@ sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 
 [bundles]
 androidx-lifecycle = ["androidx-lifecycle-common", "androidx-lifecycle-process", "androidx-lifecycle-runtime"]
-coil = ["coil-core", "coil-gif", "coil-compose", "coil-network-okhttp"]
+coil = ["coil-core", "coil-gif", "coil-compose", "coil-network-okhttp", "coil-svg"]
 kotlinx-coroutines = ["kotlinx-coroutines-core", "kotlinx-coroutines-android", "kotlinx-coroutines-guava"]
 markdown = ["markdown-core", "markdown-coil"]
 okhttp = ["okhttp-core", "okhttp-logging", "okhttp-brotli", "okhttp-dnsOverHttps", "okhttp-sse"]

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -112,6 +112,7 @@
     <string name="action_resume">Resume</string>
     <string name="action_open_in_browser">Open in browser</string>
     <string name="action_show_manga">Show entry</string>
+    <string name="action_copy">Copy</string>
     <string name="action_copy_to_clipboard">Copy to clipboard</string>
     <string name="action_copy_link">Copy link</string>
     <!-- Do not translate "WebView" -->
@@ -1031,6 +1032,10 @@
     <string name="epub_reader_search_no_results">No results found</string>
     <string name="epub_reader_search_not_supported">Search is not available for this EPUB.</string>
     <string name="epub_reader_search_error">Search failed</string>
+    <string name="epub_reader_image_preview">Preview</string>
+    <string name="epub_reader_image_actions">Image actions</string>
+    <string name="epub_reader_image_load_failed">The image couldn’t be loaded.</string>
+    <string name="epub_reader_image_action_failed">Unable to save or share this image.</string>
     <string name="action_reload_reader">Reload reader</string>
     <string name="error_no_match">No match found</string>
     <string name="track_error">%1$s error: %2$s</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -671,6 +671,10 @@
     <string name="epub_reader_search_no_results">未找到结果</string>
     <string name="epub_reader_search_not_supported">这本 EPUB 不支持搜索。</string>
     <string name="epub_reader_search_error">搜索失败</string>
+    <string name="epub_reader_image_preview">预览</string>
+    <string name="epub_reader_image_actions">图片操作</string>
+    <string name="epub_reader_image_load_failed">无法加载图片。</string>
+    <string name="epub_reader_image_action_failed">无法保存或分享此图片。</string>
     <string name="action_reload_reader">重新载入阅读器</string>
     <string name="unread">未读</string>
     <string name="date">日期</string>
@@ -883,6 +887,7 @@
     <string name="track_error">%1$s 发生错误：%2$s</string>
     <string name="information_required_plain">*必填</string>
     <string name="pref_hide_in_library_items">隐藏已添加到书架的作品</string>
+    <string name="action_copy">复制</string>
     <string name="action_copy_to_clipboard">复制到剪贴板</string>
     <string name="action_update_category">更新分类</string>
     <string name="split_tall_images">分割长图</string>

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/ActionButton.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/ActionButton.kt
@@ -2,6 +2,8 @@ package tachiyomi.presentation.core.components
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -19,10 +21,12 @@ fun ActionButton(
     icon: ImageVector,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    colors: ButtonColors = ButtonDefaults.textButtonColors(),
 ) {
     TextButton(
         modifier = modifier,
         onClick = onClick,
+        colors = colors,
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(MaterialTheme.padding.extraSmall),


### PR DESCRIPTION
## 中文

### 变更内容

- 为 EPUB 正文图片增加单击全屏预览和长按操作菜单。
- 支持 `img`、`picture.currentSrc`、SVG `image` 以及 `href` / `xlink:href` 图片引用识别。
- 相对于所属 XHTML 解析图片地址，并通过 Readium `Publication.get()` 安全读取原始资源。
- 全屏预览支持图片内点击切换控件、图片外点击关闭、双击/多指缩放和拖动。
- 增加保存、分享和复制到剪贴板操作，保留原始 MIME、扩展名与字节，并隔离 EPUB 临时分享缓存。
- 连续滚动模式按 reading-order 资源索引解析 iframe 中的图片。
- 恢复漫画原始四项横排图片操作样式，并为 EPUB/漫画操作按钮增加更清晰的主题配色。
- 增加图片交互、请求失效和资源路径解析单元测试。
- 更新 `AGENTS.md`，明确设备调试优先使用 ADB，默认仅提供手工验证步骤。

### 原因与影响

此前 EPUB 阅读器没有完整的图片交互链路，正文图片点击和长按无响应，连续滚动 iframe 与 SVG 图片也缺少可靠的资源定位。此次改动将内容层识别、Readium 资源加载和原生预览/操作串联起来，同时避免泄露受保护 URL 或干扰链接图片、正文滚动和阅读菜单。

用户现在可以直接预览、缩放、保存、分享和复制 EPUB 图片；链接图片仍保留原有跳转行为。加载失败只影响当前图片覆盖层，不影响正文阅读。

### 验证

- `spotlessApply`
- `spotlessCheck`
- `:app:compileDebugKotlin`
- `EpubImageInteractionTest`
- `EpubImageModelsTest`
- `EpubImageResourceLoaderTest`（共 9 项测试通过）

## English

### What changed

- Added tap-to-preview and long-press actions for images in EPUB content.
- Added recognition for `img`, `picture.currentSrc`, SVG `image`, and both `href` / `xlink:href` references.
- Resolves image paths relative to their owning XHTML resource and reads bytes safely through Readium `Publication.get()`.
- Added a fullscreen viewer with control toggling, outside-tap dismissal, double-tap/pinch zoom, and panning.
- Added save, share, and clipboard actions while preserving the original MIME type, extension, and bytes in an isolated EPUB share cache.
- Resolves images inside continuous-scroll iframes with their reading-order resource index.
- Restored the original four-item horizontal comic image action layout and applied clearer theme colors to EPUB and comic action buttons.
- Added unit coverage for interaction scripts, stale-request invalidation, and publication resource resolution.
- Updated `AGENTS.md` to prefer ADB for device debugging and manual validation instructions by default.

### Why and impact

The EPUB reader previously had no complete image interaction pipeline, so taps and long presses did not work reliably. Continuous-scroll iframes and SVG image references also lacked dependable resource resolution. This change connects content-side detection with Readium-backed loading and native presentation without exposing protected URLs or interfering with linked images, scrolling, or reader menus.

Readers can now preview, zoom, save, share, and copy EPUB images. Linked images retain their navigation behavior, and image failures remain isolated from normal reading.

### Validation

- `spotlessApply`
- `spotlessCheck`
- `:app:compileDebugKotlin`
- `EpubImageInteractionTest`
- `EpubImageModelsTest`
- `EpubImageResourceLoaderTest` (9 tests passed)
