### PR TITLE
优化作品详情显示与阅读进度 / Refine manga detail display and reading progress

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
         applicationId = "app.koharia"
 
         versionCode = 4
-        versionName = "0.2.2"
+        versionName = "0.2.3"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getLatestCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getLatestCommitSha()}\"")

--- a/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/components/CommonMangaItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -79,6 +80,7 @@ fun MangaCompactGridItem(
     coverAlpha: Float = 1f,
     coverBadgeStart: @Composable (RowScope.() -> Unit)? = null,
     coverBadgeEnd: @Composable (RowScope.() -> Unit)? = null,
+    coverOverlay: (@Composable BoxScope.() -> Unit)? = null,
 ) {
     GridItemSelectable(
         isSelected = isSelected,
@@ -96,6 +98,7 @@ fun MangaCompactGridItem(
             },
             badgesStart = coverBadgeStart,
             badgesEnd = coverBadgeEnd,
+            overlay = coverOverlay,
             content = {
                 if (title != null) {
                     CoverTextOverlay(
@@ -184,6 +187,7 @@ fun MangaComfortableGridItem(
     coverAlpha: Float = 1f,
     coverBadgeStart: (@Composable RowScope.() -> Unit)? = null,
     coverBadgeEnd: (@Composable RowScope.() -> Unit)? = null,
+    coverOverlay: (@Composable BoxScope.() -> Unit)? = null,
     onClickContinueReading: (() -> Unit)? = null,
 ) {
     GridItemSelectable(
@@ -203,6 +207,7 @@ fun MangaComfortableGridItem(
                 },
                 badgesStart = coverBadgeStart,
                 badgesEnd = coverBadgeEnd,
+                overlay = coverOverlay,
                 content = {
                     if (onClickContinueReading != null) {
                         ContinueReadingButton(
@@ -237,6 +242,7 @@ private fun MangaGridCover(
     badgesStart: (@Composable RowScope.() -> Unit)? = null,
     badgesEnd: (@Composable RowScope.() -> Unit)? = null,
     content: @Composable (BoxScope.() -> Unit)? = null,
+    overlay: @Composable (BoxScope.() -> Unit)? = null,
 ) {
     Box(
         modifier = modifier
@@ -260,6 +266,14 @@ private fun MangaGridCover(
                     .padding(4.dp)
                     .align(Alignment.TopEnd),
                 content = badgesEnd,
+            )
+        }
+        if (overlay != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(MaterialTheme.shapes.extraSmall),
+                content = overlay,
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -31,7 +31,7 @@ import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.manga.model.downloadedFilter
 import eu.kanade.presentation.components.TabbedDialog
 import eu.kanade.presentation.components.TabbedDialogPaddings
-import eu.kanade.tachiyomi.source.isKomgaSource
+import eu.kanade.presentation.more.settings.widget.SwitchPreferenceWidget
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.core.common.preference.TriState
 import tachiyomi.domain.manga.model.Manga
@@ -57,15 +57,12 @@ fun ChapterSettingsDialog(
     onScanlatorFilterClicked: (() -> Unit),
     onSortModeChanged: (Long) -> Unit,
     onDisplayModeChanged: (Long) -> Unit,
-    onChapterCoverDisplayModeChanged: (Long) -> Unit,
+    showChapterReadProgress: Boolean,
+    onShowChapterReadProgressChanged: (Boolean) -> Unit,
     onSetAsDefault: (applyToExistingManga: Boolean) -> Unit,
     onResetToDefault: () -> Unit,
 ) {
     var showSetAsDefaultDialog by rememberSaveable { mutableStateOf(false) }
-    val sourceManager = remember { Injekt.get<tachiyomi.domain.source.service.SourceManager>() }
-    val supportsChapterCoverDisplay = remember(manga) {
-        manga?.let { sourceManager.get(it.source)?.isKomgaSource() } == true
-    }
     if (showSetAsDefaultDialog) {
         SetAsDefaultDialog(
             onDismissRequest = { showSetAsDefaultDialog = false },
@@ -129,10 +126,9 @@ fun ChapterSettingsDialog(
                 2 -> {
                     DisplayPage(
                         displayMode = manga?.displayMode ?: 0,
-                        supportsChapterCoverDisplay = supportsChapterCoverDisplay,
-                        chapterCoverDisplayMode = manga?.chapterCoverDisplayMode ?: 0,
                         onDisplayModeSelected = onDisplayModeChanged,
-                        onChapterCoverDisplayModeSelected = onChapterCoverDisplayModeChanged,
+                        showChapterReadProgress = showChapterReadProgress,
+                        onShowChapterReadProgressChanged = onShowChapterReadProgressChanged,
                     )
                 }
             }
@@ -227,30 +223,16 @@ private fun ColumnScope.SortPage(
 @Composable
 private fun ColumnScope.DisplayPage(
     displayMode: Long,
-    supportsChapterCoverDisplay: Boolean,
-    chapterCoverDisplayMode: Long,
     onDisplayModeSelected: (Long) -> Unit,
-    onChapterCoverDisplayModeSelected: (Long) -> Unit,
+    showChapterReadProgress: Boolean,
+    onShowChapterReadProgressChanged: (Boolean) -> Unit,
 ) {
-    if (supportsChapterCoverDisplay) {
-        Text(
-            text = stringResource(MR.strings.chapter_cover_display_mode),
-            modifier = Modifier.padding(horizontal = TabbedDialogPaddings.Horizontal, vertical = 8.dp),
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.primary,
-        )
-        listOf(
-            MR.strings.action_display_chapter_text_only to Manga.CHAPTER_COVER_DISPLAY_TEXT,
-            MR.strings.action_display_chapter_cover_only to Manga.CHAPTER_COVER_DISPLAY_COVER,
-            MR.strings.action_display_chapter_cover_and_title to Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE,
-        ).map { (titleRes, mode) ->
-            RadioItem(
-                label = stringResource(titleRes),
-                selected = chapterCoverDisplayMode == mode,
-                onClick = { onChapterCoverDisplayModeSelected(mode) },
-            )
-        }
-    }
+    SwitchPreferenceWidget(
+        title = stringResource(MR.strings.pref_show_chapter_read_progress),
+        subtitle = stringResource(MR.strings.pref_show_chapter_read_progress_summary),
+        checked = showChapterReadProgress,
+        onCheckedChanged = onShowChapterReadProgressChanged,
+    )
 
     Text(
         text = stringResource(MR.strings.chapter_title_display_mode),

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -2,8 +2,10 @@ package eu.kanade.presentation.manga
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
@@ -12,9 +14,11 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -27,8 +31,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SmallExtendedFloatingActionButton
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -42,18 +48,29 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.BlurredEdgeTreatment
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
 import eu.kanade.presentation.components.relativeDateText
 import eu.kanade.presentation.library.components.CommonMangaItemDefaults
+import eu.kanade.presentation.library.components.MangaComfortableGridItem
 import eu.kanade.presentation.library.components.MangaCompactGridItem
 import eu.kanade.presentation.manga.components.ChapterDownloadAction
 import eu.kanade.presentation.manga.components.ChapterHeader
@@ -70,7 +87,9 @@ import eu.kanade.tachiyomi.source.getNameForMangaInfo
 import eu.kanade.tachiyomi.source.isKomgaSource
 import eu.kanade.tachiyomi.ui.manga.ChapterList
 import eu.kanade.tachiyomi.ui.manga.MangaScreenModel
+import eu.kanade.tachiyomi.ui.reader.pageProgressPercent
 import eu.kanade.tachiyomi.util.system.copyToClipboard
+import koharia.komga.download.KomgaChapterMemo
 import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.chapter.service.missingChaptersCount
 import tachiyomi.domain.library.service.LibraryPreferences
@@ -94,6 +113,7 @@ fun MangaScreen(
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
+    showChapterReadProgress: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
@@ -105,6 +125,7 @@ fun MangaScreen(
     onTagSearch: (String) -> Unit,
 
     onFilterButtonClicked: () -> Unit,
+    onChapterCoverDisplayModeChange: (Long) -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
@@ -148,6 +169,7 @@ fun MangaScreen(
             chapterSwipeStartAction = chapterSwipeStartAction,
             chapterSwipeEndAction = chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
+            showChapterReadProgress = showChapterReadProgress,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -158,6 +180,7 @@ fun MangaScreen(
             onTagSearch = onTagSearch,
             onCopyTagToClipboard = onCopyTagToClipboard,
             onFilterClicked = onFilterButtonClicked,
+            onChapterCoverDisplayModeChange = onChapterCoverDisplayModeChange,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
@@ -183,6 +206,7 @@ fun MangaScreen(
             chapterSwipeStartAction = chapterSwipeStartAction,
             chapterSwipeEndAction = chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
+            showChapterReadProgress = showChapterReadProgress,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -193,6 +217,7 @@ fun MangaScreen(
             onTagSearch = onTagSearch,
             onCopyTagToClipboard = onCopyTagToClipboard,
             onFilterButtonClicked = onFilterButtonClicked,
+            onChapterCoverDisplayModeChange = onChapterCoverDisplayModeChange,
             onRefresh = onRefresh,
             onContinueReading = onContinueReading,
             onSearch = onSearch,
@@ -221,6 +246,7 @@ private fun MangaScreenSmallImpl(
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
+    showChapterReadProgress: Boolean,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -234,6 +260,7 @@ private fun MangaScreenSmallImpl(
     onCopyTagToClipboard: (tag: String) -> Unit,
 
     onFilterClicked: () -> Unit,
+    onChapterCoverDisplayModeChange: (Long) -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
@@ -314,8 +341,10 @@ private fun MangaScreenSmallImpl(
                 title = state.manga.title,
                 hasFilters = state.filterActive,
                 isKomgaCacheMode = isKomgaCacheMode,
+                chapterCoverDisplayMode = state.manga.chapterCoverDisplayMode.takeIf { isKomgaCacheMode },
                 navigateUp = navigateUp,
                 onClickFilter = onFilterClicked,
+                onChapterCoverDisplayModeChange = onChapterCoverDisplayModeChange,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,
                 onClickEditCategory = onEditCategoryClicked,
@@ -419,6 +448,7 @@ private fun MangaScreenSmallImpl(
                         manga = state.manga,
                         isKomgaSource = state.source.isKomgaSource(),
                         chapters = listItem,
+                        showChapterReadProgress = showChapterReadProgress,
                         isAnyChapterSelected = chapters.fastAny { it.selected },
                         onChapterClicked = onChapterClicked,
                         onChapterSelected = onChapterSelected,
@@ -459,6 +489,7 @@ private fun MangaScreenSmallImpl(
                         sharedChapterItems(
                             manga = state.manga,
                             chapters = listItem,
+                            showChapterReadProgress = showChapterReadProgress,
                             isKomgaCacheMode = isKomgaCacheMode,
                             isAnyChapterSelected = chapters.fastAny { it.selected },
                             chapterSwipeStartAction = chapterSwipeStartAction,
@@ -482,6 +513,7 @@ fun MangaScreenLargeImpl(
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
+    showChapterReadProgress: Boolean,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -495,6 +527,7 @@ fun MangaScreenLargeImpl(
     onCopyTagToClipboard: (tag: String) -> Unit,
 
     onFilterButtonClicked: () -> Unit,
+    onChapterCoverDisplayModeChange: (Long) -> Unit,
     onRefresh: () -> Unit,
     onContinueReading: () -> Unit,
     onSearch: (query: String, global: Boolean) -> Unit,
@@ -556,8 +589,10 @@ fun MangaScreenLargeImpl(
                 title = state.manga.title,
                 hasFilters = state.filterActive,
                 isKomgaCacheMode = isKomgaCacheMode,
+                chapterCoverDisplayMode = state.manga.chapterCoverDisplayMode.takeIf { isKomgaCacheMode },
                 navigateUp = navigateUp,
                 onClickFilter = onFilterButtonClicked,
+                onChapterCoverDisplayModeChange = onChapterCoverDisplayModeChange,
                 onClickShare = onShareClicked,
                 onClickDownload = onDownloadActionClicked,
                 onClickEditCategory = onEditCategoryClicked,
@@ -664,7 +699,6 @@ fun MangaScreenLargeImpl(
                             onEditCategory = onEditCategoryClicked,
                         )
                         ExpandableMangaDescription(
-                            defaultExpandState = true,
                             description = state.manga.description,
                             tagsProvider = { state.manga.genre },
                             notes = state.manga.notes,
@@ -699,6 +733,7 @@ fun MangaScreenLargeImpl(
                                 manga = state.manga,
                                 isKomgaSource = state.source.isKomgaSource(),
                                 chapters = listItem,
+                                showChapterReadProgress = showChapterReadProgress,
                                 isAnyChapterSelected = chapters.fastAny { it.selected },
                                 onChapterClicked = onChapterClicked,
                                 onChapterSelected = onChapterSelected,
@@ -726,6 +761,7 @@ fun MangaScreenLargeImpl(
                                 sharedChapterItems(
                                     manga = state.manga,
                                     chapters = listItem,
+                                    showChapterReadProgress = showChapterReadProgress,
                                     isKomgaCacheMode = isKomgaCacheMode,
                                     isAnyChapterSelected = chapters.fastAny { it.selected },
                                     chapterSwipeStartAction = chapterSwipeStartAction,
@@ -791,6 +827,7 @@ private fun SharedMangaBottomActionMenu(
 private fun LazyListScope.sharedChapterItems(
     manga: Manga,
     chapters: List<ChapterList>,
+    showChapterReadProgress: Boolean,
     isKomgaCacheMode: Boolean,
     isAnyChapterSelected: Boolean,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
@@ -827,27 +864,10 @@ private fun LazyListScope.sharedChapterItems(
                         item.chapter.name
                     },
                     date = relativeDateText(item.chapter.dateUpload),
-                    readProgress = when {
-                        item.chapter.read -> null
-                        item.epubProgressPercent != null ->
-                            item.epubProgressPercent
-                                .takeIf { it > 0 }
-                                ?.let {
-                                    stringResource(
-                                        MR.strings.epub_chapter_progress,
-                                        it,
-                                    )
-                                }
-                        item.chapter.lastPageRead > 0L -> {
-                            stringResource(
-                                MR.strings.chapter_progress,
-                                item.chapter.lastPageRead + 1,
-                            )
-                        }
-                        else -> null
-                    },
+                    readProgress = chapterReadProgress(item).takeIf { showChapterReadProgress },
                     scanlator = item.chapter.scanlator.takeIf { !it.isNullOrBlank() },
                     read = item.chapter.read,
+                    showReadStatus = showChapterReadProgress,
                     bookmark = item.chapter.bookmark,
                     selected = item.selected,
                     downloadIndicatorEnabled = !isAnyChapterSelected,
@@ -933,7 +953,6 @@ private fun LazyListScope.sharedMangaDetailHeaderListItems(
         contentType = MangaScreenItem.DESCRIPTION_WITH_TAG,
     ) {
         ExpandableMangaDescription(
-            defaultExpandState = state.isFromSource,
             description = state.manga.description,
             tagsProvider = { state.manga.genre },
             notes = state.manga.notes,
@@ -981,6 +1000,7 @@ private fun LazyGridScope.sharedMangaDetailHeaderGridItems(
             isStubSource = remember { state.source is StubSource },
             onCoverClick = onCoverClicked,
             doSearch = onSearch,
+            backdropHorizontalBleed = 16.dp,
         )
     }
 
@@ -1004,7 +1024,6 @@ private fun LazyGridScope.sharedMangaDetailHeaderGridItems(
         contentType = MangaScreenItem.DESCRIPTION_WITH_TAG,
     ) {
         ExpandableMangaDescription(
-            defaultExpandState = state.isFromSource,
             description = state.manga.description,
             tagsProvider = { state.manga.genre },
             notes = state.manga.notes,
@@ -1068,6 +1087,7 @@ private fun LazyGridScope.sharedChapterGridItems(
     manga: Manga,
     isKomgaSource: Boolean,
     chapters: List<ChapterList>,
+    showChapterReadProgress: Boolean,
     isAnyChapterSelected: Boolean,
     onChapterClicked: (Chapter) -> Unit,
     onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
@@ -1095,38 +1115,202 @@ private fun LazyGridScope.sharedChapterGridItems(
                 MissingChapterCountListItem(count = item.count)
             }
             is ChapterList.Item -> {
-                MangaCompactGridItem(
-                    coverData = MangaCoverModel(
-                        mangaId = item.chapter.id,
-                        sourceId = manga.source,
-                        isMangaFavorite = false,
-                        url = item.chapter.url
-                            .takeIf { isKomgaSource }
-                            ?.let { "$it/thumbnail" },
-                        lastModified = item.chapter.dateUpload,
-                    ),
-                    title = if (manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE) {
-                        chapterTitle(manga, item)
-                    } else {
-                        null
-                    },
-                    isSelected = item.selected,
-                    coverAlpha = if (item.chapter.read) 0.38f else 1f,
-                    onLongClick = {
-                        onChapterSelected(item, !item.selected, true)
-                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                    },
-                    onClick = {
-                        onChapterItemClick(
-                            chapterItem = item,
-                            isAnyChapterSelected = isAnyChapterSelected,
-                            onToggleSelection = { onChapterSelected(item, !item.selected, false) },
-                            onChapterClicked = onChapterClicked,
-                        )
-                    },
+                val coverData = MangaCoverModel(
+                    mangaId = item.chapter.id,
+                    sourceId = manga.source,
+                    isMangaFavorite = false,
+                    url = item.chapter.url
+                        .takeIf { isKomgaSource }
+                        ?.let { "$it/thumbnail" },
+                    lastModified = item.chapter.dateUpload,
                 )
+                val onLongClick = {
+                    onChapterSelected(item, !item.selected, true)
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                }
+                val onClick = {
+                    onChapterItemClick(
+                        chapterItem = item,
+                        isAnyChapterSelected = isAnyChapterSelected,
+                        onToggleSelection = { onChapterSelected(item, !item.selected, false) },
+                        onChapterClicked = onChapterClicked,
+                    )
+                }
+                val readProgress = chapterGridProgress(item)
+                    .takeIf { showChapterReadProgress }
+                val isRead = showChapterReadProgress && item.chapter.read
+                val coverOverlay: (@Composable BoxScope.() -> Unit)? = if (readProgress != null || isRead) {
+                    {
+                        when {
+                            readProgress != null -> {
+                                ChapterProgressCorner(
+                                    progress = readProgress,
+                                    modifier = Modifier.align(Alignment.TopEnd),
+                                )
+                            }
+                            isRead -> ChapterReadCorner(modifier = Modifier.align(Alignment.TopEnd))
+                        }
+                    }
+                } else {
+                    null
+                }
+
+                if (manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COMFORTABLE) {
+                    MangaComfortableGridItem(
+                        coverData = coverData,
+                        title = chapterTitle(manga, item),
+                        isSelected = item.selected,
+                        coverOverlay = coverOverlay,
+                        onLongClick = onLongClick,
+                        onClick = onClick,
+                    )
+                } else {
+                    MangaCompactGridItem(
+                        coverData = coverData,
+                        title = if (
+                            manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE
+                        ) {
+                            chapterTitle(manga, item)
+                        } else {
+                            null
+                        },
+                        isSelected = item.selected,
+                        coverOverlay = coverOverlay,
+                        onLongClick = onLongClick,
+                        onClick = onClick,
+                    )
+                }
             }
         }
+    }
+}
+
+@Composable
+private fun ChapterProgressCorner(
+    progress: String,
+    modifier: Modifier = Modifier,
+) {
+    Layout(
+        modifier = modifier,
+        content = {
+            Text(
+                text = progress,
+                color = Color.White,
+                fontWeight = FontWeight.ExtraBold,
+                maxLines = 1,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    shadow = Shadow(
+                        color = Color.Black,
+                        blurRadius = 4f,
+                    ),
+                ),
+            )
+            Canvas(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .blur(
+                        radius = 11.dp,
+                        edgeTreatment = BlurredEdgeTreatment.Unbounded,
+                    ),
+            ) {
+                drawRect(
+                    color = Color.Black.copy(alpha = 0.58f),
+                    topLeft = Offset(size.width / 4f, size.height / 4f),
+                    size = Size(size.width / 2f, size.height / 2f),
+                )
+            }
+        },
+    ) { measurables, constraints ->
+        val textPlaceable = measurables[0].measure(
+            constraints.copy(minWidth = 0, minHeight = 0),
+        )
+        val shadowWidth = (textPlaceable.width * 2)
+            .coerceIn(constraints.minWidth, constraints.maxWidth)
+        val shadowHeight = (textPlaceable.height * 2)
+            .coerceIn(constraints.minHeight, constraints.maxHeight)
+        val shadowPlaceable = measurables[1].measure(
+            Constraints.fixed(shadowWidth, shadowHeight),
+        )
+
+        layout(shadowWidth, shadowHeight) {
+            shadowPlaceable.place(0, 0)
+            textPlaceable.place(
+                x = (shadowWidth - textPlaceable.width) / 2,
+                y = (shadowHeight - textPlaceable.height) / 2,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChapterReadCorner(modifier: Modifier = Modifier) {
+    val cornerColor = MaterialTheme.colorScheme.primaryContainer
+    val checkColor = MaterialTheme.colorScheme.primary
+    Box(modifier = modifier.size(28.dp)) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawPath(
+                path = Path().apply {
+                    moveTo(0f, 0f)
+                    lineTo(size.width, 0f)
+                    lineTo(size.width, size.height)
+                    close()
+                },
+                color = cornerColor,
+            )
+        }
+        Icon(
+            imageVector = Icons.Filled.Check,
+            contentDescription = null,
+            tint = checkColor,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 2.dp, end = 2.dp)
+                .size(14.dp),
+        )
+    }
+}
+
+@Composable
+private fun chapterReadProgress(
+    item: ChapterList.Item,
+): String? {
+    if (item.chapter.read) return null
+
+    item.epubProgressPercent
+        ?.takeIf { it > 0 }
+        ?.let { progress ->
+            return stringResource(
+                MR.strings.epub_chapter_progress,
+                progress,
+            )
+        }
+
+    return item.chapter.lastPageRead
+        .takeIf { it > 0L }
+        ?.let { lastPageRead ->
+            stringResource(
+                MR.strings.chapter_progress,
+                lastPageRead + 1,
+            )
+        }
+}
+
+@Composable
+private fun chapterGridProgress(item: ChapterList.Item): String? {
+    if (item.chapter.read) return null
+
+    val progressPercent = item.epubProgressPercent
+        ?.takeIf { it > 0 }
+        ?: run {
+            val totalPages = KomgaChapterMemo.pagesCount(item.chapter.memo) ?: return null
+            item.chapter.lastPageRead
+                .takeIf { it > 0L }
+                ?.let { pageIndex -> pageProgressPercent(pageIndex.toInt(), totalPages) }
+                ?.takeIf { it > 0 }
+        }
+
+    return progressPercent?.let { progress ->
+        stringResource(MR.strings.epub_chapter_progress_short, progress)
     }
 }
 

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaChapterListItem.kt
@@ -52,6 +52,7 @@ fun MangaChapterListItem(
     readProgress: String?,
     scanlator: String?,
     read: Boolean,
+    showReadStatus: Boolean,
     bookmark: Boolean,
     selected: Boolean,
     downloadIndicatorEnabled: Boolean,
@@ -108,7 +109,7 @@ fun MangaChapterListItem(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     var textHeight by remember { mutableIntStateOf(0) }
-                    if (!read) {
+                    if (showReadStatus && !read) {
                         Icon(
                             imageVector = Icons.Filled.Circle,
                             contentDescription = stringResource(MR.strings.unread),
@@ -133,7 +134,9 @@ fun MangaChapterListItem(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         onTextLayout = { textHeight = it.size.height },
-                        color = LocalContentColor.current.copy(alpha = if (read) DISABLED_ALPHA else 1f),
+                        color = LocalContentColor.current.copy(
+                            alpha = if (showReadStatus && read) DISABLED_ALPHA else 1f,
+                        ),
                     )
                 }
 
@@ -141,7 +144,9 @@ fun MangaChapterListItem(
                     val subtitleStyle = MaterialTheme.typography.bodySmall
                         .merge(
                             color = LocalContentColor.current
-                                .copy(alpha = if (read) DISABLED_ALPHA else SECONDARY_ALPHA),
+                                .copy(
+                                    alpha = if (showReadStatus && read) DISABLED_ALPHA else SECONDARY_ALPHA,
+                                ),
                         )
                     ProvideTextStyle(value = subtitleStyle) {
                         if (date != null) {

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.LinkAnnotation
@@ -118,6 +119,7 @@ fun MangaInfoBox(
     isStubSource: Boolean,
     onCoverClick: () -> Unit,
     doSearch: (query: String, global: Boolean) -> Unit,
+    backdropHorizontalBleed: Dp = 0.dp,
     modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
@@ -135,6 +137,7 @@ fun MangaInfoBox(
             contentScale = ContentScale.Crop,
             modifier = Modifier
                 .matchParentSize()
+                .horizontalBleed(backdropHorizontalBleed)
                 .drawWithContent {
                     drawContent()
                     drawRect(
@@ -166,6 +169,32 @@ fun MangaInfoBox(
                     doSearch = doSearch,
                 )
             }
+        }
+    }
+}
+
+private fun Modifier.horizontalBleed(horizontal: Dp): Modifier {
+    if (horizontal <= 0.dp) return this
+
+    return layout { measurable, constraints ->
+        val horizontalPx = horizontal.roundToPx()
+        val extraWidth = horizontalPx * 2
+        val expandedMaxWidth = if (constraints.hasBoundedWidth) {
+            constraints.maxWidth + extraWidth
+        } else {
+            Constraints.Infinity
+        }
+        val placeable = measurable.measure(
+            constraints.copy(
+                minWidth = (constraints.minWidth + extraWidth).coerceAtMost(expandedMaxWidth),
+                maxWidth = expandedMaxWidth,
+            ),
+        )
+        layout(
+            width = (placeable.width - extraWidth).coerceIn(constraints.minWidth, constraints.maxWidth),
+            height = placeable.height.coerceIn(constraints.minHeight, constraints.maxHeight),
+        ) {
+            placeable.placeRelative(-horizontalPx, 0)
         }
     }
 }
@@ -210,7 +239,6 @@ fun MangaActionRow(
 
 @Composable
 fun ExpandableMangaDescription(
-    defaultExpandState: Boolean,
     description: String?,
     tagsProvider: () -> List<String>?,
     notes: String,
@@ -221,7 +249,7 @@ fun ExpandableMangaDescription(
 ) {
     Column(modifier = modifier) {
         val (expanded, onExpanded) = rememberSaveable {
-            mutableStateOf(defaultExpandState)
+            mutableStateOf(false)
         }
         val desc =
             description.takeIf { !it.isNullOrBlank() } ?: stringResource(MR.strings.description_placeholder)
@@ -653,9 +681,9 @@ private fun MangaSummary(
         contents = listOf(
             {
                 Text(
-                    // Shows at least 3 lines if no notes
-                    // when there are notes show 6
-                    text = if (notes.isBlank()) "\n\n" else "\n\n\n\n\n",
+                    // Shows at least 4 lines if no notes
+                    // when there are notes show 7
+                    text = if (notes.isBlank()) "\n\n\n" else "\n\n\n\n\n\n",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },

--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaToolbar.kt
@@ -1,12 +1,15 @@
 package eu.kanade.presentation.manga.components
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ViewList
+import androidx.compose.material.icons.filled.ViewModule
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.FlipToBack
 import androidx.compose.material.icons.outlined.SelectAll
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,8 +23,11 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.AppBarTitle
 import eu.kanade.presentation.components.DownloadDropdownMenu
+import eu.kanade.presentation.components.DropdownMenu
+import eu.kanade.presentation.components.RadioMenuItem
 import eu.kanade.presentation.manga.DownloadAction
 import kotlinx.collections.immutable.persistentListOf
+import tachiyomi.domain.manga.model.Manga
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.theme.active
@@ -31,8 +37,10 @@ fun MangaToolbar(
     title: String,
     hasFilters: Boolean,
     isKomgaCacheMode: Boolean,
+    chapterCoverDisplayMode: Long?,
     navigateUp: () -> Unit,
     onClickFilter: () -> Unit,
+    onChapterCoverDisplayModeChange: (Long) -> Unit,
     onClickShare: (() -> Unit)?,
     onClickDownload: ((DownloadAction) -> Unit)?,
     onClickEditCategory: (() -> Unit)?,
@@ -66,6 +74,7 @@ fun MangaToolbar(
         navigateUp = navigateUp,
         actions = {
             var downloadExpanded by remember { mutableStateOf(false) }
+            var displayModeExpanded by remember { mutableStateOf(false) }
             if (onClickDownload != null) {
                 val onDismissRequest = { downloadExpanded = false }
                 DownloadDropdownMenu(
@@ -96,14 +105,16 @@ fun MangaToolbar(
                         )
                         return@apply
                     }
-                    if (onClickDownload != null) {
+                    if (chapterCoverDisplayMode != null) {
                         add(
                             AppBar.Action(
-                                title = stringResource(
-                                    if (isKomgaCacheMode) MR.strings.komga_action_cache else MR.strings.manga_download,
-                                ),
-                                icon = Icons.Outlined.Download,
-                                onClick = { downloadExpanded = !downloadExpanded },
+                                title = stringResource(MR.strings.action_display_mode),
+                                icon = if (chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_TEXT) {
+                                    Icons.AutoMirrored.Filled.ViewList
+                                } else {
+                                    Icons.Filled.ViewModule
+                                },
+                                onClick = { displayModeExpanded = true },
                             ),
                         )
                     }
@@ -115,6 +126,17 @@ fun MangaToolbar(
                             onClick = onClickFilter,
                         ),
                     )
+                    if (onClickDownload != null) {
+                        add(
+                            AppBar.Action(
+                                title = stringResource(
+                                    if (isKomgaCacheMode) MR.strings.komga_action_cache else MR.strings.manga_download,
+                                ),
+                                icon = Icons.Outlined.Download,
+                                onClick = { downloadExpanded = !downloadExpanded },
+                            ),
+                        )
+                    }
                     add(
                         AppBar.OverflowAction(
                             title = stringResource(MR.strings.action_webview_refresh),
@@ -154,6 +176,29 @@ fun MangaToolbar(
                 }
                     .build(),
             )
+
+            if (!isActionMode && chapterCoverDisplayMode != null) {
+                DropdownMenu(
+                    expanded = displayModeExpanded,
+                    onDismissRequest = { displayModeExpanded = false },
+                ) {
+                    listOf(
+                        MR.strings.action_display_comfortable_grid to
+                            Manga.CHAPTER_COVER_DISPLAY_COMFORTABLE,
+                        MR.strings.action_display_grid to Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE,
+                        MR.strings.action_display_cover_only_grid to Manga.CHAPTER_COVER_DISPLAY_COVER,
+                        MR.strings.action_display_list to Manga.CHAPTER_COVER_DISPLAY_TEXT,
+                    ).forEach { (titleRes, mode) ->
+                        RadioMenuItem(
+                            text = { Text(text = stringResource(titleRes)) },
+                            isChecked = chapterCoverDisplayMode == mode,
+                        ) {
+                            displayModeExpanded = false
+                            onChapterCoverDisplayModeChange(mode)
+                        }
+                    }
+                }
+            }
         },
         isActionMode = isActionMode,
         onCancelActionMode = onCancelActionMode,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -241,10 +241,11 @@ object SettingsLibraryScreen : SearchableSettings {
         )
         val displayChapterByNameOrNumber by libraryPreferences.displayChapterByNameOrNumber.collectAsState()
         val chapterCoverDisplayModeEntries = persistentMapOf(
-            Manga.CHAPTER_COVER_DISPLAY_TEXT to stringResource(MR.strings.action_display_chapter_text_only),
-            Manga.CHAPTER_COVER_DISPLAY_COVER to stringResource(MR.strings.action_display_chapter_cover_only),
-            Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE to
-                stringResource(MR.strings.action_display_chapter_cover_and_title),
+            Manga.CHAPTER_COVER_DISPLAY_COMFORTABLE to
+                stringResource(MR.strings.action_display_comfortable_grid),
+            Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE to stringResource(MR.strings.action_display_grid),
+            Manga.CHAPTER_COVER_DISPLAY_COVER to stringResource(MR.strings.action_display_cover_only_grid),
+            Manga.CHAPTER_COVER_DISPLAY_TEXT to stringResource(MR.strings.action_display_list),
         )
         val chapterCoverDisplayMode by libraryPreferences.chapterCoverDisplayMode.collectAsState()
         val chapterCoverGridColumnsPref = libraryPreferences.chapterCoverGridColumns
@@ -272,6 +273,11 @@ object SettingsLibraryScreen : SearchableSettings {
                     valueRange = 2..6,
                     enabled = chapterCoverDisplayMode != Manga.CHAPTER_COVER_DISPLAY_TEXT,
                     onValueChanged = { chapterCoverGridColumnsPref.set(it) },
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.showChapterReadProgress,
+                    title = stringResource(MR.strings.pref_show_chapter_read_progress),
+                    subtitle = stringResource(MR.strings.pref_show_chapter_read_progress_summary),
                 ),
             ),
         )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -95,6 +95,7 @@ class MangaScreen(
 
         val state by screenModel.state.collectAsStateWithLifecycle()
         val chapterCoverGridColumns by screenModel.chapterCoverGridColumns
+        val showChapterReadProgress = screenModel.showChapterReadProgress
 
         if (state is MangaScreenModel.State.Loading) {
             LoadingScreen()
@@ -116,6 +117,7 @@ class MangaScreen(
             chapterSwipeStartAction = screenModel.chapterSwipeStartAction,
             chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
+            showChapterReadProgress = showChapterReadProgress,
             navigateUp = navigator::pop,
             onChapterClicked = { openChapter(context, scope, epubReaderLauncher, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
@@ -127,6 +129,7 @@ class MangaScreen(
             onWebViewLongClicked = null,
             onTagSearch = { scope.launch { performGenreSearch(navigator, it, screenModel.source!!) } },
             onFilterButtonClicked = screenModel::showSettingsDialog,
+            onChapterCoverDisplayModeChange = screenModel::setChapterCoverDisplayMode,
             onRefresh = screenModel::fetchAllFromSource,
             onContinueReading = {
                 continueReading(context, scope, epubReaderLauncher, screenModel.getNextUnreadChapter())
@@ -203,7 +206,8 @@ class MangaScreen(
                 onBookmarkedFilterChanged = screenModel::setBookmarkedFilter,
                 onSortModeChanged = screenModel::setSorting,
                 onDisplayModeChanged = screenModel::setDisplayMode,
-                onChapterCoverDisplayModeChanged = screenModel::setChapterCoverDisplayMode,
+                showChapterReadProgress = showChapterReadProgress,
+                onShowChapterReadProgressChanged = screenModel::updateShowChapterReadProgress,
                 onSetAsDefault = screenModel::setCurrentSettingsAsDefault,
                 onResetToDefault = screenModel::resetToDefaultSettings,
                 scanlatorFilterActive = successState.scanlatorFilterActive,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.util.fastAny
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
@@ -184,6 +186,8 @@ class MangaScreenModel(
     val chapterSwipeStartAction = libraryPreferences.swipeToEndAction.get()
     val chapterSwipeEndAction = libraryPreferences.swipeToStartAction.get()
     val chapterCoverGridColumns = libraryPreferences.chapterCoverGridColumns.asState(screenModelScope)
+    var showChapterReadProgress by mutableStateOf(libraryPreferences.showChapterReadProgress.get())
+        private set
     var autoTrackState = trackPreferences.autoUpdateTrackOnMarkRead.get()
 
     private val skipFiltered by readerPreferences.skipFiltered.asState(screenModelScope)
@@ -1132,6 +1136,10 @@ class MangaScreenModel(
         }
     }
 
+    fun updateShowChapterReadProgress(show: Boolean) {
+        showChapterReadProgress = show
+    }
+
     /**
      * Sets the sorting method and requests an UI update.
      * @param sort the sorting mode.
@@ -1146,8 +1154,10 @@ class MangaScreenModel(
 
     fun setCurrentSettingsAsDefault(applyToExisting: Boolean) {
         val manga = successState?.manga ?: return
+        val showReadProgress = showChapterReadProgress
         screenModelScope.launchNonCancellable {
             libraryPreferences.setChapterSettingsDefault(manga)
+            libraryPreferences.showChapterReadProgress.set(showReadProgress)
             if (applyToExisting) {
                 setMangaDefaultChapterFlags.awaitAll()
             }
@@ -1157,6 +1167,7 @@ class MangaScreenModel(
 
     fun resetToDefaultSettings() {
         val manga = successState?.manga ?: return
+        showChapterReadProgress = libraryPreferences.showChapterReadProgress.get()
         screenModelScope.launchNonCancellable {
             setMangaDefaultChapterFlags.await(manga)
         }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -176,6 +176,11 @@ class LibraryPreferences(
         3,
     )
 
+    val showChapterReadProgress: Preference<Boolean> = preferenceStore.getBoolean(
+        "show_chapter_read_progress",
+        true,
+    )
+
     val sortChapterByAscendingOrDescending: Preference<Long> = preferenceStore.getLong(
         "default_chapter_sort_by_ascending_or_descending",
         Manga.CHAPTER_SORT_DESC,

--- a/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/model/Manga.kt
@@ -112,6 +112,7 @@ data class Manga(
         const val CHAPTER_COVER_DISPLAY_TEXT = 0x00000000L
         const val CHAPTER_COVER_DISPLAY_COVER = 0x00200000L
         const val CHAPTER_COVER_DISPLAY_COVER_AND_TITLE = 0x00400000L
+        const val CHAPTER_COVER_DISPLAY_COMFORTABLE = 0x00600000L
         const val CHAPTER_COVER_DISPLAY_MASK = 0x00600000L
 
         fun create() = Manga(

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1065,7 +1065,11 @@
     <string name="cover_updated">Cover updated</string>
     <string name="share_page_info">%1$s: %2$s, page %3$d</string>
     <string name="chapter_progress">Page: %1$d</string>
+    <string name="chapter_progress_short">P. %1$d</string>
     <string name="epub_chapter_progress">Progress: %1$d%%</string>
+    <string name="epub_chapter_progress_short">%1$d%%</string>
+    <string name="pref_show_chapter_read_progress">Show reading progress and read status</string>
+    <string name="pref_show_chapter_read_progress_summary">Show progress, unread markers, and read checkmarks in chapter lists and grids</string>
     <string name="no_next_chapter">Next chapter not found</string>
     <string name="decode_image_error">The image couldn\'t be loaded</string>
     <string name="confirm_set_image_as_cover">Use this image as cover art?</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -311,7 +311,11 @@
     <string name="set_as_cover">设为封面</string>
     <string name="cover_updated">封面已更新</string>
     <string name="chapter_progress">第 %1$d 页</string>
+    <string name="chapter_progress_short">第%1$d页</string>
     <string name="epub_chapter_progress">&#24050;&#35835; %1$d%%</string>
+    <string name="epub_chapter_progress_short">%1$d%%</string>
+    <string name="pref_show_chapter_read_progress">显示阅读进度与已读状态</string>
+    <string name="pref_show_chapter_read_progress_summary">在章节列表和网格中显示进度、未读标记及已读勾选</string>
     <string name="no_next_chapter">后面没有啦</string>
     <string name="decode_image_error">加载图片失败</string>
     <string name="confirm_set_image_as_cover">要将此页设为封面吗？</string>


### PR DESCRIPTION
## 中文

### 变更内容

- 将作品详情页的章节显示模式从筛选菜单中拆出，在顶部工具栏提供独立切换入口，并补齐松散网格、紧凑网格、纯封面和列表模式。
- 为网格模式增加阅读百分比和已读角标；漫画进度使用百分比显示，列表模式继续保留已读页数。
- 增加全局“显示阅读进度/已读状态”偏好，并在详情页显示设置中提供页面级临时开关；只有“设为默认”才写入全局偏好。
- 优化进度文字阴影、已读角标、封面明暗表现及通用网格覆盖层。
- 修复网格模式下详情页顶部封面背景未铺满左右边缘的问题。
- 作品简介默认收起，折叠态由 3 行增加到 4 行。
- 调整顶部工具栏顺序为“显示模式 → 筛选 → 下载 → 更多”。
- 将应用版本更新为 0.2.3。

### 原因与影响

详情页此前主要按列表布局设计：显示模式入口与筛选耦合，网格模式缺少松散布局和进度表达，页面显示设置还会立即污染全局默认值。网格容器新增的水平内边距也会同步压缩跨列详情头背景。

本次修改统一了各显示模式的进度体验，区分页面临时设置与全局默认，并修复详情头背景和简介折叠体验。数据模型、Komga 云端进度及下载状态语义不变。

### 验证

- `git diff --cached --check`
- 按协作约定，最终提交未重新运行 Gradle；建议 CI 执行 Spotless 与 Debug Kotlin 编译。

---

## English

### Changes

- Moved chapter display mode selection out of the filter menu into a dedicated toolbar action, with comfortable grid, compact grid, cover-only, and list modes.
- Added reading-percentage and read-state corner indicators to grid layouts. Comic grid progress is shown as a percentage, while list mode keeps the existing page-count text.
- Added a global preference for progress/read indicators and a page-local shortcut in manga display settings. The global preference is updated only through “Set as default.”
- Refined progress text shadows, read badges, cover dimming, and reusable grid cover overlays.
- Fixed the manga detail backdrop being narrowed by grid content padding.
- Made the description collapsed by default and increased its collapsed preview from three to four lines.
- Reordered toolbar actions to “Display mode → Filter → Download → More.”
- Bumped the app version to 0.2.3.

### Rationale and impact

The detail screen was primarily designed around list mode: display controls were coupled to filtering, grid layouts lacked a comfortable mode and progress treatment, and page-level display changes immediately mutated global defaults. Grid content padding also narrowed the full-span detail backdrop.

This change aligns progress presentation across layouts, separates temporary page settings from global defaults, and improves the detail header and description experience without changing Komga cloud progress, download state, or source APIs.

### Validation

- `git diff --cached --check`
- Per the collaboration preference, Gradle was not rerun for the final commit; CI should run Spotless and Debug Kotlin compilation.