### PR TITLE
修复 EPUB 图片反色与翻页闪烁 / Fix EPUB image inversion and page-turn flicker

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -160,7 +160,7 @@ object SettingsReaderScreen : SearchableSettings {
             getEpubTypographyGroup(readerPreferences, epubLayoutPreferences),
             getEpubNavigationGroup(readerPreferences, epubLayoutPreferences),
             getEpubDisplayGroup(readerPreferences),
-            getEpubFilterGroup(readerPreferences),
+            getEpubFilterGroup(readerPreferences, epubLayoutPreferences),
         )
     }
 
@@ -431,7 +431,10 @@ object SettingsReaderScreen : SearchableSettings {
     }
 
     @Composable
-    private fun getEpubFilterGroup(readerPreferences: ReaderPreferences): Preference.PreferenceGroup {
+    private fun getEpubFilterGroup(
+        readerPreferences: ReaderPreferences,
+        epubLayoutPreferences: EpubLayoutPreferences,
+    ): Preference.PreferenceGroup {
         val colorFilterEnabled by readerPreferences.colorFilter.collectAsState()
         val colorValue by readerPreferences.colorFilterValue.collectAsState()
         return Preference.PreferenceGroup(
@@ -485,6 +488,11 @@ object SettingsReaderScreen : SearchableSettings {
                 Preference.PreferenceItem.SwitchPreference(
                     preference = readerPreferences.invertedColors,
                     title = stringResource(MR.strings.pref_inverted_colors),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = epubLayoutPreferences.preserveImageColors,
+                    title = stringResource(MR.strings.pref_epub_preserve_image_colors),
+                    subtitle = stringResource(MR.strings.pref_epub_preserve_image_colors_summary),
                 ),
             ),
         )

--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -197,6 +197,7 @@ internal fun buildEpubContinuousScrollInstallScript(
                     }
                     try { iframe.contentWindow.eval(paragraphIndentScript); } catch (_) {}
                     installImageInteractions(iframe.contentWindow, index);
+                    iframe.style.visibility = 'visible';
                     const height = Math.max(
                         doc.documentElement.scrollHeight || 0,
                         doc.body ? doc.body.scrollHeight || 0 : 0,
@@ -218,6 +219,7 @@ internal fun buildEpubContinuousScrollInstallScript(
                 iframe.setAttribute('frameborder', '0');
                 iframe.setAttribute('title', resources[index].href || '');
                 iframe.style.height = (measuredHeights.get(index) || viewportHeight) + 'px';
+                iframe.style.visibility = 'hidden';
                 iframe.addEventListener('load', function() {
                     failedResources.delete(index);
                     measureFrame(index, iframe);

--- a/app/src/main/java/koharia/epub/EpubImageInteraction.kt
+++ b/app/src/main/java/koharia/epub/EpubImageInteraction.kt
@@ -1,14 +1,59 @@
 package koharia.epub
 
+internal fun buildEpubImageColorPolicyScript(
+    preserveImageColors: Boolean,
+    parentColorsInverted: Boolean,
+): String =
+    """
+    (function() {
+        const preserveImageColors = $preserveImageColors;
+        const parentColorsInverted = $parentColorsInverted;
+        const styleId = '$IMAGE_COLOR_POLICY_STYLE_ID';
+        let style = document.getElementById(styleId);
+        if (!preserveImageColors) {
+            if (style) style.remove();
+            return 'removed';
+        }
+        if (!style) {
+            style = document.createElement('style');
+            style.id = styleId;
+            (document.head || document.documentElement).appendChild(style);
+        }
+        style.textContent = parentColorsInverted
+            ? `
+                :root img,
+                :root svg {
+                    -webkit-filter: invert(100%) !important;
+                    filter: invert(100%) !important;
+                }
+            `
+            : `
+                :root[style*="readium-night-on"] [epub\\:type~="titlepage"] img:only-child,
+                :root[style*="readium-night-on"] [type~="titlepage"] img:only-child,
+                :root[style*="readium-night-on"] img[class*="gaiji"],
+                :root[style*="readium-night-on"][style*="readium-darken-on"] img,
+                :root[style*="readium-night-on"][style*="readium-invert-on"] img {
+                    -webkit-filter: none !important;
+                    filter: none !important;
+                }
+            `;
+        return 'applied';
+    })()
+    """.trimIndent()
+
 internal fun buildEpubImageInteractionInstallScript(
     longPressTimeoutMs: Int,
     touchSlopCssPx: Float,
+    preserveImageColors: Boolean,
+    parentColorsInverted: Boolean,
 ): String =
     """
     (function() {
         const resourceIndex = Number.isInteger(window.__kohariaImageResourceIndex)
             ? window.__kohariaImageResourceIndex
             : -1;
+        ${buildEpubImageColorPolicyScript(preserveImageColors, parentColorsInverted)};
+
         const existing = window.__kohariaImageInteractions;
         if (existing) {
             existing.resourceIndex = resourceIndex;
@@ -148,3 +193,4 @@ internal fun buildEpubImageInteractionInstallScript(
 internal const val EPUB_IMAGE_BRIDGE_NAME = "KohariaEpubImage"
 private const val SVG_NAMESPACE = "http://www.w3.org/2000/svg"
 private const val XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+private const val IMAGE_COLOR_POLICY_STYLE_ID = "koharia-epub-image-color-policy"

--- a/app/src/main/java/koharia/epub/EpubImageInteraction.kt
+++ b/app/src/main/java/koharia/epub/EpubImageInteraction.kt
@@ -9,24 +9,47 @@ internal fun buildEpubImageColorPolicyScript(
         const preserveImageColors = $preserveImageColors;
         const parentColorsInverted = $parentColorsInverted;
         const styleId = '$IMAGE_COLOR_POLICY_STYLE_ID';
+        const root = document.documentElement;
+        const styleNamespace = root && root.namespaceURI === '$SVG_NAMESPACE'
+            ? '$SVG_NAMESPACE'
+            : '$XHTML_NAMESPACE';
         let style = document.getElementById(styleId);
         if (!preserveImageColors) {
             if (style) style.remove();
             return 'removed';
         }
+        if (style && style.namespaceURI !== styleNamespace) {
+            style.remove();
+            style = null;
+        }
         if (!style) {
-            style = document.createElement('style');
+            style = document.createElementNS(styleNamespace, 'style');
             style.id = styleId;
+            style.setAttribute('type', 'text/css');
             (document.head || document.documentElement).appendChild(style);
         }
+        const rootIsSvg = document.documentElement &&
+            document.documentElement.namespaceURI === '$SVG_NAMESPACE' &&
+            document.documentElement.localName.toLowerCase() === 'svg';
         style.textContent = parentColorsInverted
-            ? `
+            ? rootIsSvg
+                ? `
+                :root {
+                    -webkit-filter: invert(100%) !important;
+                    filter: invert(100%) !important;
+                }
+                `
+                : `
                 :root img,
                 :root svg {
                     -webkit-filter: invert(100%) !important;
                     filter: invert(100%) !important;
                 }
-            `
+                :root svg svg {
+                    -webkit-filter: none !important;
+                    filter: none !important;
+                }
+                `
             : `
                 :root[style*="readium-night-on"] [epub\\:type~="titlepage"] img:only-child,
                 :root[style*="readium-night-on"] [type~="titlepage"] img:only-child,
@@ -192,5 +215,6 @@ internal fun buildEpubImageInteractionInstallScript(
 
 internal const val EPUB_IMAGE_BRIDGE_NAME = "KohariaEpubImage"
 private const val SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+private const val XHTML_NAMESPACE = "http://www.w3.org/1999/xhtml"
 private const val XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
 private const val IMAGE_COLOR_POLICY_STYLE_ID = "koharia-epub-image-color-policy"

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -300,6 +300,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             val grayscale by readerPreferences.grayscale.changes().collectAsState(readerPreferences.grayscale.get())
             val invertedColors by readerPreferences.invertedColors.changes()
                 .collectAsState(readerPreferences.invertedColors.get())
+            val preserveImageColors by epubLayoutPreferences.preserveImageColors.changes()
+                .collectAsState(epubLayoutPreferences.preserveImageColors.get())
             val currentReaderBackgroundColor = remember(
                 currentTheme,
                 currentCustomBackgroundColor,
@@ -563,6 +565,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                                     drawUnderCutout = drawUnderCutout,
                                     grayscale = grayscale,
                                     invertedColors = invertedColors,
+                                    preserveImageColors = preserveImageColors,
                                     theme = currentTheme,
                                     customBackgroundColor = currentCustomBackgroundColor,
                                     verticalMargins = currentVerticalMargins,
@@ -1306,6 +1309,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         drawUnderCutout: Boolean,
         grayscale: Boolean,
         invertedColors: Boolean,
+        preserveImageColors: Boolean,
         theme: EpubLayoutPreferences.Theme,
         customBackgroundColor: Int,
         verticalMargins: Float,
@@ -1319,6 +1323,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 arguments = arguments,
                 onUpdate = { fragment ->
                     readerFragment = fragment
+                    fragment.updateImageColorPolicy(
+                        preserveImageColors = preserveImageColors,
+                        parentColorsInverted = invertedColors,
+                    )
                     fragment.view?.let { view ->
                         view.setBackgroundColor(theme.readerBackgroundColor(customBackgroundColor))
                         view.setLayerType(View.LAYER_TYPE_HARDWARE, readerColorFilterPaint(grayscale, invertedColors))
@@ -1337,10 +1345,15 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 drawUnderCutout,
                 grayscale,
                 invertedColors,
+                preserveImageColors,
                 theme,
                 customBackgroundColor,
                 verticalMargins,
             ) {
+                readerFragment?.updateImageColorPolicy(
+                    preserveImageColors = preserveImageColors,
+                    parentColorsInverted = invertedColors,
+                )
                 // AndroidFragment.onUpdate is only invoked when the Fragment is created. Re-apply
                 // layout-affecting reader settings when Compose preferences change in the same session.
                 readerFragment?.view?.let { view ->

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -3,6 +3,7 @@ package koharia.epub
 import android.content.Context
 import android.graphics.Rect
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.HapticFeedbackConstants
 import android.view.View
 import android.view.ViewConfiguration
@@ -105,6 +106,7 @@ class EpubReaderFragment : Fragment() {
     private var imageColorPolicyPreDrawListener: ViewTreeObserver.OnPreDrawListener? = null
     private val installedImageColorPolicies = WeakHashMap<WebView, String>()
     private val pendingImageColorPolicies = WeakHashMap<WebView, String>()
+    private val imageColorPolicyDrawWaits = WeakHashMap<WebView, ImageColorPolicyDrawWait>()
     private var continuousScrollInstalledHref: String? = null
     private var continuousScrollLocator: Locator? = null
 
@@ -389,6 +391,7 @@ class EpubReaderFragment : Fragment() {
         imageColorPolicyGeneration++
         installedImageColorPolicies.clear()
         pendingImageColorPolicies.clear()
+        imageColorPolicyDrawWaits.clear()
         imageColorPolicyRoot?.postInvalidateOnAnimation()
         val navigator = readyNavigatorFragment()
         scheduleImageInteractionsInstall(navigator)
@@ -504,6 +507,7 @@ class EpubReaderFragment : Fragment() {
         imageColorPolicyPreDrawListener = null
         installedImageColorPolicies.clear()
         pendingImageColorPolicies.clear()
+        imageColorPolicyDrawWaits.clear()
     }
 
     private fun applyImageColorPolicyBeforeDraw(root: View): Boolean {
@@ -513,15 +517,19 @@ class EpubReaderFragment : Fragment() {
         root.forEachWebView { webView ->
             val url = webView.url?.substringBefore('#')?.takeIf { it.isNotBlank() } ?: return@forEachWebView
             val policyKey = "$generation:$url"
+            val isVisible = webView.isVisiblyDrawn()
             if (webView.progress < 100) {
                 installedImageColorPolicies.remove(webView)
-                if (webView.isVisiblyDrawn()) {
+                if (isVisible && shouldBlockImageColorPolicyDraw(root, webView, policyKey)) {
                     visiblePolicyPending = true
                     root.postInvalidateOnAnimation()
                 }
                 return@forEachWebView
             }
-            if (installedImageColorPolicies[webView] == policyKey) return@forEachWebView
+            if (installedImageColorPolicies[webView] == policyKey) {
+                imageColorPolicyDrawWaits.remove(webView)
+                return@forEachWebView
+            }
 
             if (pendingImageColorPolicies[webView] != policyKey) {
                 pendingImageColorPolicies[webView] = policyKey
@@ -534,6 +542,7 @@ class EpubReaderFragment : Fragment() {
                             webView.url?.substringBefore('#') == url
                         ) {
                             installedImageColorPolicies[webView] = policyKey
+                            imageColorPolicyDrawWaits.remove(webView)
                         }
                         root.postInvalidateOnAnimation()
                     }
@@ -541,7 +550,12 @@ class EpubReaderFragment : Fragment() {
                         {
                             if (pendingImageColorPolicies[webView] == policyKey) {
                                 pendingImageColorPolicies.remove(webView)
-                                installedImageColorPolicies[webView] = policyKey
+                                if (imageColorPolicyGeneration == generation &&
+                                    webView.url?.substringBefore('#') == url
+                                ) {
+                                    installedImageColorPolicies[webView] = policyKey
+                                    imageColorPolicyDrawWaits.remove(webView)
+                                }
                                 root.postInvalidateOnAnimation()
                             }
                         },
@@ -552,9 +566,39 @@ class EpubReaderFragment : Fragment() {
                     root.postInvalidateOnAnimation()
                 }
             }
-            if (webView.isVisiblyDrawn()) visiblePolicyPending = true
+            if (isVisible && shouldBlockImageColorPolicyDraw(root, webView, policyKey)) {
+                visiblePolicyPending = true
+            }
         }
         return !visiblePolicyPending
+    }
+
+    private fun shouldBlockImageColorPolicyDraw(
+        root: View,
+        webView: WebView,
+        policyKey: String,
+    ): Boolean {
+        val now = SystemClock.uptimeMillis()
+        val currentWait = imageColorPolicyDrawWaits[webView]
+        val wait = if (currentWait?.policyKey == policyKey) {
+            currentWait
+        } else {
+            ImageColorPolicyDrawWait(
+                policyKey = policyKey,
+                expiresAt = now + IMAGE_COLOR_POLICY_DRAW_TIMEOUT_MS,
+            ).also { newWait ->
+                imageColorPolicyDrawWaits[webView] = newWait
+                webView.postDelayed(
+                    {
+                        if (imageColorPolicyDrawWaits[webView] == newWait) {
+                            root.postInvalidateOnAnimation()
+                        }
+                    },
+                    IMAGE_COLOR_POLICY_DRAW_TIMEOUT_MS,
+                )
+            }
+        }
+        return now < wait.expiresAt
     }
 
     private fun View.forEachWebView(action: (WebView) -> Unit) {
@@ -886,4 +930,9 @@ class EpubReaderFragment : Fragment() {
             return EpubReaderFragment().apply { arguments = createArguments(chapterId, sourceId) }
         }
     }
+
+    private data class ImageColorPolicyDrawWait(
+        val policyKey: String,
+        val expiresAt: Long,
+    )
 }

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -1,10 +1,13 @@
 package koharia.epub
 
 import android.content.Context
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
 import android.view.View
 import android.view.ViewConfiguration
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.FrameLayout
@@ -39,6 +42,7 @@ import org.readium.r2.shared.util.mediatype.MediaType
 import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.util.WeakHashMap
 
 @OptIn(ExperimentalReadiumApi::class)
 class EpubReaderFragment : Fragment() {
@@ -90,6 +94,17 @@ class EpubReaderFragment : Fragment() {
     private var paragraphIndentOverrideEnabled = false
     private var continuousScrollInstallJob: Job? = null
     private var imageInteractionInstallJob: Job? = null
+    private var preserveImageColors = true
+    private var parentColorsInverted = false
+    private var imageColorPolicyScript = buildEpubImageColorPolicyScript(
+        preserveImageColors = preserveImageColors,
+        parentColorsInverted = parentColorsInverted,
+    )
+    private var imageColorPolicyGeneration = 0L
+    private var imageColorPolicyRoot: View? = null
+    private var imageColorPolicyPreDrawListener: ViewTreeObserver.OnPreDrawListener? = null
+    private val installedImageColorPolicies = WeakHashMap<WebView, String>()
+    private val pendingImageColorPolicies = WeakHashMap<WebView, String>()
     private var continuousScrollInstalledHref: String? = null
     private var continuousScrollLocator: Locator? = null
 
@@ -231,6 +246,7 @@ class EpubReaderFragment : Fragment() {
         clearContinuousScrollState()
         imageInteractionInstallJob?.cancel()
         imageInteractionInstallJob = null
+        clearImageColorPolicyDrawGuard()
         clearNavigatorInputListener()
         super.onDestroyView()
     }
@@ -355,6 +371,30 @@ class EpubReaderFragment : Fragment() {
         }
     }
 
+    internal fun updateImageColorPolicy(
+        preserveImageColors: Boolean,
+        parentColorsInverted: Boolean,
+    ) {
+        if (this.preserveImageColors == preserveImageColors &&
+            this.parentColorsInverted == parentColorsInverted
+        ) {
+            return
+        }
+        this.preserveImageColors = preserveImageColors
+        this.parentColorsInverted = parentColorsInverted
+        imageColorPolicyScript = buildEpubImageColorPolicyScript(
+            preserveImageColors = preserveImageColors,
+            parentColorsInverted = parentColorsInverted,
+        )
+        imageColorPolicyGeneration++
+        installedImageColorPolicies.clear()
+        pendingImageColorPolicies.clear()
+        imageColorPolicyRoot?.postInvalidateOnAnimation()
+        val navigator = readyNavigatorFragment()
+        scheduleImageInteractionsInstall(navigator)
+        scheduleContinuousScrollInstall(navigator)
+    }
+
     private fun observeNavigator(navigator: EpubNavigatorFragment) {
         logcat(LogPriority.DEBUG) {
             "EPUB fragment observe navigator chapterId=$chapterId"
@@ -401,7 +441,12 @@ class EpubReaderFragment : Fragment() {
 
     private fun observeNavigatorViewReady(navigator: EpubNavigatorFragment) {
         navigator.viewLifecycleOwnerLiveData.observe(viewLifecycleOwner) { owner ->
-            if (owner == null || !isAdded || view == null) return@observe
+            if (owner == null) {
+                clearImageColorPolicyDrawGuard()
+                return@observe
+            }
+            if (!isAdded || view == null) return@observe
+            installImageColorPolicyDrawGuard(navigator.publicationView)
             host?.onNavigatorReady(this)
             scheduleImageInteractionsInstall(navigator)
             scheduleContinuousScrollInstall(navigator)
@@ -413,6 +458,7 @@ class EpubReaderFragment : Fragment() {
     ) {
         imageInteractionInstallJob?.cancel()
         if (navigator == null || !isAdded || view == null) return
+        imageColorPolicyRoot?.postInvalidateOnAnimation()
         imageInteractionInstallJob = viewLifecycleOwner.lifecycleScope.launch {
             delay(IMAGE_INTERACTION_INSTALL_DELAY_MS)
             if (!isAdded || view == null || readyNavigatorFragment() !== navigator) return@launch
@@ -423,6 +469,8 @@ class EpubReaderFragment : Fragment() {
                     buildEpubImageInteractionInstallScript(
                         longPressTimeoutMs = ViewConfiguration.getLongPressTimeout(),
                         touchSlopCssPx = configuration.scaledTouchSlop / density,
+                        preserveImageColors = preserveImageColors,
+                        parentColorsInverted = parentColorsInverted,
                     ),
                 )
             }.onFailure { error ->
@@ -430,6 +478,98 @@ class EpubReaderFragment : Fragment() {
             }
         }
     }
+
+    private fun installImageColorPolicyDrawGuard(root: View) {
+        if (imageColorPolicyRoot === root && imageColorPolicyPreDrawListener != null) {
+            root.postInvalidateOnAnimation()
+            return
+        }
+        clearImageColorPolicyDrawGuard()
+        imageColorPolicyRoot = root
+        imageColorPolicyPreDrawListener = ViewTreeObserver.OnPreDrawListener {
+            applyImageColorPolicyBeforeDraw(root)
+        }.also { listener ->
+            root.viewTreeObserver.addOnPreDrawListener(listener)
+        }
+        root.postInvalidateOnAnimation()
+    }
+
+    private fun clearImageColorPolicyDrawGuard() {
+        val root = imageColorPolicyRoot
+        val listener = imageColorPolicyPreDrawListener
+        if (root != null && listener != null && root.viewTreeObserver.isAlive) {
+            root.viewTreeObserver.removeOnPreDrawListener(listener)
+        }
+        imageColorPolicyRoot = null
+        imageColorPolicyPreDrawListener = null
+        installedImageColorPolicies.clear()
+        pendingImageColorPolicies.clear()
+    }
+
+    private fun applyImageColorPolicyBeforeDraw(root: View): Boolean {
+        val generation = imageColorPolicyGeneration
+        val script = imageColorPolicyScript
+        var visiblePolicyPending = false
+        root.forEachWebView { webView ->
+            val url = webView.url?.substringBefore('#')?.takeIf { it.isNotBlank() } ?: return@forEachWebView
+            val policyKey = "$generation:$url"
+            if (webView.progress < 100) {
+                installedImageColorPolicies.remove(webView)
+                if (webView.isVisiblyDrawn()) {
+                    visiblePolicyPending = true
+                    root.postInvalidateOnAnimation()
+                }
+                return@forEachWebView
+            }
+            if (installedImageColorPolicies[webView] == policyKey) return@forEachWebView
+
+            if (pendingImageColorPolicies[webView] != policyKey) {
+                pendingImageColorPolicies[webView] = policyKey
+                runCatching {
+                    webView.evaluateJavascript(script) {
+                        if (pendingImageColorPolicies[webView] == policyKey) {
+                            pendingImageColorPolicies.remove(webView)
+                        }
+                        if (imageColorPolicyGeneration == generation &&
+                            webView.url?.substringBefore('#') == url
+                        ) {
+                            installedImageColorPolicies[webView] = policyKey
+                        }
+                        root.postInvalidateOnAnimation()
+                    }
+                    webView.postDelayed(
+                        {
+                            if (pendingImageColorPolicies[webView] == policyKey) {
+                                pendingImageColorPolicies.remove(webView)
+                                installedImageColorPolicies[webView] = policyKey
+                                root.postInvalidateOnAnimation()
+                            }
+                        },
+                        IMAGE_COLOR_POLICY_DRAW_TIMEOUT_MS,
+                    )
+                }.onFailure {
+                    pendingImageColorPolicies.remove(webView)
+                    root.postInvalidateOnAnimation()
+                }
+            }
+            if (webView.isVisiblyDrawn()) visiblePolicyPending = true
+        }
+        return !visiblePolicyPending
+    }
+
+    private fun View.forEachWebView(action: (WebView) -> Unit) {
+        if (this is WebView) {
+            action(this)
+            return
+        }
+        if (this !is ViewGroup) return
+        repeat(childCount) { index ->
+            getChildAt(index).forEachWebView(action)
+        }
+    }
+
+    private fun WebView.isVisiblyDrawn(): Boolean =
+        isShown && width > 0 && height > 0 && getGlobalVisibleRect(Rect())
 
     private fun scheduleContinuousScrollInstall(
         navigator: EpubNavigatorFragment?,
@@ -473,6 +613,8 @@ class EpubReaderFragment : Fragment() {
                             longPressTimeoutMs = ViewConfiguration.getLongPressTimeout(),
                             touchSlopCssPx = ViewConfiguration.get(requireContext()).scaledTouchSlop /
                                 (requireContext().resources.displayMetrics.density.takeIf { it > 0f } ?: 1f),
+                            preserveImageColors = preserveImageColors,
+                            parentColorsInverted = parentColorsInverted,
                         ),
                         paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
                             APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
@@ -701,6 +843,7 @@ class EpubReaderFragment : Fragment() {
         private const val CONTINUOUS_SCROLL_BRIDGE_NAME = "KohariaContinuousScroll"
         private const val CONTINUOUS_SCROLL_INSTALL_DELAY_MS = 180L
         private const val IMAGE_INTERACTION_INSTALL_DELAY_MS = 80L
+        private const val IMAGE_COLOR_POLICY_DRAW_TIMEOUT_MS = 250L
         private val READIUM_PACKAGE_BASE_URL = AbsoluteUrl("https://readium_package/")!!
         private val PARAGRAPH_INDENT_DEBUG_SCRIPT =
             """

--- a/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
@@ -54,6 +54,9 @@ class EpubLayoutPreferences(
     val publisherStyles: Preference<Boolean> =
         preferenceStore.getBoolean("epub_layout_publisher_styles", true)
 
+    val preserveImageColors: Preference<Boolean> =
+        preferenceStore.getBoolean("epub_layout_preserve_image_colors", true)
+
     val readWithVolumeKeys: Preference<Boolean> =
         preferenceStore.getBoolean("epub_layout_volume_keys", true)
 

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -1465,7 +1465,7 @@ private fun MoreReadingSettingsSheet(
             when (page) {
                 0 -> EpubReadingSettingsPage(preferences, readerPreferences)
                 1 -> EpubGeneralSettingsPage(readerPreferences, epubReaderPreferences)
-                2 -> EpubFilterSettingsPage(readerPreferences)
+                2 -> EpubFilterSettingsPage(preferences, readerPreferences)
             }
         }
     }
@@ -1544,7 +1544,10 @@ private fun ColumnScope.EpubGeneralSettingsPage(
 }
 
 @Composable
-private fun ColumnScope.EpubFilterSettingsPage(readerPreferences: ReaderPreferences) {
+private fun ColumnScope.EpubFilterSettingsPage(
+    preferences: EpubLayoutPreferences,
+    readerPreferences: ReaderPreferences,
+) {
     val colorFilter by readerPreferences.colorFilter.changes().collectAsState(readerPreferences.colorFilter.get())
     CheckboxItem(
         label = stringResource(MR.strings.pref_custom_color_filter),
@@ -1602,6 +1605,10 @@ private fun ColumnScope.EpubFilterSettingsPage(readerPreferences: ReaderPreferen
     CheckboxItem(
         label = stringResource(MR.strings.pref_inverted_colors),
         pref = readerPreferences.invertedColors,
+    )
+    CheckboxItem(
+        label = stringResource(MR.strings.pref_epub_preserve_image_colors),
+        pref = preferences.preserveImageColors,
     )
 }
 

--- a/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
@@ -51,5 +51,26 @@ class EpubImageInteractionTest {
 
         assertTrue(invertedScript.contains("const parentColorsInverted = true"))
         assertTrue(invertedScript.contains("filter: invert(100%) !important"))
+        assertTrue(invertedScript.contains("document.createElementNS(styleNamespace, 'style')"))
+        assertTrue(
+            invertedScript.contains("document.documentElement.namespaceURI === 'http://www.w3.org/2000/svg'"),
+        )
+        assertTrue(invertedScript.contains(":root svg svg"))
+    }
+
+    @Test
+    fun `continuous scroll hides frames until image policy is installed`() {
+        val continuousScript = buildEpubContinuousScrollInstallScript(
+            resources = listOf(
+                EpubContinuousScrollResource(0, "chapter.xhtml", "https://readium/chapter.xhtml"),
+            ),
+            currentIndex = 0,
+            initialProgression = 0.0,
+            imageInteractionScript = script,
+            paragraphIndentScript = "",
+        )
+
+        assertTrue(continuousScript.contains("iframe.style.visibility = 'hidden'"))
+        assertTrue(continuousScript.contains("iframe.style.visibility = 'visible'"))
     }
 }

--- a/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
@@ -8,6 +8,8 @@ class EpubImageInteractionTest {
     private val script = buildEpubImageInteractionInstallScript(
         longPressTimeoutMs = 500,
         touchSlopCssPx = 8f,
+        preserveImageColors = true,
+        parentColorsInverted = false,
     )
 
     @Test
@@ -29,5 +31,25 @@ class EpubImageInteractionTest {
     @Test
     fun `linked images retain their navigation behavior`() {
         assertTrue(script.contains("image.closest('a[href]')"))
+    }
+
+    @Test
+    fun `script keeps images unchanged in Readium night mode`() {
+        assertTrue(script.contains("koharia-epub-image-color-policy"))
+        assertTrue(script.contains("readium-night-on"))
+        assertTrue(script.contains("filter: none !important"))
+    }
+
+    @Test
+    fun `script counter-inverts images when the parent view is inverted`() {
+        val invertedScript = buildEpubImageInteractionInstallScript(
+            longPressTimeoutMs = 500,
+            touchSlopCssPx = 8f,
+            preserveImageColors = true,
+            parentColorsInverted = true,
+        )
+
+        assertTrue(invertedScript.contains("const parentColorsInverted = true"))
+        assertTrue(invertedScript.contains("filter: invert(100%) !important"))
     }
 }

--- a/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
@@ -33,6 +33,13 @@ class EpubReaderPreferenceDefaultsTest {
     }
 
     @Test
+    fun `EPUB images preserve their colors by default`() {
+        val preferences = EpubLayoutPreferences(InMemoryPreferenceStore())
+
+        assertTrue(preferences.preserveImageColors.get())
+    }
+
+    @Test
     fun `legacy free global orientation is exposed as default`() {
         val store = InMemoryPreferenceStore()
         store.getInt("pref_default_orientation_type_key").set(ReaderOrientation.FREE.flagValue)

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -967,6 +967,8 @@
     <string name="pref_epub_layout_mode">Layout mode</string>
     <string name="pref_epub_page_direction">Page direction</string>
     <string name="pref_epub_typography_and_appearance">Typography &amp; appearance</string>
+    <string name="pref_epub_preserve_image_colors">Keep image colors when inverted</string>
+    <string name="pref_epub_preserve_image_colors_summary">Prevent EPUB images from being color-inverted by the reader or dark theme</string>
     <string name="pref_epub_layout_paginated">Paginated</string>
     <string name="pref_epub_layout_scrolled">Continuous scroll</string>
     <string name="pref_epub_theme">Background settings</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -610,6 +610,8 @@
     <string name="pref_epub_layout_mode">布局模式</string>
     <string name="pref_epub_page_direction">翻页方向</string>
     <string name="pref_epub_typography_and_appearance">排版与外观</string>
+    <string name="pref_epub_preserve_image_colors">反色时保持图片原色</string>
+    <string name="pref_epub_preserve_image_colors_summary">避免 EPUB 图片被阅读器反色或深色主题反色</string>
     <string name="pref_epub_layout_paginated">分页</string>
     <string name="pref_epub_layout_scrolled">连续滚动</string>
     <string name="pref_epub_theme">背景设置</string>


### PR DESCRIPTION
## 概述 / Summary

- 新增默认开启的“反色时保持图片原色”设置，并在全局阅读设置与 EPUB 阅读器快捷设置中共用同一偏好。
- Add a default-enabled “preserve image colors when inverted” option shared by global reader settings and EPUB quick settings.
- 覆盖整体颜色反转与 Readium 夜间主题，支持分页、连续滚动 iframe、`img`/`picture` 与 SVG。
- Cover full-page inversion and the Readium night theme across paginated and continuous-scroll content, including `img`/`picture` and SVG images.

## 修复 / Fix

- 根因是硬件颜色反转会先于页面加载后注入的 CSS 补偿生效，翻页时因此短暂显示反色图片。
- The flicker occurred because hardware color inversion was applied before the post-load CSS compensation.
- 将图片颜色策略与点击/长按交互脚本拆分，并提前注入当前及 Readium 预加载 WebView；首次绘制等待策略应用，同时使用 250 ms 失效保护避免阻塞。
- Separate the image color policy from click/long-press interaction scripts, inject it into current and preloaded Readium WebViews, and guard first draw until the policy is applied with a 250 ms fail-safe.

## 验证 / Verification

- `git diff --check`：通过 / passed.
- 按当前协作约定未运行 Gradle。/ Gradle was not run per the current collaboration preference.
- 建议检查 / Suggested checks:
  - `.\gradlew.bat spotlessApply`
  - `.\gradlew.bat spotlessCheck`
  - `.\gradlew.bat :app:compileDebugKotlin`