### PR TITLE
扩展 Komga 搜索范围与容错 / Expand Komga search scope and resilience

### DIFF
--- a/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
@@ -1,6 +1,8 @@
 package koharia.komga.api
 
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.network.HttpException
+import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.network.awaitSuccess
 import koharia.komga.api.dto.AuthorDto
 import koharia.komga.api.dto.ClientSettingDto
@@ -31,7 +33,12 @@ class KomgaApiClient(
     private val headers: Headers,
     private val client: OkHttpClient,
     @PublishedApi internal val json: Json,
+    private val searchCapabilities: KomgaSearchCapabilities = KomgaSearchCapabilities(),
 ) {
+
+    init {
+        searchCapabilities.prepareFor(baseUrl)
+    }
 
     fun popularRequest(
         page: Int,
@@ -112,12 +119,8 @@ class KomgaApiClient(
         oneshot?.let { url.addQueryParameter("oneshot", it.toString()) }
 
         val sortCriteria = when (sortIndex) {
-            0 -> "relevance"
-            1 -> when (typePath) {
-                "series" -> "metadata.titleSort"
-                "books" -> "metadata.title"
-                else -> "name"
-            }
+            0 -> "relevance".takeIf { query.isNotBlank() }
+            1 -> type.alphabeticalSortField()
             2 -> "createdDate"
             3 -> "lastModifiedDate"
             4 -> "random"
@@ -134,6 +137,86 @@ class KomgaApiClient(
             .komgaCachePolicy(cachePolicy)
             .build()
     }
+
+    fun searchListRequest(
+        page: Int,
+        query: String,
+        type: SearchType,
+        defaultLibraries: Set<String>,
+        selectedLibraries: Set<String> = emptySet(),
+        collectionId: String? = null,
+        sortIndex: Int = 0,
+        sortAscending: Boolean = true,
+        readStatuses: Set<String> = emptySet(),
+        statuses: Set<String> = emptySet(),
+        genres: Set<String> = emptySet(),
+        tags: Set<String> = emptySet(),
+        publishers: Set<String> = emptySet(),
+        authors: List<Pair<String, String>> = emptyList(),
+        oneshot: Boolean? = null,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ): Request {
+        require(type == SearchType.SERIES || type == SearchType.BOOKS)
+        val libraries = if (selectedLibraries.isEmpty()) defaultLibraries else selectedLibraries
+        val request = KomgaSearchRequest(
+            condition = buildSearchCondition(
+                type = type,
+                libraries = libraries,
+                collectionId = collectionId,
+                readStatuses = readStatuses,
+                statuses = statuses,
+                genres = genres,
+                tags = tags,
+                publishers = publishers,
+                authors = authors,
+                oneshot = oneshot,
+            ),
+            fullTextSearch = query.takeIf { it.isNotBlank() },
+        )
+        val url = "$baseUrl/api/v1/${type.pathSegment}/list".toHttpUrl().newBuilder()
+            .addQueryParameter("page", (page - 1).toString())
+        val sortCriteria = when (sortIndex) {
+            0 -> "relevance".takeIf { query.isNotBlank() }
+            1 -> type.alphabeticalSortField()
+            2 -> "createdDate"
+            3 -> "lastModifiedDate"
+            4 -> "random"
+            else -> null
+        }?.let { "$it,${if (sortAscending) "asc" else "desc"}" }
+        sortCriteria?.let { url.addQueryParameter("sort", it) }
+
+        return POST(
+            url = url.build().toString(),
+            headers = headers,
+            body = json.encodeToString(request).toRequestBody(JSON_MEDIA_TYPE),
+        )
+            .newBuilder()
+            .komgaCachePolicy(cachePolicy)
+            .build()
+    }
+
+    suspend fun executeSearch(
+        type: SearchType,
+        modernRequest: Request,
+        legacyRequest: Request,
+        legacyCompatible: Boolean,
+    ): Response {
+        if (searchCapabilities.usesLegacy(type)) {
+            check(legacyCompatible) { "This search requires Komga 1.19 or newer" }
+            return execute(legacyRequest)
+        }
+
+        return try {
+            execute(modernRequest)
+        } catch (error: HttpException) {
+            if (error.code != 404 && error.code != 405) throw error
+            searchCapabilities.markLegacy(type)
+            check(legacyCompatible) { "This search requires Komga 1.19 or newer" }
+            execute(legacyRequest)
+        }
+    }
+
+    suspend fun execute(request: Request): Response = client.newCall(request).awaitSuccess()
 
     fun detailsRequest(url: String, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Request =
         GET(url, headers)
@@ -297,5 +380,26 @@ class KomgaApiClient(
         SERIES,
         READ_LISTS,
         BOOKS,
+        ALL,
+        ;
+
+        val pathSegment: String
+            get() = when (this) {
+                SERIES -> "series"
+                READ_LISTS -> "readlists"
+                BOOKS -> "books"
+                ALL -> error("All searches use separate series and book requests")
+            }
+
+        fun alphabeticalSortField(): String = when (this) {
+            SERIES -> "metadata.titleSort"
+            BOOKS -> "metadata.title"
+            READ_LISTS -> "name"
+            ALL -> error("All searches only support relevance sorting")
+        }
+    }
+
+    companion object {
+        private val JSON_MEDIA_TYPE = "application/json".toMediaType()
     }
 }

--- a/app/src/main/java/koharia/komga/api/KomgaSearch.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaSearch.kt
@@ -1,0 +1,127 @@
+package koharia.komga.api
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.util.concurrent.ConcurrentHashMap
+
+@Serializable
+internal data class KomgaSearchRequest(
+    val condition: JsonObject,
+    val fullTextSearch: String? = null,
+)
+
+class KomgaSearchCapabilities {
+    private val legacyTypes = ConcurrentHashMap.newKeySet<KomgaApiClient.SearchType>()
+
+    @Volatile
+    private var serverKey: String? = null
+
+    @Synchronized
+    internal fun prepareFor(serverKey: String) {
+        if (this.serverKey == serverKey) return
+        this.serverKey = serverKey
+        legacyTypes.clear()
+    }
+
+    internal fun usesLegacy(type: KomgaApiClient.SearchType): Boolean = type in legacyTypes
+
+    internal fun markLegacy(type: KomgaApiClient.SearchType) {
+        legacyTypes += type
+    }
+
+    internal fun clear() {
+        legacyTypes.clear()
+    }
+}
+
+internal fun buildSearchCondition(
+    type: KomgaApiClient.SearchType,
+    libraries: Set<String>,
+    collectionId: String?,
+    readStatuses: Set<String>,
+    statuses: Set<String>,
+    genres: Set<String>,
+    tags: Set<String>,
+    publishers: Set<String>,
+    authors: List<Pair<String, String>>,
+    oneshot: Boolean?,
+): JsonObject {
+    val conditions = buildList {
+        add(booleanCondition("deleted", false))
+        addAnyOf("libraryId", libraries)
+        addAnyOf("readStatus", readStatuses)
+        addAnyOf("tag", tags)
+        addAnyOfAuthors(authors)
+        oneshot?.let { add(booleanCondition("oneShot", it)) }
+
+        if (type == KomgaApiClient.SearchType.SERIES) {
+            collectionId?.let { add(equalityCondition("collectionId", it)) }
+            addAnyOf("seriesStatus", statuses)
+            addAnyOf("genre", genres)
+            addAnyOf("publisher", publishers)
+        }
+    }
+    return buildJsonObject { put("allOf", JsonArray(conditions)) }
+}
+
+private fun MutableList<JsonObject>.addAnyOf(field: String, values: Collection<String>) {
+    if (values.isEmpty()) return
+    add(
+        buildJsonObject {
+            put("anyOf", JsonArray(values.map { equalityCondition(field, it) }))
+        },
+    )
+}
+
+private fun MutableList<JsonObject>.addAnyOfAuthors(authors: List<Pair<String, String>>) {
+    if (authors.isEmpty()) return
+    add(
+        buildJsonObject {
+            put(
+                "anyOf",
+                JsonArray(
+                    authors.map { (name, role) ->
+                        buildJsonObject {
+                            put(
+                                "author",
+                                buildJsonObject {
+                                    put("operator", "is")
+                                    put(
+                                        "value",
+                                        buildJsonObject {
+                                            put("name", name)
+                                            put("role", role)
+                                        },
+                                    )
+                                },
+                            )
+                        }
+                    },
+                ),
+            )
+        },
+    )
+}
+
+private fun equalityCondition(field: String, value: String): JsonObject = buildJsonObject {
+    put(
+        field,
+        buildJsonObject {
+            put("operator", "is")
+            put("value", value)
+        },
+    )
+}
+
+private fun booleanCondition(field: String, value: Boolean): JsonObject = buildJsonObject {
+    put(
+        field,
+        buildJsonObject {
+            put("operator", JsonPrimitive(if (value) "isTrue" else "isFalse"))
+        },
+    )
+}

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -424,7 +424,7 @@ private fun FilterList.multiSelectIds(name: String): Set<String> {
     return filter.state.filter { it.state }.map { it.id }.toSet()
 }
 
-private val SEARCH_DELIMITERS = Regex("[()（）【】]")
+private val SEARCH_DELIMITERS = Regex("""[()\[\]（）【】]""")
 private val REPEATED_WHITESPACE = Regex("\\s+")
 private val ADVANCED_FIELD_QUERY = Regex(
     "(?:^|\\s)(?:title|isbn|tag|series_tag|book_tag|author|writer|penciller|inker|colorist|letterer|" +

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -1,6 +1,5 @@
 package koharia.komga.domain.repository
 
-import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
@@ -26,8 +25,13 @@ import koharia.source.komga.OneshotFilter
 import koharia.source.komga.ReadFilter
 import koharia.source.komga.ReadingStateGroup
 import koharia.source.komga.SeriesSort
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_BOOKS_INDEX
+import koharia.source.komga.TYPE_READ_LISTS_INDEX
 import koharia.source.komga.TypeSelect
 import koharia.source.komga.UnreadFilter
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import okhttp3.Request
 import tachiyomi.core.common.util.lang.withIOContext
 import java.text.ParseException
@@ -60,6 +64,7 @@ class KomgaRepository(
         cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
     ): Request {
         val type = filters.searchType()
+        require(type != KomgaApiClient.SearchType.ALL)
         val supportsBookFilters = type != KomgaApiClient.SearchType.READ_LISTS
         val supportsSeriesFilters = type == KomgaApiClient.SearchType.SERIES
         return apiClient.searchRequest(
@@ -80,6 +85,130 @@ class KomgaRepository(
             oneshot = filters.oneshot().takeIf { supportsSeriesFilters },
             cachePolicy = cachePolicy,
         )
+    }
+
+    suspend fun getSearchManga(
+        page: Int,
+        query: String,
+        filters: FilterList,
+        defaultLibraries: Set<String>,
+        cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
+    ): MangasPage {
+        val type = filters.searchType()
+        if (type == KomgaApiClient.SearchType.READ_LISTS) {
+            return apiClient.execute(
+                searchMangaRequest(page, query, filters, defaultLibraries, cachePolicy),
+            ).let(::parseMangasPage)
+        }
+
+        val normalizedQuery = normalizeSearchQuery(query)
+        if (query.isNotBlank() && normalizedQuery.isBlank()) {
+            return MangasPage(emptyList(), false)
+        }
+
+        return when (type) {
+            KomgaApiClient.SearchType.ALL -> coroutineScope {
+                val books = async {
+                    getSearchMangaPage(
+                        page = page,
+                        query = normalizedQuery,
+                        type = KomgaApiClient.SearchType.BOOKS,
+                        filters = filters,
+                        defaultLibraries = defaultLibraries,
+                        forceRelevanceSort = true,
+                        cachePolicy = cachePolicy,
+                    )
+                }
+                val series = async {
+                    getSearchMangaPage(
+                        page = page,
+                        query = normalizedQuery,
+                        type = KomgaApiClient.SearchType.SERIES,
+                        filters = filters,
+                        defaultLibraries = defaultLibraries,
+                        forceRelevanceSort = true,
+                        cachePolicy = cachePolicy,
+                    )
+                }
+                mergeSearchPages(books.await(), series.await())
+            }
+            KomgaApiClient.SearchType.BOOKS,
+            KomgaApiClient.SearchType.SERIES,
+            -> getSearchMangaPage(
+                page = page,
+                query = normalizedQuery,
+                type = type,
+                filters = filters,
+                defaultLibraries = defaultLibraries,
+                forceRelevanceSort = false,
+                cachePolicy = cachePolicy,
+            )
+            KomgaApiClient.SearchType.READ_LISTS -> error("Handled above")
+        }
+    }
+
+    private suspend fun getSearchMangaPage(
+        page: Int,
+        query: String,
+        type: KomgaApiClient.SearchType,
+        filters: FilterList,
+        defaultLibraries: Set<String>,
+        forceRelevanceSort: Boolean,
+        cachePolicy: KomgaCachePolicy,
+    ): MangasPage {
+        val isSeries = type == KomgaApiClient.SearchType.SERIES
+        val selectedLibraries = filters.selectedLibraries()
+        val sortSelection = if (forceRelevanceSort) 0 to true else filters.sortSelection()
+        val readStatuses = filters.readStatuses()
+        val statuses = filters.multiSelectIds("Status").takeIf { isSeries }.orEmpty()
+        val genres = filters.multiSelectIds("Genres").takeIf { isSeries }.orEmpty()
+        val tags = filters.multiSelectIds("Tags")
+        val publishers = filters.multiSelectIds("Publishers").takeIf { isSeries }.orEmpty()
+        val authors = filters.selectedAuthors()
+        val oneshot = filters.oneshot()
+        val collectionId = filters.collectionId().takeIf { isSeries }
+        val modernRequest = apiClient.searchListRequest(
+            page = page,
+            query = query,
+            type = type,
+            defaultLibraries = defaultLibraries,
+            selectedLibraries = selectedLibraries,
+            collectionId = collectionId,
+            sortIndex = sortSelection.first,
+            sortAscending = sortSelection.second,
+            readStatuses = readStatuses,
+            statuses = statuses,
+            genres = genres,
+            tags = tags,
+            publishers = publishers,
+            authors = authors,
+            oneshot = oneshot,
+            cachePolicy = cachePolicy,
+        )
+        val legacyRequest = apiClient.searchRequest(
+            page = page,
+            query = query,
+            type = type,
+            defaultLibraries = defaultLibraries,
+            selectedLibraries = selectedLibraries,
+            collectionId = collectionId,
+            sortIndex = sortSelection.first,
+            sortAscending = sortSelection.second,
+            readStatuses = readStatuses,
+            statuses = statuses,
+            genres = genres,
+            tags = tags,
+            publishers = publishers,
+            authors = authors.takeIf { isSeries }.orEmpty(),
+            oneshot = oneshot.takeIf { isSeries },
+            cachePolicy = cachePolicy,
+        )
+        return apiClient.executeSearch(
+            type = type,
+            modernRequest = modernRequest,
+            legacyRequest = legacyRequest,
+            legacyCompatible = isSeries || (authors.isEmpty() && oneshot == null),
+        ).let(::parseMangasPage)
     }
 
     fun parseMangasPage(response: okhttp3.Response): MangasPage {
@@ -215,10 +344,28 @@ class KomgaRepository(
     }
 }
 
+internal fun normalizeSearchQuery(query: String): String = query
+    .replace(SEARCH_DELIMITERS, " ")
+    .replace(REPEATED_WHITESPACE, " ")
+    .trim()
+
+internal fun mergeSearchPages(books: MangasPage, series: MangasPage): MangasPage {
+    val mangas = buildList(books.mangas.size + series.mangas.size) {
+        val maxSize = maxOf(books.mangas.size, series.mangas.size)
+        repeat(maxSize) { index ->
+            books.mangas.getOrNull(index)?.let(::add)
+            series.mangas.getOrNull(index)?.let(::add)
+        }
+    }
+    return MangasPage(mangas, books.hasNextPage || series.hasNextPage)
+}
+
 private fun FilterList.searchType(): KomgaApiClient.SearchType = when {
     collectionId() != null -> KomgaApiClient.SearchType.SERIES
-    filterIsInstance<TypeSelect>().firstOrNull()?.state == 1 -> KomgaApiClient.SearchType.READ_LISTS
-    filterIsInstance<TypeSelect>().firstOrNull()?.state == 2 -> KomgaApiClient.SearchType.BOOKS
+    filterIsInstance<TypeSelect>().firstOrNull()?.state == TYPE_READ_LISTS_INDEX ->
+        KomgaApiClient.SearchType.READ_LISTS
+    filterIsInstance<TypeSelect>().firstOrNull()?.state == TYPE_BOOKS_INDEX -> KomgaApiClient.SearchType.BOOKS
+    filterIsInstance<TypeSelect>().firstOrNull()?.state == TYPE_ALL_INDEX -> KomgaApiClient.SearchType.ALL
     else -> KomgaApiClient.SearchType.SERIES
 }
 
@@ -270,3 +417,6 @@ private fun FilterList.multiSelectIds(name: String): Set<String> {
     val filter = firstOrNull { it.name == name } as? koharia.source.komga.UriMultiSelectFilter ?: return emptySet()
     return filter.state.filter { it.state }.map { it.id }.toSet()
 }
+
+private val SEARCH_DELIMITERS = Regex("[()（）【】]")
+private val REPEATED_WHITESPACE = Regex("\\s+")

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -63,8 +63,8 @@ class KomgaRepository(
         defaultLibraries: Set<String>,
         cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default,
     ): Request {
-        val type = filters.searchType()
-        require(type != KomgaApiClient.SearchType.ALL)
+        val type = filters.searchType().takeUnless { it == KomgaApiClient.SearchType.ALL }
+            ?: KomgaApiClient.SearchType.SERIES
         val supportsBookFilters = type != KomgaApiClient.SearchType.READ_LISTS
         val supportsSeriesFilters = type == KomgaApiClient.SearchType.SERIES
         return apiClient.searchRequest(
@@ -344,10 +344,16 @@ class KomgaRepository(
     }
 }
 
-internal fun normalizeSearchQuery(query: String): String = query
-    .replace(SEARCH_DELIMITERS, " ")
-    .replace(REPEATED_WHITESPACE, " ")
-    .trim()
+internal fun normalizeSearchQuery(query: String): String {
+    val trimmedQuery = query.trim()
+    if (ADVANCED_FIELD_QUERY.containsMatchIn(trimmedQuery) || BOOLEAN_GROUP_QUERY.containsMatchIn(trimmedQuery)) {
+        return trimmedQuery
+    }
+    return trimmedQuery
+        .replace(SEARCH_DELIMITERS, " ")
+        .replace(REPEATED_WHITESPACE, " ")
+        .trim()
+}
 
 internal fun mergeSearchPages(books: MangasPage, series: MangasPage): MangasPage {
     val mangas = buildList(books.mangas.size + series.mangas.size) {
@@ -420,3 +426,10 @@ private fun FilterList.multiSelectIds(name: String): Set<String> {
 
 private val SEARCH_DELIMITERS = Regex("[()（）【】]")
 private val REPEATED_WHITESPACE = Regex("\\s+")
+private val ADVANCED_FIELD_QUERY = Regex(
+    "(?:^|\\s)(?:title|isbn|tag|series_tag|book_tag|author|writer|penciller|inker|colorist|letterer|" +
+        "cover|editor|translator|publisher|status|reading_direction|age_rating|language|genre|" +
+        "sharing_label|total_book_count|book_count|release_date|deleted|oneshot|complete):",
+    RegexOption.IGNORE_CASE,
+)
+private val BOOLEAN_GROUP_QUERY = Regex("\\([^)]*\\b(?:AND|OR|NOT)\\b[^)]*\\)")

--- a/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
@@ -25,9 +25,12 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import koharia.source.komga.AuthorGroup
 import koharia.source.komga.CollectionSelect
 import koharia.source.komga.LibraryFilter
-import koharia.source.komga.OneshotFilter
 import koharia.source.komga.ReadingStateGroup
 import koharia.source.komga.SeriesSort
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_BOOKS_INDEX
+import koharia.source.komga.TYPE_READ_LISTS_INDEX
+import koharia.source.komga.TYPE_SERIES_INDEX
 import koharia.source.komga.TypeSelect
 import koharia.source.komga.UriMultiSelectFilter
 import tachiyomi.core.common.preference.TriState
@@ -147,9 +150,10 @@ private fun FilterItem(filter: Filter<*>, filters: FilterList, onUpdate: () -> U
                 options = filter.values.map { komgaFilterLabel(it.toString()) }.toTypedArray(),
                 selectedIndex = filter.state,
             ) {
-                filter.state = it
                 if (filter is TypeSelect) {
-                    filters.clearFiltersHiddenFor(it)
+                    filters.selectContentType(it)
+                } else {
+                    filter.state = it
                 }
                 onUpdate()
             }
@@ -189,9 +193,6 @@ private fun FilterItem(filter: Filter<*>, filters: FilterList, onUpdate: () -> U
                 Column {
                     filter.state
                         .filterIsInstance<Filter<*>>()
-                        .filter {
-                            filters.selectedContentType() == TYPE_SERIES_INDEX || it !is OneshotFilter
-                        }
                         .map { FilterItem(filter = it, filters = filters, onUpdate = onUpdate) }
                 }
             }
@@ -206,6 +207,7 @@ private fun komgaFilterLabel(label: String): String {
         "Series" -> stringResource(MR.strings.komga_filter_series)
         "Read lists" -> stringResource(MR.strings.komga_filter_read_lists)
         "Books" -> stringResource(MR.strings.komga_filter_books)
+        "All" -> stringResource(MR.strings.all)
         "Sort" -> stringResource(MR.strings.action_sort)
         "Relevance" -> stringResource(MR.strings.komga_filter_sort_relevance)
         "Alphabetically" -> stringResource(MR.strings.komga_filter_sort_alphabetically)
@@ -253,6 +255,7 @@ private fun FilterList.visibleFilters(): List<Filter<*>> {
         when (type) {
             TYPE_READ_LISTS_INDEX -> filter.isReadListFilter()
             TYPE_BOOKS_INDEX -> filter.isBookFilter()
+            TYPE_ALL_INDEX -> filter.isAllFilter()
             else -> filter !is SeriesSort || !hasCollection
         }
     }
@@ -271,13 +274,29 @@ private fun Filter<*>.isBookFilter(): Boolean {
         this is LibraryFilter ||
         this is ReadingStateGroup ||
         (this is UriMultiSelectFilter && name == "Tags") ||
+        this is AuthorGroup ||
         this is SeriesSort ||
         this is Filter.Header ||
         this is Filter.Separator
 }
 
+private fun Filter<*>.isAllFilter(): Boolean {
+    return this is TypeSelect ||
+        this is LibraryFilter ||
+        this is ReadingStateGroup ||
+        (this is UriMultiSelectFilter && name == "Tags") ||
+        this is AuthorGroup ||
+        this is Filter.Header ||
+        this is Filter.Separator
+}
+
 private fun FilterList.selectedContentType(): Int =
-    filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_SERIES_INDEX
+    filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_ALL_INDEX
+
+internal fun FilterList.selectContentType(type: Int) {
+    filterIsInstance<TypeSelect>().firstOrNull()?.state = type
+    clearFiltersHiddenFor(type)
+}
 
 private fun FilterList.clearFiltersHiddenFor(type: Int) {
     if (type == TYPE_SERIES_INDEX) return
@@ -289,22 +308,18 @@ private fun FilterList.clearFiltersHiddenFor(type: Int) {
             type == TYPE_READ_LISTS_INDEX && filter is UriMultiSelectFilter && filter !is LibraryFilter ->
                 filter.clearSelections()
             type == TYPE_READ_LISTS_INDEX && filter is AuthorGroup -> filter.clearSelections()
-            type == TYPE_BOOKS_INDEX && filter is ReadingStateGroup ->
-                filter.state.filterIsInstance<OneshotFilter>().forEach { it.state = false }
-            type == TYPE_BOOKS_INDEX && filter is UriMultiSelectFilter &&
+            (type == TYPE_BOOKS_INDEX || type == TYPE_ALL_INDEX) && filter is UriMultiSelectFilter &&
                 filter !is LibraryFilter && filter.name != "Tags" -> filter.clearSelections()
-            type == TYPE_BOOKS_INDEX && filter is AuthorGroup -> filter.clearSelections()
         }
+    }
+    if (type == TYPE_ALL_INDEX) {
+        filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(0, true)
     }
 }
 
 private fun Filter.Group<*>.clearSelections() {
     state.filterIsInstance<Filter.CheckBox>().forEach { it.state = false }
 }
-
-private const val TYPE_SERIES_INDEX = 0
-private const val TYPE_READ_LISTS_INDEX = 1
-private const val TYPE_BOOKS_INDEX = 2
 
 private fun Int.toTriStateFilter(): TriState {
     return when (this) {

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -223,6 +224,9 @@ data class KomgaLibraryScreen(
                         onFilterClick = screenModel::openFilterSheet,
                         navigateUp = navigateUp.takeIf { showNavigationUp },
                         onSearch = screenModel::search,
+                        onClickCloseSearch = screenModel::exitSearch,
+                        searchType = state.searchType,
+                        onSearchTypeSelect = screenModel::setSearchType,
                     )
 
                     Row(
@@ -231,7 +235,20 @@ data class KomgaLibraryScreen(
                             .padding(horizontal = MaterialTheme.padding.small),
                         horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
                     ) {
-                        if (state.komgaLibraries.isNotEmpty()) {
+                        if (state.isUserQuery) {
+                            Surface(
+                                modifier = Modifier.padding(vertical = 8.dp),
+                                shape = MaterialTheme.shapes.small,
+                                color = MaterialTheme.colorScheme.secondaryContainer,
+                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ) {
+                                Text(
+                                    text = stringResource(MR.strings.search_results),
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 6.dp),
+                                    style = MaterialTheme.typography.labelLarge,
+                                )
+                            }
+                        } else if (state.komgaLibraries.isNotEmpty()) {
                             FilterChip(
                                 selected = state.selectedKomgaLibraryId == null,
                                 onClick = {

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -81,6 +81,7 @@ class KomgaLibraryScreenModel(
     @Volatile
     private var filtersInitialized = false
     private var listingBeforeSearch: Listing? = null
+    private var filtersBeforeSearch: FilterList? = null
 
     init {
         if (source is CatalogueSource) {
@@ -177,6 +178,7 @@ class KomgaLibraryScreenModel(
 
     fun setListing(listing: Listing) {
         listingBeforeSearch = null
+        filtersBeforeSearch = null
         mutableState.update { it.copy(listing = listing, toolbarQuery = null) }
     }
 
@@ -209,8 +211,10 @@ class KomgaLibraryScreenModel(
         if (!query.isNullOrEmpty() && input.query.isNullOrEmpty() && listingBeforeSearch == null) {
             listingBeforeSearch = currentListing
         }
-        (source as? KomgaSource)?.saveSessionFilterState(nextFilters, libraryScope)
-        (source as? KomgaSource)?.savePersistentFilterState(nextFilters, libraryScope)
+        if (filters != null || filtersBeforeSearch == null) {
+            (source as? KomgaSource)?.saveSessionFilterState(nextFilters, libraryScope)
+            (source as? KomgaSource)?.savePersistentFilterState(nextFilters, libraryScope)
+        }
 
         mutableState.update {
             it.copy(
@@ -225,14 +229,17 @@ class KomgaLibraryScreenModel(
 
     fun exitSearch() {
         val currentListing = state.value.listing
+        val restoredFilters = filtersBeforeSearch ?: state.value.filters
         val restoredListing = listingBeforeSearch ?: when (currentListing) {
-            is Listing.Search -> currentListing.copy(query = null)
+            is Listing.Search -> currentListing.copy(query = null, filters = restoredFilters)
             else -> currentListing
         }
         listingBeforeSearch = null
+        filtersBeforeSearch = null
         mutableState.update {
             it.copy(
                 listing = restoredListing,
+                filters = restoredFilters,
                 toolbarQuery = null,
             )
         }
@@ -320,7 +327,13 @@ class KomgaLibraryScreenModel(
 
     fun setToolbarQuery(query: String?) {
         if (query != null && state.value.toolbarQuery == null) {
+            filtersBeforeSearch = state.value.filters
             setSearchType(TYPE_ALL_INDEX)
+        } else if (query == null && filtersBeforeSearch != null && !state.value.isUserQuery) {
+            val restoredFilters = filtersBeforeSearch ?: state.value.filters
+            filtersBeforeSearch = null
+            mutableState.update { it.copy(filters = restoredFilters, toolbarQuery = null) }
+            return
         }
         mutableState.update { it.copy(toolbarQuery = query) }
     }
@@ -338,9 +351,6 @@ class KomgaLibraryScreenModel(
             currentFilters = currentState.filters,
         )
         filters.selectContentType(type)
-        komgaSource.saveSessionFilterState(filters, libraryScope)
-        komgaSource.savePersistentFilterState(filters, libraryScope)
-
         val activeQuery = currentState.toolbarQuery
             ?.takeIf { currentState.isUserQuery && it.isNotBlank() }
         val listing = if (activeQuery != null) {

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -31,7 +31,6 @@ import koharia.source.komga.TYPE_ALL_INDEX
 import koharia.source.komga.TYPE_BOOKS_INDEX
 import koharia.source.komga.TYPE_READ_LISTS_INDEX
 import koharia.source.komga.TYPE_SERIES_INDEX
-import koharia.source.komga.TypeSelect
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -81,7 +80,6 @@ class KomgaLibraryScreenModel(
     @Volatile
     private var filtersInitialized = false
     private var listingBeforeSearch: Listing? = null
-    private var filtersBeforeSearch: FilterList? = null
 
     init {
         if (source is CatalogueSource) {
@@ -178,8 +176,7 @@ class KomgaLibraryScreenModel(
 
     fun setListing(listing: Listing) {
         listingBeforeSearch = null
-        filtersBeforeSearch = null
-        mutableState.update { it.copy(listing = listing, toolbarQuery = null) }
+        mutableState.update { it.copy(listing = listing, toolbarQuery = null, searchType = TYPE_ALL_INDEX) }
     }
 
     fun setFilters(filters: FilterList) {
@@ -207,11 +204,15 @@ class KomgaLibraryScreenModel(
                 ) ?: source.getFilterList(),
             )
 
-        val nextFilters = filters ?: state.value.filters.takeIf { it.isNotEmpty() } ?: input.filters
+        val nextFilters = when {
+            filters != null -> filters
+            query != null -> buildSearchFilters(state.value.filters, state.value.searchType)
+            else -> state.value.filters.takeIf { it.isNotEmpty() } ?: input.filters
+        }
         if (!query.isNullOrEmpty() && input.query.isNullOrEmpty() && listingBeforeSearch == null) {
             listingBeforeSearch = currentListing
         }
-        if (filters != null || filtersBeforeSearch == null) {
+        if (filters != null) {
             (source as? KomgaSource)?.saveSessionFilterState(nextFilters, libraryScope)
             (source as? KomgaSource)?.savePersistentFilterState(nextFilters, libraryScope)
         }
@@ -229,18 +230,16 @@ class KomgaLibraryScreenModel(
 
     fun exitSearch() {
         val currentListing = state.value.listing
-        val restoredFilters = filtersBeforeSearch ?: state.value.filters
         val restoredListing = listingBeforeSearch ?: when (currentListing) {
-            is Listing.Search -> currentListing.copy(query = null, filters = restoredFilters)
+            is Listing.Search -> currentListing.copy(query = null, filters = state.value.filters)
             else -> currentListing
         }
         listingBeforeSearch = null
-        filtersBeforeSearch = null
         mutableState.update {
             it.copy(
                 listing = restoredListing,
-                filters = restoredFilters,
                 toolbarQuery = null,
+                searchType = TYPE_ALL_INDEX,
             )
         }
     }
@@ -326,46 +325,46 @@ class KomgaLibraryScreenModel(
     }
 
     fun setToolbarQuery(query: String?) {
-        if (query != null && state.value.toolbarQuery == null) {
-            filtersBeforeSearch = state.value.filters
-            setSearchType(TYPE_ALL_INDEX)
-        } else if (query == null && filtersBeforeSearch != null && !state.value.isUserQuery) {
-            val restoredFilters = filtersBeforeSearch ?: state.value.filters
-            filtersBeforeSearch = null
-            mutableState.update { it.copy(filters = restoredFilters, toolbarQuery = null) }
-            return
+        mutableState.update {
+            it.copy(
+                toolbarQuery = query,
+                searchType = if (query == null || it.toolbarQuery == null) TYPE_ALL_INDEX else it.searchType,
+            )
         }
-        mutableState.update { it.copy(toolbarQuery = query) }
     }
 
     fun setSearchType(type: Int) {
         if (type !in SEARCH_TYPES) return
-        val komgaSource = source as? KomgaSource ?: return
         val currentState = state.value
         if (currentState.searchType == type) return
 
-        val filters = komgaSource.buildFilterListForLibrary(
-            libraryId = currentState.selectedKomgaLibraryId,
-            allowedLibraryIds = currentAllowedLibraryIds(),
-            libraryScope = libraryScope,
-            currentFilters = currentState.filters,
-        )
-        filters.selectContentType(type)
         val activeQuery = currentState.toolbarQuery
             ?.takeIf { currentState.isUserQuery && it.isNotBlank() }
         val listing = if (activeQuery != null) {
             (currentState.listing as Listing.Search).copy(
                 query = activeQuery,
-                filters = filters,
+                filters = buildSearchFilters(currentState.filters, type),
             )
         } else {
             currentState.listing
         }
         mutableState.update {
             it.copy(
-                filters = filters,
                 listing = listing,
+                searchType = type,
             )
+        }
+    }
+
+    private fun buildSearchFilters(filters: FilterList, searchType: Int): FilterList {
+        val komgaSource = source as? KomgaSource ?: return filters
+        return komgaSource.buildFilterListForLibrary(
+            libraryId = state.value.selectedKomgaLibraryId,
+            allowedLibraryIds = currentAllowedLibraryIds(),
+            libraryScope = libraryScope,
+            currentFilters = filters,
+        ).apply {
+            selectContentType(searchType)
         }
     }
 
@@ -401,6 +400,7 @@ class KomgaLibraryScreenModel(
                 filters = filters,
                 listing = Listing.Search(query = null, filters = filters),
                 toolbarQuery = null,
+                searchType = TYPE_ALL_INDEX,
             )
         }
         komgaSource.saveSessionFilterState(filters, libraryScope)
@@ -427,6 +427,8 @@ class KomgaLibraryScreenModel(
                     komgaLibraries = persistentListOf(),
                     selectedKomgaLibraryId = null,
                     isRefreshing = false,
+                    toolbarQuery = null,
+                    searchType = TYPE_ALL_INDEX,
                     persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                 )
             }
@@ -461,6 +463,7 @@ class KomgaLibraryScreenModel(
                     selectedKomgaLibraryId = selectedLibraryId,
                     isLibraryScopeEmpty = libraryScope != KomgaLibraryScope.ALL && visibleLibraries.isEmpty(),
                     toolbarQuery = null,
+                    searchType = TYPE_ALL_INDEX,
                     persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                 )
             }
@@ -484,6 +487,7 @@ class KomgaLibraryScreenModel(
                         komgaLibraries = persistentListOf(),
                         selectedKomgaLibraryId = null,
                         toolbarQuery = null,
+                        searchType = TYPE_ALL_INDEX,
                         persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                     )
                 }
@@ -528,6 +532,7 @@ class KomgaLibraryScreenModel(
                 listing = Listing.Search(query = null, filters = filters),
                 filters = filters,
                 toolbarQuery = null,
+                searchType = TYPE_ALL_INDEX,
                 komgaLibraries = visibleLibraries.toImmutableList(),
                 selectedKomgaLibraryId = selectedLibraryId,
                 isLibraryScopeEmpty = visibleLibraries.isEmpty(),
@@ -556,7 +561,7 @@ class KomgaLibraryScreenModel(
 
     private fun currentFiltersForReload(): FilterList? {
         if (!filtersInitialized) return null
-        return state.value.listing.filters.takeIf { it.isNotEmpty() }
+        return state.value.filters.takeIf { it.isNotEmpty() }
     }
 
     sealed class Listing(open val query: String?, open val filters: FilterList) {
@@ -593,9 +598,9 @@ class KomgaLibraryScreenModel(
         val isRefreshing: Boolean = false,
         val isLibraryScopeEmpty: Boolean = false,
         val persistentFilteringEnabled: Boolean = false,
+        val searchType: Int = TYPE_ALL_INDEX,
     ) {
         val isUserQuery get() = listing is Listing.Search && !listing.query.isNullOrEmpty()
-        val searchType get() = filters.filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_ALL_INDEX
     }
 
     private companion object {

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -27,6 +27,11 @@ import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLibraryKind
 import koharia.source.komga.KomgaLibraryScope
 import koharia.source.komga.KomgaSource
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_BOOKS_INDEX
+import koharia.source.komga.TYPE_READ_LISTS_INDEX
+import koharia.source.komga.TYPE_SERIES_INDEX
+import koharia.source.komga.TypeSelect
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -75,6 +80,7 @@ class KomgaLibraryScreenModel(
 
     @Volatile
     private var filtersInitialized = false
+    private var listingBeforeSearch: Listing? = null
 
     init {
         if (source is CatalogueSource) {
@@ -170,6 +176,7 @@ class KomgaLibraryScreenModel(
     }
 
     fun setListing(listing: Listing) {
+        listingBeforeSearch = null
         mutableState.update { it.copy(listing = listing, toolbarQuery = null) }
     }
 
@@ -186,7 +193,8 @@ class KomgaLibraryScreenModel(
     fun search(query: String? = null, filters: FilterList? = null) {
         if (source !is CatalogueSource) return
 
-        val input = state.value.listing as? Listing.Search
+        val currentListing = state.value.listing
+        val input = currentListing as? Listing.Search
             ?: Listing.Search(
                 query = null,
                 filters = (source as? KomgaSource)?.buildFilterListForLibrary(
@@ -197,7 +205,10 @@ class KomgaLibraryScreenModel(
                 ) ?: source.getFilterList(),
             )
 
-        val nextFilters = filters ?: input.filters
+        val nextFilters = filters ?: state.value.filters.takeIf { it.isNotEmpty() } ?: input.filters
+        if (!query.isNullOrEmpty() && input.query.isNullOrEmpty() && listingBeforeSearch == null) {
+            listingBeforeSearch = currentListing
+        }
         (source as? KomgaSource)?.saveSessionFilterState(nextFilters, libraryScope)
         (source as? KomgaSource)?.savePersistentFilterState(nextFilters, libraryScope)
 
@@ -208,6 +219,21 @@ class KomgaLibraryScreenModel(
                     filters = nextFilters,
                 ),
                 toolbarQuery = query ?: input.query,
+            )
+        }
+    }
+
+    fun exitSearch() {
+        val currentListing = state.value.listing
+        val restoredListing = listingBeforeSearch ?: when (currentListing) {
+            is Listing.Search -> currentListing.copy(query = null)
+            else -> currentListing
+        }
+        listingBeforeSearch = null
+        mutableState.update {
+            it.copy(
+                listing = restoredListing,
+                toolbarQuery = null,
             )
         }
     }
@@ -293,7 +319,44 @@ class KomgaLibraryScreenModel(
     }
 
     fun setToolbarQuery(query: String?) {
+        if (query != null && state.value.toolbarQuery == null) {
+            setSearchType(TYPE_ALL_INDEX)
+        }
         mutableState.update { it.copy(toolbarQuery = query) }
+    }
+
+    fun setSearchType(type: Int) {
+        if (type !in SEARCH_TYPES) return
+        val komgaSource = source as? KomgaSource ?: return
+        val currentState = state.value
+        if (currentState.searchType == type) return
+
+        val filters = komgaSource.buildFilterListForLibrary(
+            libraryId = currentState.selectedKomgaLibraryId,
+            allowedLibraryIds = currentAllowedLibraryIds(),
+            libraryScope = libraryScope,
+            currentFilters = currentState.filters,
+        )
+        filters.selectContentType(type)
+        komgaSource.saveSessionFilterState(filters, libraryScope)
+        komgaSource.savePersistentFilterState(filters, libraryScope)
+
+        val activeQuery = currentState.toolbarQuery
+            ?.takeIf { currentState.isUserQuery && it.isNotBlank() }
+        val listing = if (activeQuery != null) {
+            (currentState.listing as Listing.Search).copy(
+                query = activeQuery,
+                filters = filters,
+            )
+        } else {
+            currentState.listing
+        }
+        mutableState.update {
+            it.copy(
+                filters = filters,
+                listing = listing,
+            )
+        }
     }
 
     fun refresh() {
@@ -522,6 +585,16 @@ class KomgaLibraryScreenModel(
         val persistentFilteringEnabled: Boolean = false,
     ) {
         val isUserQuery get() = listing is Listing.Search && !listing.query.isNullOrEmpty()
+        val searchType get() = filters.filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_ALL_INDEX
+    }
+
+    private companion object {
+        val SEARCH_TYPES = setOf(
+            TYPE_SERIES_INDEX,
+            TYPE_READ_LISTS_INDEX,
+            TYPE_BOOKS_INDEX,
+            TYPE_ALL_INDEX,
+        )
     }
 }
 

--- a/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
+++ b/app/src/main/java/koharia/komga/ui/library/components/KomgaLibraryToolbar.kt
@@ -1,17 +1,24 @@
 package koharia.komga.ui.library.components
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ViewList
 import androidx.compose.material.icons.filled.ViewModule
+import androidx.compose.material.icons.outlined.ArrowDropDown
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
 import eu.kanade.presentation.components.AppBarTitle
@@ -19,6 +26,10 @@ import eu.kanade.presentation.components.DropdownMenu
 import eu.kanade.presentation.components.RadioMenuItem
 import eu.kanade.presentation.components.SearchToolbar
 import koharia.source.komga.KomgaServerProfile
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_BOOKS_INDEX
+import koharia.source.komga.TYPE_READ_LISTS_INDEX
+import koharia.source.komga.TYPE_SERIES_INDEX
 import kotlinx.collections.immutable.persistentListOf
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.i18n.MR
@@ -37,10 +48,14 @@ fun KomgaLibraryToolbar(
     onFilterClick: () -> Unit,
     navigateUp: (() -> Unit)?,
     onSearch: (String) -> Unit,
+    onClickCloseSearch: () -> Unit,
+    searchType: Int,
+    onSearchTypeSelect: (Int) -> Unit,
     scrollBehavior: TopAppBarScrollBehavior? = null,
 ) {
     var selectingDisplayMode by remember { mutableStateOf(false) }
     var selectingServer by remember { mutableStateOf(false) }
+    var selectingSearchType by remember { mutableStateOf(false) }
     val canSwitchServer = serverProfiles.size > 1
 
     SearchToolbar(
@@ -49,8 +64,43 @@ fun KomgaLibraryToolbar(
         searchQuery = searchQuery,
         onChangeSearchQuery = onSearchQueryChange,
         onSearch = onSearch,
-        onClickCloseSearch = { onSearchQueryChange(null) },
-        actions = {
+        onClickCloseSearch = onClickCloseSearch,
+        actions = actions@{
+            if (searchQuery != null) {
+                Box {
+                    TextButton(
+                        onClick = { selectingSearchType = true },
+                        contentPadding = PaddingValues(horizontal = 8.dp),
+                    ) {
+                        Text(
+                            text = searchTypeLabel(searchType),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Icon(
+                            imageVector = Icons.Outlined.ArrowDropDown,
+                            contentDescription = null,
+                        )
+                    }
+
+                    DropdownMenu(
+                        expanded = selectingSearchType,
+                        onDismissRequest = { selectingSearchType = false },
+                    ) {
+                        SEARCH_TYPES.forEach { type ->
+                            RadioMenuItem(
+                                text = { Text(text = searchTypeLabel(type)) },
+                                isChecked = searchType == type,
+                            ) {
+                                selectingSearchType = false
+                                onSearchTypeSelect(type)
+                            }
+                        }
+                    }
+                }
+                return@actions
+            }
+
             AppBarActions(
                 actions = persistentListOf<AppBar.AppBarAction>().builder()
                     .apply {
@@ -140,4 +190,21 @@ fun KomgaLibraryToolbar(
         },
         scrollBehavior = scrollBehavior,
     )
+}
+
+private val SEARCH_TYPES = listOf(
+    TYPE_ALL_INDEX,
+    TYPE_SERIES_INDEX,
+    TYPE_READ_LISTS_INDEX,
+    TYPE_BOOKS_INDEX,
+)
+
+@Composable
+private fun searchTypeLabel(type: Int): String {
+    return when (type) {
+        TYPE_SERIES_INDEX -> stringResource(MR.strings.komga_filter_series)
+        TYPE_READ_LISTS_INDEX -> stringResource(MR.strings.komga_filter_read_lists)
+        TYPE_BOOKS_INDEX -> stringResource(MR.strings.komga_filter_books)
+        else -> stringResource(MR.strings.all)
+    }
 }

--- a/app/src/main/java/koharia/source/komga/KomgaCacheControlInterceptor.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaCacheControlInterceptor.kt
@@ -13,7 +13,7 @@ class KomgaCacheControlInterceptor(
         val request = chain.request()
         val response = chain.proceed(request)
 
-        if (request.method != "GET" || !response.isSuccessful) {
+        if (!response.isSuccessful) {
             return response
         }
 
@@ -21,9 +21,13 @@ class KomgaCacheControlInterceptor(
             return response
         }
 
-        val cacheableResponse = response.newBuilder()
-            .header("Cache-Control", "public, max-age=$MAX_AGE_SECONDS")
-            .build()
+        val cacheableResponse = if (request.method == "GET") {
+            response.newBuilder()
+                .header("Cache-Control", "public, max-age=$MAX_AGE_SECONDS")
+                .build()
+        } else {
+            response
+        }
 
         return metadataCacheStore.save(request, cacheableResponse)
     }

--- a/app/src/main/java/koharia/source/komga/KomgaFilters.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaFilters.kt
@@ -13,7 +13,7 @@ class TypeSelect :
             KomgaSource.TYPE_BOOKS,
             KomgaSource.TYPE_ALL,
         ),
-        TYPE_ALL_INDEX,
+        TYPE_SERIES_INDEX,
     )
 
 class SeriesSort(selection: Selection? = null) :

--- a/app/src/main/java/koharia/source/komga/KomgaFilters.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaFilters.kt
@@ -11,7 +11,9 @@ class TypeSelect :
             KomgaSource.TYPE_SERIES,
             KomgaSource.TYPE_READ_LISTS,
             KomgaSource.TYPE_BOOKS,
+            KomgaSource.TYPE_ALL,
         ),
+        TYPE_ALL_INDEX,
     )
 
 class SeriesSort(selection: Selection? = null) :
@@ -74,3 +76,8 @@ data class CollectionFilterEntry(
     val name: String,
     val id: String? = null,
 )
+
+internal const val TYPE_SERIES_INDEX = 0
+internal const val TYPE_READ_LISTS_INDEX = 1
+internal const val TYPE_BOOKS_INDEX = 2
+internal const val TYPE_ALL_INDEX = 3

--- a/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
@@ -6,6 +6,7 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
 import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
 import java.io.File
 import java.security.MessageDigest
@@ -17,14 +18,19 @@ internal class KomgaMetadataCacheStore(
     private val cacheDir = LocalTempCacheDirectoryProvider.metadataCacheDir(context)
 
     fun isEligible(request: Request): Boolean {
-        if (request.method != "GET") return false
-        return isEligibleUrl(request.url.toString())
+        return when (request.method) {
+            "GET" -> isEligibleUrl(request.url.toString())
+            "POST" -> request.body?.contentType()?.subtype == "json" &&
+                SEARCH_LIST_PATHS.any { request.url.encodedPath.endsWith(it) }
+            else -> false
+        }
     }
 
     fun load(request: Request): Response? {
         if (!isEligible(request)) return null
 
-        val entry = readEntry(request.url.toString()) ?: return null
+        val identity = request.cacheIdentity() ?: return null
+        val entry = readEntry(identity) ?: return null
         return Response.Builder()
             .request(request)
             .protocol(okhttp3.Protocol.HTTP_1_1)
@@ -39,12 +45,13 @@ internal class KomgaMetadataCacheStore(
     fun save(request: Request, response: Response): Response {
         if (!isEligible(request) || !response.isSuccessful) return response
 
+        val identity = request.cacheIdentity() ?: return response
         val body = response.body
         val contentType = body.contentType()
         val bodyBytes = body.bytes()
 
         writeEntry(
-            url = request.url.toString(),
+            identity = identity,
             body = bodyBytes,
             contentType = contentType,
         )
@@ -54,14 +61,14 @@ internal class KomgaMetadataCacheStore(
             .build()
     }
 
-    private fun readEntry(url: String): CacheEntry? {
-        val bodyFile = bodyFile(url)
-        val metaFile = metaFile(url)
+    private fun readEntry(identity: String): CacheEntry? {
+        val bodyFile = bodyFile(identity)
+        val metaFile = metaFile(identity)
         if (!bodyFile.exists() || !metaFile.exists()) return null
 
         return runCatching {
             val metadata = metaFile.readLines()
-            if (metadata.size < 3 || metadata[0] != url) {
+            if (metadata.size < 3 || metadata[0] != identity) {
                 return null
             }
 
@@ -74,15 +81,15 @@ internal class KomgaMetadataCacheStore(
         }.getOrNull()
     }
 
-    private fun writeEntry(url: String, body: ByteArray, contentType: MediaType?) {
-        val bodyFile = bodyFile(url)
-        val metaFile = metaFile(url)
+    private fun writeEntry(identity: String, body: ByteArray, contentType: MediaType?) {
+        val bodyFile = bodyFile(identity)
+        val metaFile = metaFile(identity)
         val tmpBodyFile = File(bodyFile.parentFile, "${bodyFile.name}.tmp")
         val tmpMetaFile = File(metaFile.parentFile, "${metaFile.name}.tmp")
 
         runCatching {
             val metadata = buildString {
-                appendLine(url)
+                appendLine(identity)
                 appendLine(contentType?.toString().orEmpty())
                 appendLine(System.currentTimeMillis().toString())
             }
@@ -91,10 +98,10 @@ internal class KomgaMetadataCacheStore(
             tmpMetaFile.writeText(metadata)
 
             if (!tmpBodyFile.renameTo(bodyFile)) {
-                throw IllegalStateException("Failed to write metadata cache body for $url")
+                throw IllegalStateException("Failed to write metadata cache body for $identity")
             }
             if (!tmpMetaFile.renameTo(metaFile)) {
-                throw IllegalStateException("Failed to write metadata cache metadata for $url")
+                throw IllegalStateException("Failed to write metadata cache metadata for $identity")
             }
         }.onFailure {
             tmpBodyFile.delete()
@@ -102,9 +109,9 @@ internal class KomgaMetadataCacheStore(
         }
     }
 
-    private fun bodyFile(url: String): File = File(cacheDir, "${key(url)}.body")
+    private fun bodyFile(identity: String): File = File(cacheDir, "${key(identity)}.body")
 
-    private fun metaFile(url: String): File = File(cacheDir, "${key(url)}.meta")
+    private fun metaFile(identity: String): File = File(cacheDir, "${key(identity)}.meta")
 
     private fun key(url: String): String {
         return MessageDigest.getInstance("MD5")
@@ -136,5 +143,20 @@ internal class KomgaMetadataCacheStore(
         }
 
         private val PAGE_IMAGE_REGEX = Regex("/pages/\\d+(?:\\?.*)?$")
+        private val SEARCH_LIST_PATHS = setOf("/api/v1/books/list", "/api/v1/series/list")
     }
+}
+
+private fun Request.cacheIdentity(): String? {
+    if (method == "GET") return url.toString()
+    val bodyBytes = runCatching {
+        Buffer().use { buffer ->
+            body?.writeTo(buffer) ?: return null
+            buffer.readByteArray()
+        }
+    }.getOrNull() ?: return null
+    val bodyDigest = MessageDigest.getInstance("SHA-256")
+        .digest(bodyBytes)
+        .joinToString("") { "%02x".format(it) }
+    return "$method $url $bodyDigest"
 }

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -712,7 +712,7 @@ class KomgaSource(
 
         if (!hasPreservedState) {
             scopedFilters.resetFilterState()
-            scopedFilters.filterIsInstance<TypeSelect>().firstOrNull()?.state = TYPE_ALL_INDEX
+            scopedFilters.filterIsInstance<TypeSelect>().firstOrNull()?.state = TYPE_SERIES_INDEX
             scopedFilters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(0, true)
         }
         scopedFilters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.let { options ->
@@ -852,7 +852,7 @@ internal data class PersistentSortState(
 private fun defaultLibraryPersistentFilterState(): PersistentFilterState {
     return PersistentFilterState(
         version = CURRENT_PERSISTENT_FILTER_VERSION,
-        selects = mapOf("Search for" to TYPE_ALL_INDEX),
+        selects = mapOf("Search for" to TYPE_SERIES_INDEX),
         sorts = mapOf("Sort" to PersistentSortState(index = 0, ascending = true)),
     )
 }

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -376,7 +376,7 @@ class KomgaSource(
         val saved = (scopedState ?: legacyState)
             ?.let { runCatching { json.decodeFromString<PersistentFilterState>(it) }.getOrNull() }
             ?: return false
-        val migrated = saved.migrateSearchType()
+        val migrated = saved.migratePersistentFilterState()
         if (migrated != saved) {
             preferences.edit()
                 .putString(persistentFilterStateKey(libraryScope), json.encodeToString(migrated))
@@ -857,22 +857,9 @@ private fun defaultLibraryPersistentFilterState(): PersistentFilterState {
     )
 }
 
-internal fun PersistentFilterState.migrateSearchType(): PersistentFilterState {
+internal fun PersistentFilterState.migratePersistentFilterState(): PersistentFilterState {
     if (version >= CURRENT_PERSISTENT_FILTER_VERSION) return this
-    val selectedType = selects["Search for"]
-    return copy(
-        version = CURRENT_PERSISTENT_FILTER_VERSION,
-        selects = if (selectedType == TYPE_SERIES_INDEX) {
-            selects + ("Search for" to TYPE_ALL_INDEX)
-        } else {
-            selects
-        },
-        sorts = if (selectedType == TYPE_SERIES_INDEX) {
-            sorts + ("Sort" to PersistentSortState(index = 0, ascending = true))
-        } else {
-            sorts
-        },
-    )
+    return copy(version = CURRENT_PERSISTENT_FILTER_VERSION)
 }
 
 private enum class FetchFilterStatus {

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -20,6 +20,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.source.sourcePreferences
 import koharia.komga.api.KomgaApiClient
+import koharia.komga.api.KomgaSearchCapabilities
 import koharia.komga.api.dto.BookDto
 import koharia.komga.api.dto.LibraryDto
 import koharia.komga.domain.repository.KomgaRepository
@@ -86,8 +87,9 @@ class KomgaSource(
     private val chapterNameTemplate: String
         get() = preferences.getString(PREF_CHAPTER_NAME_TEMPLATE, PREF_CHAPTER_NAME_TEMPLATE_DEFAULT)!!
 
+    private val searchCapabilities = KomgaSearchCapabilities()
     private val apiClient: KomgaApiClient
-        get() = KomgaApiClient(baseUrl, currentHeaders(), client, json)
+        get() = KomgaApiClient(baseUrl, currentHeaders(), client, json, searchCapabilities)
 
     private val repository: KomgaRepository
         get() = KomgaRepository(baseUrl, apiClient)
@@ -149,6 +151,9 @@ class KomgaSource(
         repository.searchMangaRequest(page, query, filters, defaultLibraries, consumeBrowseCachePolicy())
 
     override fun searchMangaParse(response: Response) = repository.parseMangasPage(response)
+
+    override suspend fun getSearchManga(page: Int, query: String, filters: FilterList) =
+        repository.getSearchManga(page, query, filters, defaultLibraries, consumeBrowseCachePolicy())
 
     override fun getMangaUrl(manga: eu.kanade.tachiyomi.source.model.SManga): String = manga.url.replace("/api/v1", "")
 
@@ -371,11 +376,17 @@ class KomgaSource(
         val saved = (scopedState ?: legacyState)
             ?.let { runCatching { json.decodeFromString<PersistentFilterState>(it) }.getOrNull() }
             ?: return false
+        val migrated = saved.migrateSearchType()
+        if (migrated != saved) {
+            preferences.edit()
+                .putString(persistentFilterStateKey(libraryScope), json.encodeToString(migrated))
+                .apply()
+        }
 
         if (scopedState != null && libraryScope != KomgaLibraryScope.ALL) {
             filters.resetFilterState()
         }
-        filters.applyPersistentFilterState(saved)
+        filters.applyPersistentFilterState(migrated)
         return true
     }
 
@@ -651,6 +662,7 @@ class KomgaSource(
     ): SharedPreferences.OnSharedPreferenceChangeListener {
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key in SERVER_SETTING_KEYS) {
+                searchCapabilities.clear()
                 invalidateBrowseCache()
                 onChanged()
             }
@@ -700,8 +712,8 @@ class KomgaSource(
 
         if (!hasPreservedState) {
             scopedFilters.resetFilterState()
-            scopedFilters.filterIsInstance<TypeSelect>().firstOrNull()?.state = 0
-            scopedFilters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(1, true)
+            scopedFilters.filterIsInstance<TypeSelect>().firstOrNull()?.state = TYPE_ALL_INDEX
+            scopedFilters.filterIsInstance<SeriesSort>().firstOrNull()?.state = Filter.Sort.Selection(0, true)
         }
         scopedFilters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.let { options ->
             when {
@@ -795,6 +807,7 @@ class KomgaSource(
         const val TYPE_SERIES = "Series"
         const val TYPE_READ_LISTS = "Read lists"
         const val TYPE_BOOKS = "Books"
+        const val TYPE_ALL = "All"
         private const val BROWSE_REFRESH_WINDOW_MILLIS = 30_000L
 
         private val SERVER_SETTING_KEYS = setOf(
@@ -822,7 +835,8 @@ class KomgaSource(
 }
 
 @Serializable
-private data class PersistentFilterState(
+internal data class PersistentFilterState(
+    val version: Int = 0,
     val checkBoxes: Map<String, Boolean> = emptyMap(),
     val selects: Map<String, Int> = emptyMap(),
     val sorts: Map<String, PersistentSortState> = emptyMap(),
@@ -830,15 +844,34 @@ private data class PersistentFilterState(
 )
 
 @Serializable
-private data class PersistentSortState(
+internal data class PersistentSortState(
     val index: Int,
     val ascending: Boolean,
 )
 
 private fun defaultLibraryPersistentFilterState(): PersistentFilterState {
     return PersistentFilterState(
-        selects = mapOf("Search for" to 0),
-        sorts = mapOf("Sort" to PersistentSortState(index = 1, ascending = true)),
+        version = CURRENT_PERSISTENT_FILTER_VERSION,
+        selects = mapOf("Search for" to TYPE_ALL_INDEX),
+        sorts = mapOf("Sort" to PersistentSortState(index = 0, ascending = true)),
+    )
+}
+
+internal fun PersistentFilterState.migrateSearchType(): PersistentFilterState {
+    if (version >= CURRENT_PERSISTENT_FILTER_VERSION) return this
+    val selectedType = selects["Search for"]
+    return copy(
+        version = CURRENT_PERSISTENT_FILTER_VERSION,
+        selects = if (selectedType == TYPE_SERIES_INDEX) {
+            selects + ("Search for" to TYPE_ALL_INDEX)
+        } else {
+            selects
+        },
+        sorts = if (selectedType == TYPE_SERIES_INDEX) {
+            sorts + ("Sort" to PersistentSortState(index = 0, ascending = true))
+        } else {
+            sorts
+        },
     )
 }
 
@@ -945,6 +978,7 @@ private fun FilterList.toPersistentFilterState(): PersistentFilterState {
     }
 
     return PersistentFilterState(
+        version = CURRENT_PERSISTENT_FILTER_VERSION,
         checkBoxes = checkBoxes,
         selects = selects,
         sorts = sorts,
@@ -993,6 +1027,7 @@ private const val PREF_PERSISTENT_FILTERS_ENABLED_BOOK = "Persistent filters ena
 private const val PREF_PERSISTENT_FILTERS_STATE = "Persistent filters state"
 private const val PREF_PERSISTENT_FILTERS_STATE_COMIC = "Persistent filters state comic"
 private const val PREF_PERSISTENT_FILTERS_STATE_BOOK = "Persistent filters state book"
+private const val CURRENT_PERSISTENT_FILTER_VERSION = 1
 
 private fun PreferenceScreen.addEditTextPreference(
     title: String,

--- a/app/src/test/java/koharia/komga/api/KomgaApiSearchTest.kt
+++ b/app/src/test/java/koharia/komga/api/KomgaApiSearchTest.kt
@@ -1,0 +1,161 @@
+package koharia.komga.api
+
+import eu.kanade.tachiyomi.network.HttpException
+import koharia.source.komga.KomgaCachePolicy
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaApiSearchTest {
+
+    @Test
+    fun `book list request uses current endpoint and structured conditions`() {
+        val api = apiClient(OkHttpClient())
+
+        val request = api.searchListRequest(
+            page = 2,
+            query = "Book title",
+            type = KomgaApiClient.SearchType.BOOKS,
+            defaultLibraries = setOf("default-library"),
+            selectedLibraries = setOf("selected-library"),
+            sortIndex = 1,
+            sortAscending = false,
+            readStatuses = setOf("UNREAD"),
+            tags = setOf("tag"),
+            authors = listOf("Author" to "writer"),
+            oneshot = true,
+            cachePolicy = KomgaCachePolicy.Default,
+        )
+
+        assertEquals("POST", request.method)
+        assertEquals("/api/v1/books/list", request.url.encodedPath)
+        assertEquals("1", request.url.queryParameter("page"))
+        assertEquals("metadata.title,desc", request.url.queryParameter("sort"))
+
+        val body = Buffer().also { request.body!!.writeTo(it) }.readUtf8()
+        val json = Json.parseToJsonElement(body).jsonObject
+        assertEquals("Book title", json.getValue("fullTextSearch").jsonPrimitive.content)
+        val conditions = json.getValue("condition").jsonObject.getValue("allOf").jsonArray
+        assertTrue(conditions.any { "deleted" in it.jsonObject })
+        assertTrue(conditions.hasAnyOfField("libraryId"))
+        assertTrue(conditions.hasAnyOfField("readStatus"))
+        assertTrue(conditions.hasAnyOfField("tag"))
+        assertTrue(conditions.hasAnyOfField("author"))
+        assertTrue(conditions.any { "oneShot" in it.jsonObject })
+    }
+
+    @Test
+    fun `404 response falls back once and caches legacy capability`() = runTest {
+        val methods = mutableListOf<String>()
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                methods += chain.request().method
+                response(chain.request(), if (chain.request().method == "POST") 404 else 200)
+            }
+            .build()
+        val api = apiClient(client)
+        val modern = request("POST")
+        val legacy = request("GET")
+
+        api.executeSearch(KomgaApiClient.SearchType.BOOKS, modern, legacy, true).close()
+        api.executeSearch(KomgaApiClient.SearchType.BOOKS, modern, legacy, true).close()
+
+        assertEquals(listOf("POST", "GET", "GET"), methods)
+    }
+
+    @Test
+    fun `server errors do not fall back`() {
+        val methods = mutableListOf<String>()
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                methods += chain.request().method
+                response(chain.request(), 500)
+            }
+            .build()
+        val api = apiClient(client)
+
+        assertThrows(HttpException::class.java) {
+            runTest {
+                api.executeSearch(
+                    KomgaApiClient.SearchType.SERIES,
+                    request("POST"),
+                    request("GET"),
+                    true,
+                )
+            }
+        }
+        assertEquals(listOf("POST"), methods)
+    }
+
+    @Test
+    fun `legacy book search rejects unsupported structured filters`() {
+        val methods = mutableListOf<String>()
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                methods += chain.request().method
+                response(chain.request(), 404)
+            }
+            .build()
+        val api = apiClient(client)
+
+        assertThrows(IllegalStateException::class.java) {
+            runTest {
+                api.executeSearch(
+                    KomgaApiClient.SearchType.BOOKS,
+                    request("POST"),
+                    request("GET"),
+                    false,
+                )
+            }
+        }
+        assertEquals(listOf("POST"), methods)
+    }
+
+    private fun apiClient(client: OkHttpClient): KomgaApiClient = KomgaApiClient(
+        baseUrl = "https://komga.test",
+        headers = Headers.Builder().build(),
+        client = client,
+        json = Json,
+        searchCapabilities = KomgaSearchCapabilities(),
+    )
+
+    private fun request(method: String): Request {
+        val builder = Request.Builder().url("https://komga.test/search")
+        return if (method == "POST") {
+            builder.post("{}".toRequestBody("application/json".toMediaType())).build()
+        } else {
+            builder.get().build()
+        }
+    }
+
+    private fun response(request: Request, code: Int): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(code)
+        .message(code.toString())
+        .body("{}".toResponseBody("application/json".toMediaType()))
+        .build()
+
+    private fun kotlinx.serialization.json.JsonArray.hasAnyOfField(field: String): Boolean {
+        return any { condition ->
+            condition.jsonObject["anyOf"]
+                ?.jsonArray
+                ?.any { field in it.jsonObject } == true
+        }
+    }
+}

--- a/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
+++ b/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
@@ -1,0 +1,64 @@
+package koharia.komga.domain.repository
+
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.SManga
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaSearchTest {
+
+    @Test
+    fun `search query removes delimiters but keeps their content`() {
+        assertEquals("Title Edition Extra Full", normalizeSearchQuery(" Title(Edition)【Extra】（Full） "))
+        assertEquals("Title Edition", normalizeSearchQuery("Title( Edition"))
+        assertEquals("Title Edition", normalizeSearchQuery("Title   Edition"))
+    }
+
+    @Test
+    fun `search query made only of delimiters becomes blank`() {
+        assertEquals("", normalizeSearchQuery("（【()】）"))
+    }
+
+    @Test
+    fun `search query without delimiters remains unchanged`() {
+        assertEquals("A normal title", normalizeSearchQuery("A normal title"))
+    }
+
+    @Test
+    fun `combined pages interleave books first and retain remaining items`() {
+        val books = MangasPage(
+            listOf(manga("book-1"), manga("book-2"), manga("book-3")),
+            hasNextPage = false,
+        )
+        val series = MangasPage(
+            listOf(manga("series-1"), manga("series-2")),
+            hasNextPage = true,
+        )
+
+        val merged = mergeSearchPages(books, series)
+
+        assertEquals(
+            listOf("book-1", "series-1", "book-2", "series-2", "book-3"),
+            merged.mangas.map { it.title },
+        )
+        assertTrue(merged.hasNextPage)
+    }
+
+    @Test
+    fun `combined pages stop when both sources stop`() {
+        val merged = mergeSearchPages(
+            MangasPage(emptyList(), false),
+            MangasPage(listOf(manga("series")), false),
+        )
+
+        assertEquals(listOf("series"), merged.mangas.map { it.title })
+        assertFalse(merged.hasNextPage)
+    }
+
+    private fun manga(title: String) = SManga.create().apply {
+        this.title = title
+        url = "/$title"
+    }
+}

--- a/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
+++ b/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
@@ -1,7 +1,14 @@
 package koharia.komga.domain.repository
 
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
+import koharia.komga.api.KomgaApiClient
+import koharia.komga.api.KomgaSearchCapabilities
+import koharia.source.komga.TypeSelect
+import kotlinx.serialization.json.Json
+import okhttp3.Headers
+import okhttp3.OkHttpClient
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -24,6 +31,28 @@ class KomgaSearchTest {
     @Test
     fun `search query without delimiters remains unchanged`() {
         assertEquals("A normal title", normalizeSearchQuery("A normal title"))
+    }
+
+    @Test
+    fun `advanced lucene queries keep grouping delimiters`() {
+        assertEquals("writer:(sean murphy)", normalizeSearchQuery(" writer:(sean murphy) "))
+        assertEquals("(batman OR robin)", normalizeSearchQuery("(batman OR robin)"))
+    }
+
+    @Test
+    fun `legacy request path maps all search to series`() {
+        val apiClient = KomgaApiClient(
+            baseUrl = "https://komga.test",
+            headers = Headers.Builder().build(),
+            client = OkHttpClient(),
+            json = Json,
+            searchCapabilities = KomgaSearchCapabilities(),
+        )
+        val repository = KomgaRepository("https://komga.test", apiClient)
+
+        val request = repository.searchMangaRequest(1, "title", FilterList(TypeSelect()), emptySet())
+
+        assertEquals("/api/v1/series", request.url.encodedPath)
     }
 
     @Test

--- a/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
+++ b/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
@@ -18,14 +18,15 @@ class KomgaSearchTest {
 
     @Test
     fun `search query removes delimiters but keeps their content`() {
-        assertEquals("Title Edition Extra Full", normalizeSearchQuery(" Title(Edition)【Extra】（Full） "))
+        assertEquals("Title Edition Extra Full English", normalizeSearchQuery(" Title(Edition)【Extra】（Full）[English] "))
         assertEquals("Title Edition", normalizeSearchQuery("Title( Edition"))
+        assertEquals("Title Scan", normalizeSearchQuery("Title[Scan"))
         assertEquals("Title Edition", normalizeSearchQuery("Title   Edition"))
     }
 
     @Test
     fun `search query made only of delimiters becomes blank`() {
-        assertEquals("", normalizeSearchQuery("（【()】）"))
+        assertEquals("", normalizeSearchQuery("（【([])】）"))
     }
 
     @Test
@@ -37,6 +38,7 @@ class KomgaSearchTest {
     fun `advanced lucene queries keep grouping delimiters`() {
         assertEquals("writer:(sean murphy)", normalizeSearchQuery(" writer:(sean murphy) "))
         assertEquals("(batman OR robin)", normalizeSearchQuery("(batman OR robin)"))
+        assertEquals("release_date:[2020 TO 2024]", normalizeSearchQuery("release_date:[2020 TO 2024]"))
     }
 
     @Test

--- a/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
+++ b/app/src/test/java/koharia/komga/domain/repository/KomgaSearchTest.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SManga
 import koharia.komga.api.KomgaApiClient
 import koharia.komga.api.KomgaSearchCapabilities
+import koharia.source.komga.TYPE_ALL_INDEX
 import koharia.source.komga.TypeSelect
 import kotlinx.serialization.json.Json
 import okhttp3.Headers
@@ -52,7 +53,8 @@ class KomgaSearchTest {
         )
         val repository = KomgaRepository("https://komga.test", apiClient)
 
-        val request = repository.searchMangaRequest(1, "title", FilterList(TypeSelect()), emptySet())
+        val filters = FilterList(TypeSelect().apply { state = TYPE_ALL_INDEX })
+        val request = repository.searchMangaRequest(1, "title", filters, emptySet())
 
         assertEquals("/api/v1/series", request.url.encodedPath)
     }

--- a/app/src/test/java/koharia/komga/ui/library/KomgaSearchTypeTest.kt
+++ b/app/src/test/java/koharia/komga/ui/library/KomgaSearchTypeTest.kt
@@ -6,6 +6,7 @@ import koharia.source.komga.CollectionFilterEntry
 import koharia.source.komga.CollectionSelect
 import koharia.source.komga.SeriesSort
 import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_SERIES_INDEX
 import koharia.source.komga.TypeSelect
 import koharia.source.komga.UriMultiSelectFilter
 import koharia.source.komga.UriMultiSelectOption
@@ -17,8 +18,17 @@ import org.junit.jupiter.api.Test
 class KomgaSearchTypeTest {
 
     @Test
-    fun `search type defaults to all`() {
-        assertEquals(TYPE_ALL_INDEX, TypeSelect().state)
+    fun `browse type defaults to series`() {
+        assertEquals(TYPE_SERIES_INDEX, TypeSelect().state)
+    }
+
+    @Test
+    fun `toolbar search scope defaults to all independently`() {
+        val state = KomgaLibraryScreenModel.State(
+            listing = KomgaLibraryScreenModel.Listing.Search(query = null, filters = FilterList()),
+        )
+
+        assertEquals(TYPE_ALL_INDEX, state.searchType)
     }
 
     @Test

--- a/app/src/test/java/koharia/komga/ui/library/KomgaSearchTypeTest.kt
+++ b/app/src/test/java/koharia/komga/ui/library/KomgaSearchTypeTest.kt
@@ -1,0 +1,52 @@
+package koharia.komga.ui.library
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import koharia.source.komga.CollectionFilterEntry
+import koharia.source.komga.CollectionSelect
+import koharia.source.komga.SeriesSort
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TypeSelect
+import koharia.source.komga.UriMultiSelectFilter
+import koharia.source.komga.UriMultiSelectOption
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaSearchTypeTest {
+
+    @Test
+    fun `search type defaults to all`() {
+        assertEquals(TYPE_ALL_INDEX, TypeSelect().state)
+    }
+
+    @Test
+    fun `selecting all clears unsupported series filters`() {
+        val type = TypeSelect().apply { state = 0 }
+        val collection = CollectionSelect(
+            listOf(
+                CollectionFilterEntry("None"),
+                CollectionFilterEntry("Collection", "collection-id"),
+            ),
+        ).apply { state = 1 }
+        val genre = UriMultiSelectOption("Action").apply { state = true }
+        val tag = UriMultiSelectOption("Favorite").apply { state = true }
+        val sort = SeriesSort(Filter.Sort.Selection(2, false))
+        val filters = FilterList(
+            type,
+            collection,
+            UriMultiSelectFilter("Genres", listOf(genre)),
+            UriMultiSelectFilter("Tags", listOf(tag)),
+            sort,
+        )
+
+        filters.selectContentType(TYPE_ALL_INDEX)
+
+        assertEquals(TYPE_ALL_INDEX, type.state)
+        assertEquals(0, collection.state)
+        assertFalse(genre.state)
+        assertTrue(tag.state)
+        assertEquals(Filter.Sort.Selection(0, true), sort.state)
+    }
+}

--- a/app/src/test/java/koharia/source/komga/KomgaFilterStateTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaFilterStateTest.kt
@@ -1,22 +1,24 @@
 package koharia.source.komga
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class KomgaFilterStateTest {
 
     @Test
-    fun `legacy default series selection migrates to all once`() {
+    fun `legacy series selection and sort remain unchanged after version migration`() {
         val legacy = PersistentFilterState(
             selects = mapOf("Search for" to TYPE_SERIES_INDEX),
             sorts = mapOf("Sort" to PersistentSortState(index = 1, ascending = true)),
         )
 
-        val migrated = legacy.migrateSearchType()
+        val migrated = legacy.migratePersistentFilterState()
 
-        assertEquals(TYPE_ALL_INDEX, migrated.selects["Search for"])
-        assertEquals(0, migrated.sorts["Sort"]?.index)
-        assertEquals(migrated, migrated.migrateSearchType())
+        assertEquals(TYPE_SERIES_INDEX, migrated.selects["Search for"])
+        assertEquals(PersistentSortState(index = 1, ascending = true), migrated.sorts["Sort"])
+        assertTrue(migrated.version > legacy.version)
+        assertEquals(migrated, migrated.migratePersistentFilterState())
     }
 
     @Test
@@ -26,7 +28,7 @@ class KomgaFilterStateTest {
             sorts = mapOf("Sort" to PersistentSortState(index = 2, ascending = false)),
         )
 
-        val migrated = legacy.migrateSearchType()
+        val migrated = legacy.migratePersistentFilterState()
 
         assertEquals(TYPE_BOOKS_INDEX, migrated.selects["Search for"])
         assertEquals(PersistentSortState(index = 2, ascending = false), migrated.sorts["Sort"])

--- a/app/src/test/java/koharia/source/komga/KomgaFilterStateTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaFilterStateTest.kt
@@ -1,0 +1,34 @@
+package koharia.source.komga
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KomgaFilterStateTest {
+
+    @Test
+    fun `legacy default series selection migrates to all once`() {
+        val legacy = PersistentFilterState(
+            selects = mapOf("Search for" to TYPE_SERIES_INDEX),
+            sorts = mapOf("Sort" to PersistentSortState(index = 1, ascending = true)),
+        )
+
+        val migrated = legacy.migrateSearchType()
+
+        assertEquals(TYPE_ALL_INDEX, migrated.selects["Search for"])
+        assertEquals(0, migrated.sorts["Sort"]?.index)
+        assertEquals(migrated, migrated.migrateSearchType())
+    }
+
+    @Test
+    fun `legacy explicit book selection remains unchanged`() {
+        val legacy = PersistentFilterState(
+            selects = mapOf("Search for" to TYPE_BOOKS_INDEX),
+            sorts = mapOf("Sort" to PersistentSortState(index = 2, ascending = false)),
+        )
+
+        val migrated = legacy.migrateSearchType()
+
+        assertEquals(TYPE_BOOKS_INDEX, migrated.selects["Search for"])
+        assertEquals(PersistentSortState(index = 2, ascending = false), migrated.sorts["Sort"])
+    }
+}

--- a/app/src/test/java/koharia/source/komga/KomgaMetadataCacheStoreTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaMetadataCacheStoreTest.kt
@@ -1,0 +1,67 @@
+package koharia.source.komga
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class KomgaMetadataCacheStoreTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `search list posts are cached by url and request body`() {
+        val store = KomgaMetadataCacheStore(context())
+        val first = searchRequest("{\"fullTextSearch\":\"first\"}")
+        val second = searchRequest("{\"fullTextSearch\":\"second\"}")
+
+        store.save(first, response(first, "first result")).close()
+
+        assertEquals("first result", store.load(first)?.body?.string())
+        assertNull(store.load(second))
+    }
+
+    @Test
+    fun `only supported json search posts are eligible`() {
+        val store = KomgaMetadataCacheStore(context())
+        val supported = searchRequest("{}")
+        val unrelated = supported.newBuilder().url("https://komga.test/api/v1/books/an-id").build()
+        val nonJson = supported.newBuilder().post("query".toRequestBody("text/plain".toMediaType())).build()
+
+        assertTrue(store.isEligible(supported))
+        assertFalse(store.isEligible(unrelated))
+        assertFalse(store.isEligible(nonJson))
+    }
+
+    private fun context(): Context = mockk {
+        every { getExternalFilesDir(any()) } returns File(tempDir, "external")
+        every { cacheDir } returns File(tempDir, "legacy")
+        every { filesDir } returns File(tempDir, "files")
+    }
+
+    private fun searchRequest(body: String): Request = Request.Builder()
+        .url("https://komga.test/api/v1/books/list?page=0")
+        .post(body.toRequestBody("application/json".toMediaType()))
+        .build()
+
+    private fun response(request: Request, body: String): Response = Response.Builder()
+        .request(request)
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(body.toResponseBody("application/json".toMediaType()))
+        .build()
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -800,6 +800,7 @@
     <!-- missing prompt after Compose rewrite #7901 -->
     <string name="no_more_results">No more results</string>
     <string name="no_results_found">No results found</string>
+    <string name="search_results">Search results</string>
     <string name="local_source">Local source</string>
     <string name="other_source">Other</string>
     <string name="last_used_source">Last used</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -367,6 +367,7 @@
     <string name="filter_mode_lighten">变亮</string>
     <string name="filter_mode_darken">变暗</string>
     <string name="no_results_found">没有结果</string>
+    <string name="search_results">搜索结果</string>
     <string name="migration_selection_prompt">选择需要迁移的图源</string>
     <string name="action_webview_back">后退</string>
     <string name="action_webview_forward">前进</string>


### PR DESCRIPTION
## 概要 / Summary

- 默认将搜索范围设为“全部”，并合并书籍与系列结果，使用户可以直接按漫画或书籍标题搜索。
- Default search scope is now “All”, combining book and series results so titles can be searched directly.
- 在搜索栏中增加范围下拉选项，并在搜索状态下隐藏无关工具栏按钮。
- Added a search-scope dropdown and hide unrelated toolbar actions while searching.
- 增加返回箭头退出搜索及“搜索结果”状态标签。
- Added back-arrow search exit behavior and a dedicated “Search results” label.

## 实现 / Implementation

- 使用 Komga 1.19+ 的 `POST /api/v1/books/list` 与 `POST /api/v1/series/list`，仅在 404/405 时回退旧 GET 接口，并缓存接口能力。
- Uses Komga 1.19+ `POST /api/v1/books/list` and `POST /api/v1/series/list`, falling back to legacy GET endpoints only for 404/405 responses and caching endpoint capability.
- 将书籍与系列结果按书籍优先 1:1 交错，并保留各自分页状态。
- Interleaves book and series results 1:1 with books first while preserving independent pagination state.
- 清洗半角/全角圆括号和方头括号，保留括号内文字，避免 Lucene 查询解析失败。
- Normalizes half-width/full-width parentheses and square brackets while preserving enclosed text to avoid Lucene query parsing failures.
- 支持作者、标签、阅读状态、书库及单行本等公共筛选，并处理旧筛选状态迁移。
- Supports shared filters such as authors, tags, reading state, libraries, and one-shots, including legacy filter-state migration.

## 原因与影响 / Motivation and impact

原实现只搜索系列名称，因此按作者目录组织、系列名与作品名不同的资源无法通过漫画标题找到；Komga 对未配对括号及部分括号字符也较敏感，容易导致整次搜索失败。

The previous implementation searched series names only, so title searches failed for libraries organized by author or where series and book titles differ. Komga is also sensitive to unmatched or specific bracket characters, which could invalidate the whole query.

本改动扩大了默认搜索覆盖面、提高了特殊字符容错，并提供更直观的范围选择与退出搜索交互。

This change broadens default search coverage, improves resilience to special characters, and provides clearer scope selection and search-exit interactions.

## 验证 / Validation

- `.\gradlew.bat spotlessApply`
- `.\gradlew.bat spotlessCheck`
- `.\gradlew.bat :app:compileDebugKotlin`
- 13 项 Komga 搜索相关单元测试通过 / 13 Komga search-related unit tests passed
- `git diff --check`
