### PR TITLE
修复 EPUB 非标准内容兼容与进度稳定性 / Fix EPUB compatibility and progress stability

### DIFF
--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -1,7 +1,9 @@
 package koharia.epub
 
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 
 internal data class EpubContinuousScrollResource(
     val index: Int,
@@ -27,10 +29,10 @@ internal fun buildEpubContinuousScrollInstallScript(
     imageInteractionScript: String,
     paragraphIndentScript: String,
 ): String {
-    val resourcesJson = JSONArray().apply {
+    val resourcesJson = buildJsonArray {
         resources.forEach { resource ->
-            put(
-                JSONObject().apply {
+            add(
+                buildJsonObject {
                     put("index", resource.index)
                     put("href", resource.href)
                     put("url", resource.url)
@@ -38,8 +40,8 @@ internal fun buildEpubContinuousScrollInstallScript(
             )
         }
     }
-    val indentScriptJson = JSONObject.quote(paragraphIndentScript)
-    val imageInteractionScriptJson = JSONObject.quote(imageInteractionScript)
+    val indentScriptJson = JsonPrimitive(paragraphIndentScript)
+    val imageInteractionScriptJson = JsonPrimitive(imageInteractionScript)
     val clampedProgression = initialProgression.coerceIn(0.0, 1.0)
 
     return """

--- a/app/src/main/java/koharia/epub/EpubLocatorProgressStability.kt
+++ b/app/src/main/java/koharia/epub/EpubLocatorProgressStability.kt
@@ -1,0 +1,32 @@
+package koharia.epub
+
+import org.readium.r2.shared.publication.Locator
+
+internal fun Locator.preserveProgressMetricsFrom(previous: Locator?): Locator {
+    previous ?: return this
+    if (!href.toString().isSameEpubResource(previous.href.toString())) return this
+
+    val stablePosition = previous.locations.position ?: locations.position
+    val stableTotalProgression = previous.locations.totalProgression ?: locations.totalProgression
+    if (stablePosition == locations.position && stableTotalProgression == locations.totalProgression) {
+        return this
+    }
+    return copy(
+        locations = locations.copy(
+            position = stablePosition,
+            totalProgression = stableTotalProgression,
+        ),
+    )
+}
+
+private fun String.isSameEpubResource(other: String): Boolean {
+    val first = resourceKey()
+    val second = other.resourceKey()
+    if (first.isBlank() || second.isBlank()) return false
+    return first == second || first.endsWith("/$second") || second.endsWith("/$first")
+}
+
+private fun String.resourceKey(): String =
+    substringBefore('#')
+        .substringBefore('?')
+        .trimStart('/')

--- a/app/src/main/java/koharia/epub/EpubLocatorProgressStability.kt
+++ b/app/src/main/java/koharia/epub/EpubLocatorProgressStability.kt
@@ -1,6 +1,7 @@
 package koharia.epub
 
 import org.readium.r2.shared.publication.Locator
+import java.net.URI
 
 internal fun Locator.preserveProgressMetricsFrom(previous: Locator?): Locator {
     previous ?: return this
@@ -19,14 +20,63 @@ internal fun Locator.preserveProgressMetricsFrom(previous: Locator?): Locator {
     )
 }
 
-private fun String.isSameEpubResource(other: String): Boolean {
-    val first = resourceKey()
-    val second = other.resourceKey()
-    if (first.isBlank() || second.isBlank()) return false
-    return first == second || first.endsWith("/$second") || second.endsWith("/$first")
+internal fun Locator.alignToEpubPositions(positions: List<Locator>): Locator {
+    val targetProgression = locations.progression ?: return this
+    val resourcePositions = positions.mapNotNull { position ->
+        if (!position.href.toString().isSameEpubResource(href.toString())) return@mapNotNull null
+        val progression = position.locations.progression ?: return@mapNotNull null
+        position to progression
+    }
+    if (resourcePositions.isEmpty()) return this
+
+    val alignedPosition = resourcePositions
+        .filter { (_, progression) -> progression <= targetProgression }
+        .maxByOrNull { (_, progression) -> progression }
+        ?: resourcePositions.minBy { (_, progression) -> progression }
+    val authoritativeLocations = alignedPosition.first.locations
+    val alignedProgression = alignedPosition.second
+    val alignedPositionIndex = authoritativeLocations.position ?: locations.position
+    val alignedTotalProgression = authoritativeLocations.totalProgression ?: locations.totalProgression
+    if (
+        alignedProgression == locations.progression &&
+        alignedPositionIndex == locations.position &&
+        alignedTotalProgression == locations.totalProgression
+    ) {
+        return this
+    }
+
+    return copy(
+        locations = locations.copy(
+            progression = alignedProgression,
+            position = alignedPositionIndex,
+            totalProgression = alignedTotalProgression,
+        ),
+    )
 }
 
-private fun String.resourceKey(): String =
-    substringBefore('#')
+internal fun String.isSameEpubResource(other: String): Boolean {
+    val first = canonicalEpubResourcePath()
+    val second = other.canonicalEpubResourcePath()
+    if (first.isBlank() || second.isBlank()) return false
+    return first == second
+}
+
+private fun String.canonicalEpubResourcePath(): String {
+    val resourceHref = substringBefore('#')
         .substringBefore('?')
+        .trim()
+    if (resourceHref.isBlank()) return ""
+
+    val uri = runCatching { URI(resourceHref) }.getOrNull()
+    val servedPath = if (uri?.rawAuthority.equals(READIUM_PACKAGE_AUTHORITY, ignoreCase = true)) {
+        uri?.rawPath.orEmpty()
+    } else {
+        resourceHref
+    }
+    return servedPath
+        .substringAfter(READIUM_RESOURCE_PATH_PREFIX, missingDelimiterValue = servedPath)
         .trimStart('/')
+}
+
+private const val READIUM_PACKAGE_AUTHORITY = "readium_package"
+private const val READIUM_RESOURCE_PATH_PREFIX = "/resource/"

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -15,6 +15,7 @@ internal const val EPUB_PARAGRAPH_INDENT_CSS =
 
 internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
     """(function() {
+        if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
         var style = document.getElementById('$EPUB_PARAGRAPH_INDENT_STYLE_ID');
         if (!style) {
             style = document.createElementNS('http://www.w3.org/1999/xhtml', 'style');
@@ -59,6 +60,7 @@ internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
 
 internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
     """(function() {
+        if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
         var style = document.getElementById('$EPUB_PARAGRAPH_INDENT_STYLE_ID');
         if (style) style.remove();
         Array.from(document.querySelectorAll('p[$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE]')).forEach(function(paragraph) {
@@ -69,6 +71,25 @@ internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
         });
         return true;
     })()"""
+
+internal fun buildEpubDocumentPreparationScript(
+    paragraphIndentOverrideEnabled: Boolean,
+    preserveImageColors: Boolean,
+    parentColorsInverted: Boolean,
+): String {
+    val paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
+        APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
+    } else {
+        REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT
+    }
+    return """
+        (function() {
+            $paragraphIndentScript;
+            ${buildEpubImageColorPolicyScript(preserveImageColors, parentColorsInverted)};
+            return 'prepared';
+        })()
+    """.trimIndent()
+}
 
 internal fun String.injectEpubParagraphIndentStyle(): String {
     if (contains("id=\"$EPUB_PARAGRAPH_INDENT_STYLE_ID\"", ignoreCase = true)) return this

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -24,6 +24,7 @@ import koharia.epub.session.EpubReaderSessionRepository
 import koharia.epub.settings.EpubLayoutPreferences
 import koharia.epub.settings.EpubPreferencesBridge
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -97,7 +98,8 @@ class EpubReaderFragment : Fragment() {
     private var imageInteractionInstallJob: Job? = null
     private var preserveImageColors = true
     private var parentColorsInverted = false
-    private var imageColorPolicyScript = buildEpubImageColorPolicyScript(
+    private var imageColorPolicyScript = buildEpubDocumentPreparationScript(
+        paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
         preserveImageColors = preserveImageColors,
         parentColorsInverted = parentColorsInverted,
     )
@@ -127,7 +129,6 @@ class EpubReaderFragment : Fragment() {
     private val paginationListener = object : EpubNavigatorFragment.PaginationListener {
         override fun onPageChanged(pageIndex: Int, totalPages: Int, locator: Locator) {
             host?.onPageChanged(pageIndex, totalPages, locator)
-            applyParagraphIndentOverride()
             scheduleImageInteractionsInstall()
         }
     }
@@ -139,6 +140,8 @@ class EpubReaderFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val session = sessionRepository.get(chapterId)
+        paragraphIndentOverrideEnabled = epubLayoutPreferences.publisherStyles.get().not()
+        refreshDocumentPreparationPolicy()
         logcat(LogPriority.DEBUG) {
             "EPUB fragment onCreate chapterId=$chapterId hasSession=${session != null}"
         }
@@ -289,9 +292,13 @@ class EpubReaderFragment : Fragment() {
         if (!keepContinuousScrollPosition) {
             clearContinuousScrollState()
         }
-        paragraphIndentOverrideEnabled = preferences.publisherStyles == false
+        val paragraphOverrideEnabled = preferences.publisherStyles == false
+        val paragraphPolicyChanged = paragraphIndentOverrideEnabled != paragraphOverrideEnabled
+        paragraphIndentOverrideEnabled = paragraphOverrideEnabled
         navigator?.submitPreferences(preferences)
-        applyParagraphIndentOverride()
+        if (paragraphPolicyChanged) {
+            refreshDocumentPreparationPolicy()
+        }
         scheduleImageInteractionsInstall(navigator)
         if (keepContinuousScrollPosition) {
             // Keep the JS-reported Locator when the visible resource is an adjacent iframe. The
@@ -305,20 +312,6 @@ class EpubReaderFragment : Fragment() {
                 "paragraphSpacing=${preferences.paragraphSpacing} lineHeight=${preferences.lineHeight}"
         }
         logComputedParagraphIndent()
-    }
-
-    private fun applyParagraphIndentOverride() {
-        if (!isAdded || view == null) return
-        viewLifecycleOwner.lifecycleScope.launch {
-            val navigator = readyNavigatorFragment() ?: return@launch
-            navigator.evaluateJavascript(
-                if (paragraphIndentOverrideEnabled) {
-                    APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
-                } else {
-                    REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT
-                },
-            )
-        }
     }
 
     private fun logComputedParagraphIndent() {
@@ -384,7 +377,15 @@ class EpubReaderFragment : Fragment() {
         }
         this.preserveImageColors = preserveImageColors
         this.parentColorsInverted = parentColorsInverted
-        imageColorPolicyScript = buildEpubImageColorPolicyScript(
+        refreshDocumentPreparationPolicy()
+        val navigator = readyNavigatorFragment()
+        scheduleImageInteractionsInstall(navigator)
+        scheduleContinuousScrollInstall(navigator)
+    }
+
+    private fun refreshDocumentPreparationPolicy() {
+        imageColorPolicyScript = buildEpubDocumentPreparationScript(
+            paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
             preserveImageColors = preserveImageColors,
             parentColorsInverted = parentColorsInverted,
         )
@@ -393,9 +394,6 @@ class EpubReaderFragment : Fragment() {
         pendingImageColorPolicies.clear()
         imageColorPolicyDrawWaits.clear()
         imageColorPolicyRoot?.postInvalidateOnAnimation()
-        val navigator = readyNavigatorFragment()
-        scheduleImageInteractionsInstall(navigator)
-        scheduleContinuousScrollInstall(navigator)
     }
 
     private fun observeNavigator(navigator: EpubNavigatorFragment) {
@@ -427,7 +425,6 @@ class EpubReaderFragment : Fragment() {
                         host?.onLocatorChanged(locator)
                         scheduleContinuousScrollInstall(navigator, locator)
                     }
-                    applyParagraphIndentOverride()
                     scheduleImageInteractionsInstall(navigator)
                 }
             }
@@ -467,7 +464,7 @@ class EpubReaderFragment : Fragment() {
             if (!isAdded || view == null || readyNavigatorFragment() !== navigator) return@launch
             val configuration = ViewConfiguration.get(requireContext())
             val density = resources.displayMetrics.density.takeIf { it > 0f } ?: 1f
-            runCatching {
+            try {
                 navigator.evaluateJavascript(
                     buildEpubImageInteractionInstallScript(
                         longPressTimeoutMs = ViewConfiguration.getLongPressTimeout(),
@@ -476,7 +473,9 @@ class EpubReaderFragment : Fragment() {
                         parentColorsInverted = parentColorsInverted,
                     ),
                 )
-            }.onFailure { error ->
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
                 logcat(LogPriority.WARN, error) { "Failed to install EPUB image interactions" }
             }
         }

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -214,7 +214,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private val locatorPersistenceJob = viewModelScope.launch {
         locatorUpdates
             .debounce(750L)
-            .collect(::persistLocator)
+            .collect { locator -> persistLocator(locator) }
     }
 
     init {
@@ -854,10 +854,23 @@ class EpubReaderViewModel @JvmOverloads constructor(
     }
 
     fun updateLocator(locator: Locator) {
-        val persistentLocator = sessionRepository.get(chapterId)
+        val session = sessionRepository.get(chapterId)
+        val mappedLocator = session
             ?.publication
             ?.toPersistentLocator(locator)
             ?: locator
+        val persistentLocator = if (session?.positionsController?.hasAuthoritativePositions == false) {
+            mappedLocator.preserveProgressMetricsFrom(latestLocator)
+        } else {
+            mappedLocator
+        }
+        if (persistentLocator !== mappedLocator) {
+            logcat(LogPriority.DEBUG) {
+                "Preserved EPUB progress while positions are provisional chapterId=$chapterId " +
+                    "href=${persistentLocator.href} total=${persistentLocator.totalProgressionValue()} " +
+                    "position=${persistentLocator.positionIndex()}"
+            }
+        }
         val visualPagePair = visualPagePairForLocator(persistentLocator)
         visualPagePair?.first?.let { visualPageNumber = it }
         latestLocator = persistentLocator
@@ -1005,7 +1018,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
         positionsRefreshStarted = true
         viewModelScope.launch {
             runCatching { session.positionsController.refresh() }
-                .onSuccess(::applyPublicationPositions)
+                .onSuccess { positions ->
+                    applyPublicationPositions(positions)
+                    logcat(LogPriority.DEBUG) {
+                        "EPUB positions refreshed chapterId=$chapterId " +
+                            "authoritative=${session.positionsController.hasAuthoritativePositions} " +
+                            "positions=${positions.size}"
+                    }
+                    latestLocator?.let(locatorUpdates::tryEmit)
+                }
                 .onFailure { error ->
                     logcat(LogPriority.WARN, error) {
                         "Failed to refresh EPUB positions for chapterId=$chapterId"
@@ -1720,13 +1741,14 @@ class EpubReaderViewModel @JvmOverloads constructor(
     fun releaseSession() {
         closeImagePreview()
         locatorPersistenceJob.cancel()
+        val finalPositions = authoritativePublicationPositions()
         sessionRepository.remove(chapterId)?.close()
         releaseCacheLeases()
 
         val locator = latestLocator
         if (locator != null && !isIncognito()) {
             sessionReleaseScope.launch {
-                runCatching { persistLocator(locator) }
+                runCatching { persistLocator(locator, finalPositions) }
                     .onFailure { error ->
                         logcat(LogPriority.ERROR, error) {
                             "Failed to persist final EPUB locator for chapterId=$chapterId"
@@ -1860,8 +1882,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
     ) {
         val sourceId = currentSourceId.takeIf { it > 0 } ?: return
         val bookUrl = localProgress.bookUrl ?: currentBookUrl ?: return
+        val positions = authoritativePublicationPositions() ?: return
         runCatching {
-            komgaEpubProgressSyncService.pushProgression(sourceId, bookUrl, locator, localProgress.updatedAt)
+            komgaEpubProgressSyncService.pushProgression(
+                sourceId = sourceId,
+                bookUrl = bookUrl,
+                locator = locator,
+                positions = positions,
+                modifiedAt = localProgress.updatedAt,
+            )
             val syncedProgress = localProgress.copy(lastSyncedAt = localProgress.updatedAt)
             currentProgress = syncedProgress
             upsertEpubProgress.await(syncedProgress)
@@ -1872,7 +1901,10 @@ class EpubReaderViewModel @JvmOverloads constructor(
         }
     }
 
-    private suspend fun persistLocator(locator: Locator) = progressPersistenceMutex.withLock {
+    private suspend fun persistLocator(
+        locator: Locator,
+        positionsOverride: List<Locator>? = null,
+    ) = progressPersistenceMutex.withLock {
         val chapterId = chapterId.takeIf { it > 0 } ?: return@withLock
         mangaId.takeIf { it > 0 } ?: return@withLock
         val now = Date()
@@ -1894,8 +1926,15 @@ class EpubReaderViewModel @JvmOverloads constructor(
         val bookUrl = progress.bookUrl
         if (bookUrl != null && epubReaderPreferences.syncProgressionToKomga.get()) {
             val sourceId = currentSourceId.takeIf { it > 0 } ?: return@withLock
+            val positions = positionsOverride ?: authoritativePublicationPositions() ?: return@withLock
             runCatching {
-                komgaEpubProgressSyncService.pushProgression(sourceId, bookUrl, locator, now)
+                komgaEpubProgressSyncService.pushProgression(
+                    sourceId = sourceId,
+                    bookUrl = bookUrl,
+                    locator = locator,
+                    positions = positions,
+                    modifiedAt = now,
+                )
                 val syncedProgress = progress.copy(lastSyncedAt = now)
                 upsertEpubProgress.await(syncedProgress)
                 currentProgress = syncedProgress
@@ -2030,6 +2069,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     private fun Locator.totalProgressionValue(): Double? {
         return (locations.totalProgression as? Number)?.toDouble()
+    }
+
+    private fun authoritativePublicationPositions(): List<Locator>? {
+        val controller = sessionRepository.get(chapterId)?.positionsController ?: return null
+        if (!controller.hasAuthoritativePositions) return null
+        return publicationPositions.takeIf { it.isNotEmpty() }
     }
 
     private fun Locator.positionIndex(): Long? {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -1019,6 +1019,13 @@ class EpubReaderViewModel @JvmOverloads constructor(
         viewModelScope.launch {
             runCatching { session.positionsController.refresh() }
                 .onSuccess { positions ->
+                    if (session.positionsController.hasAuthoritativePositions) {
+                        latestLocator = latestLocator
+                            ?.alignToEpubPositions(positions)
+                            ?.also { alignedLocator ->
+                                locatorJson = alignedLocator.toJSON().toString()
+                            }
+                    }
                     applyPublicationPositions(positions)
                     logcat(LogPriority.DEBUG) {
                         "EPUB positions refreshed chapterId=$chapterId " +

--- a/app/src/main/java/koharia/epub/locator/EpubLocatorMapper.kt
+++ b/app/src/main/java/koharia/epub/locator/EpubLocatorMapper.kt
@@ -1,5 +1,6 @@
 package koharia.epub.locator
 
+import koharia.epub.isSameEpubResource
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.publication.Publication
@@ -23,7 +24,7 @@ private fun Publication.findResource(href: String): ResourceHref? {
         .map(Link::toResourceHref)
         .firstOrNull { resource ->
             resource.aliases.any { alias ->
-                alias == target || alias.endsWith("/$target") || target.endsWith("/$alias")
+                alias.isSameEpubResource(target)
             }
         }
 }

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.await
+import koharia.epub.alignToEpubPositions
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
 import logcat.LogPriority
@@ -274,40 +275,5 @@ class KomgaEpubProgressSyncService(
 }
 
 internal fun Locator.alignToKomgaPositions(positions: List<Locator>): Locator {
-    val targetProgression = locations.progression ?: return this
-    val targetHref = href.toString()
-    val resourcePositions = positions.mapNotNull { position ->
-        if (!position.href.toString().isSameEpubResource(targetHref)) return@mapNotNull null
-        val progression = position.locations.progression ?: return@mapNotNull null
-        position to progression
-    }
-    if (resourcePositions.isEmpty()) return this
-
-    val alignedPosition = resourcePositions
-        .filter { (_, progression) -> progression <= targetProgression }
-        .maxByOrNull { (_, progression) -> progression }
-        ?: resourcePositions.minBy { (_, progression) -> progression }
-    val alignedProgression = alignedPosition.second
-    if (alignedProgression == targetProgression) return this
-
-    return copy(
-        locations = locations.copy(
-            progression = alignedProgression,
-            position = alignedPosition.first.locations.position ?: locations.position,
-            totalProgression = alignedPosition.first.locations.totalProgression
-                ?: locations.totalProgression,
-        ),
-    )
+    return alignToEpubPositions(positions)
 }
-
-private fun String.isSameEpubResource(other: String): Boolean {
-    val first = resourceKey()
-    val second = other.resourceKey()
-    if (first.isBlank() || second.isBlank()) return false
-    return first == second || first.endsWith("/$second") || second.endsWith("/$first")
-}
-
-private fun String.resourceKey(): String =
-    substringBefore('#')
-        .substringBefore('?')
-        .trimStart('/')

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -80,10 +80,19 @@ class KomgaEpubProgressSyncService(
         sourceId: Long,
         bookUrl: String,
         locator: Locator,
+        positions: List<Locator>,
         modifiedAt: Date,
     ) = withIOContext {
         val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext
         val normalizedBookUrl = normalizeBookUrl(bookUrl)
+        val alignedLocator = locator.alignToKomgaPositions(positions)
+        if (alignedLocator !== locator) {
+            logcat(LogPriority.DEBUG) {
+                "Aligned Komga EPUB progression href=${locator.href} " +
+                    "from=${locator.locations.progression} " +
+                    "to=${alignedLocator.locations.progression}"
+            }
+        }
         val payload = JSONObject().apply {
             put(
                 "device",
@@ -92,7 +101,7 @@ class KomgaEpubProgressSyncService(
                     put("name", buildDeviceName())
                 },
             )
-            put("locator", locator.toKomgaJSON())
+            put("locator", alignedLocator.toKomgaJSON())
             put("modified", modifiedAt.toInstant().toString())
         }
         val request = Request.Builder()
@@ -263,3 +272,42 @@ class KomgaEpubProgressSyncService(
         const val MAX_CORRECTION_HOURS = 24L
     }
 }
+
+internal fun Locator.alignToKomgaPositions(positions: List<Locator>): Locator {
+    val targetProgression = locations.progression ?: return this
+    val targetHref = href.toString()
+    val resourcePositions = positions.mapNotNull { position ->
+        if (!position.href.toString().isSameEpubResource(targetHref)) return@mapNotNull null
+        val progression = position.locations.progression ?: return@mapNotNull null
+        position to progression
+    }
+    if (resourcePositions.isEmpty()) return this
+
+    val alignedPosition = resourcePositions
+        .filter { (_, progression) -> progression <= targetProgression }
+        .maxByOrNull { (_, progression) -> progression }
+        ?: resourcePositions.minBy { (_, progression) -> progression }
+    val alignedProgression = alignedPosition.second
+    if (alignedProgression == targetProgression) return this
+
+    return copy(
+        locations = locations.copy(
+            progression = alignedProgression,
+            position = alignedPosition.first.locations.position ?: locations.position,
+            totalProgression = alignedPosition.first.locations.totalProgression
+                ?: locations.totalProgression,
+        ),
+    )
+}
+
+private fun String.isSameEpubResource(other: String): Boolean {
+    val first = resourceKey()
+    val second = other.resourceKey()
+    if (first.isBlank() || second.isBlank()) return false
+    return first == second || first.endsWith("/$second") || second.endsWith("/$first")
+}
+
+private fun String.resourceKey(): String =
+    substringBefore('#')
+        .substringBefore('?')
+        .trimStart('/')

--- a/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
+++ b/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
@@ -1,8 +1,5 @@
 package koharia.epub.service
 
-import java.nio.ByteBuffer
-import java.nio.charset.Charset
-import java.nio.charset.CodingErrorAction
 import logcat.LogPriority
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Publication
@@ -12,6 +9,9 @@ import org.readium.r2.shared.util.data.Container
 import org.readium.r2.shared.util.resource.Resource
 import org.readium.r2.shared.util.resource.map
 import tachiyomi.core.common.util.system.logcat
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
 
 private data class DecodedXhtml(
     val content: String,

--- a/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
+++ b/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
@@ -1,0 +1,253 @@
+package koharia.epub.service
+
+import java.nio.ByteBuffer
+import java.nio.charset.Charset
+import java.nio.charset.CodingErrorAction
+import logcat.LogPriority
+import org.readium.r2.shared.publication.Manifest
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.data.Container
+import org.readium.r2.shared.util.resource.Resource
+import org.readium.r2.shared.util.resource.map
+import tachiyomi.core.common.util.system.logcat
+
+private data class DecodedXhtml(
+    val content: String,
+    val charset: Charset,
+    val byteOrderMark: ByteArray,
+)
+
+internal data class EpubXhtmlCompatibilityResult(
+    val content: String,
+    val repairedAttributes: Int,
+)
+
+private data class EpubXhtmlByteCompatibilityResult(
+    val bytes: ByteArray,
+    val repairedAttributes: Int,
+)
+
+internal fun Publication.Builder.installEpubXhtmlCompatibility() {
+    if (container is EpubXhtmlCompatibilityContainer) return
+    container = EpubXhtmlCompatibilityContainer(container, manifest)
+}
+
+private class EpubXhtmlCompatibilityContainer(
+    private val delegate: Container<Resource>,
+    private val manifest: Manifest,
+) : Container<Resource> {
+
+    override val sourceUrl = delegate.sourceUrl
+    override val entries = delegate.entries
+
+    override fun get(url: Url): Resource? {
+        val resource = delegate[url] ?: return null
+        if (!manifest.isHtmlResource(url)) return resource
+
+        return resource.map { bytes ->
+            val normalized = bytes.normalizeEpubXhtmlForCompatibility()
+            if (normalized.repairedAttributes > 0) {
+                logcat(LogPriority.DEBUG) {
+                    "EPUB XHTML compatibility repaired href=${url.safeLogHref()} " +
+                        "attributes=${normalized.repairedAttributes}"
+                }
+            }
+            Try.success(normalized.bytes)
+        }
+    }
+
+    override fun close() {
+        delegate.close()
+    }
+}
+
+private fun Manifest.isHtmlResource(url: Url): Boolean {
+    if (linkWithHref(url)?.mediaType?.isHtml == true) return true
+    return url.toString()
+        .substringBefore('#')
+        .substringBefore('?')
+        .substringAfterLast('.', missingDelimiterValue = "")
+        .lowercase() in HTML_FILE_EXTENSIONS
+}
+
+private fun Url.safeLogHref(): String =
+    toString()
+        .substringBefore('?')
+        .substringBefore('#')
+
+private fun ByteArray.normalizeEpubXhtmlForCompatibility(): EpubXhtmlByteCompatibilityResult {
+    val decoded = decodeXhtml() ?: return EpubXhtmlByteCompatibilityResult(this, 0)
+    val normalized = decoded.content.normalizeEpubXhtmlForCompatibility()
+    if (normalized.repairedAttributes == 0) {
+        return EpubXhtmlByteCompatibilityResult(this, 0)
+    }
+    return EpubXhtmlByteCompatibilityResult(
+        bytes = decoded.byteOrderMark + normalized.content.toByteArray(decoded.charset),
+        repairedAttributes = normalized.repairedAttributes,
+    )
+}
+
+private fun ByteArray.decodeXhtml(): DecodedXhtml? {
+    val (charset, byteOrderMark) = when {
+        startsWithBytes(UTF_16_BE_BOM) -> Charsets.UTF_16BE to UTF_16_BE_BOM
+        startsWithBytes(UTF_16_LE_BOM) -> Charsets.UTF_16LE to UTF_16_LE_BOM
+        startsWithBytes(UTF_8_BOM) -> Charsets.UTF_8 to UTF_8_BOM
+        else -> Charsets.UTF_8 to byteArrayOf()
+    }
+    val decoder = charset.newDecoder()
+        .onMalformedInput(CodingErrorAction.REPORT)
+        .onUnmappableCharacter(CodingErrorAction.REPORT)
+    val contentBytes = ByteBuffer.wrap(this, byteOrderMark.size, size - byteOrderMark.size)
+    val content = runCatching { decoder.decode(contentBytes).toString() }.getOrNull() ?: return null
+    return DecodedXhtml(content, charset, byteOrderMark)
+}
+
+private fun ByteArray.startsWithBytes(prefix: ByteArray): Boolean =
+    size >= prefix.size && prefix.indices.all { index -> this[index] == prefix[index] }
+
+internal fun String.normalizeEpubXhtmlForCompatibility(): EpubXhtmlCompatibilityResult {
+    if ('<' !in this) return EpubXhtmlCompatibilityResult(this, 0)
+
+    // Work on start-tag tokens only. A whole-document regex could rewrite attribute-shaped text
+    // inside quoted values, comments, CDATA or processing instructions.
+    val normalized = StringBuilder(length)
+    var repairedAttributes = 0
+    var cursor = 0
+    while (cursor < length) {
+        val tagStart = indexOf('<', cursor)
+        if (tagStart < 0) {
+            normalized.append(substring(cursor))
+            break
+        }
+        normalized.append(substring(cursor, tagStart))
+
+        val tagEnd = findMarkupEnd(tagStart)
+        if (tagEnd < 0) {
+            normalized.append(substring(tagStart))
+            break
+        }
+
+        val markup = substring(tagStart, tagEnd + 1)
+        if (tagStart + 1 < length && this[tagStart + 1].isXmlNameStart()) {
+            val result = markup.normalizeStartTagAttributes()
+            normalized.append(result.content)
+            repairedAttributes += result.repairedAttributes
+        } else {
+            normalized.append(markup)
+        }
+        cursor = tagEnd + 1
+    }
+    return EpubXhtmlCompatibilityResult(normalized.toString(), repairedAttributes)
+}
+
+private fun String.findMarkupEnd(tagStart: Int): Int {
+    return when {
+        startsWith("<!--", tagStart) -> indexOf("-->", tagStart + 4)
+            .takeIf { it >= 0 }
+            ?.plus(2)
+            ?: -1
+        startsWith("<![CDATA[", tagStart) -> indexOf("]]>", tagStart + 9)
+            .takeIf { it >= 0 }
+            ?.plus(2)
+            ?: -1
+        startsWith("<?", tagStart) -> indexOf("?>", tagStart + 2)
+            .takeIf { it >= 0 }
+            ?.plus(1)
+            ?: -1
+        else -> findTagEnd(tagStart + 1)
+    }
+}
+
+private fun String.findTagEnd(start: Int): Int {
+    var quote: Char? = null
+    for (index in start until length) {
+        val character = this[index]
+        if (quote != null) {
+            if (character == quote) quote = null
+        } else {
+            when (character) {
+                '\'', '"' -> quote = character
+                '>' -> return index
+            }
+        }
+    }
+    return -1
+}
+
+private fun String.normalizeStartTagAttributes(): EpubXhtmlCompatibilityResult {
+    if (length < 3 || first() != '<' || last() != '>') {
+        return EpubXhtmlCompatibilityResult(this, 0)
+    }
+
+    val normalized = StringBuilder(length)
+    normalized.append('<')
+    var cursor = 1
+    while (cursor < lastIndex && this[cursor].isXmlNamePart()) {
+        normalized.append(this[cursor])
+        cursor++
+    }
+
+    var repairedAttributes = 0
+    while (cursor < lastIndex) {
+        val character = this[cursor]
+        if (character.isWhitespace() || character == '/') {
+            normalized.append(character)
+            cursor++
+            continue
+        }
+        if (!character.isXmlNameStart()) {
+            normalized.append(character)
+            cursor++
+            continue
+        }
+
+        val nameStart = cursor
+        cursor++
+        while (cursor < lastIndex && this[cursor].isXmlNamePart()) cursor++
+        normalized.append(substring(nameStart, cursor))
+
+        val separatorStart = cursor
+        while (cursor < lastIndex && this[cursor].isWhitespace()) cursor++
+        if (cursor >= lastIndex || this[cursor] != '=') {
+            normalized.append("=\"\"")
+            repairedAttributes++
+            cursor = separatorStart
+            continue
+        }
+
+        normalized.append(substring(separatorStart, cursor + 1))
+        cursor++
+        val valueSpacingStart = cursor
+        while (cursor < lastIndex && this[cursor].isWhitespace()) cursor++
+        normalized.append(substring(valueSpacingStart, cursor))
+        if (cursor >= lastIndex) continue
+
+        val quote = this[cursor].takeIf { it == '\'' || it == '"' }
+        if (quote != null) {
+            val valueStart = cursor
+            cursor++
+            while (cursor < lastIndex && this[cursor] != quote) cursor++
+            if (cursor < lastIndex) cursor++
+            normalized.append(substring(valueStart, cursor))
+        } else {
+            val valueStart = cursor
+            while (cursor < lastIndex && !this[cursor].isWhitespace()) cursor++
+            normalized.append(substring(valueStart, cursor))
+        }
+    }
+    normalized.append('>')
+    return EpubXhtmlCompatibilityResult(normalized.toString(), repairedAttributes)
+}
+
+private fun Char.isXmlNameStart(): Boolean =
+    this == ':' || this == '_' || isLetter()
+
+private fun Char.isXmlNamePart(): Boolean =
+    isXmlNameStart() || this == '-' || this == '.' || isDigit()
+
+private val HTML_FILE_EXTENSIONS = setOf("htm", "html", "xht", "xhtml")
+private val UTF_8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+private val UTF_16_BE_BOM = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
+private val UTF_16_LE_BOM = byteArrayOf(0xFF.toByte(), 0xFE.toByte())

--- a/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
+++ b/app/src/main/java/koharia/epub/service/EpubXhtmlCompatibility.kt
@@ -134,6 +134,22 @@ internal fun String.normalizeEpubXhtmlForCompatibility(): EpubXhtmlCompatibility
             val result = markup.normalizeStartTagAttributes()
             normalized.append(result.content)
             repairedAttributes += result.repairedAttributes
+
+            val rawTextElement = markup.startTagName()
+                ?.lowercase()
+                ?.takeIf(RAW_TEXT_ELEMENT_NAMES::contains)
+            val contentStart = tagEnd + 1
+            if (rawTextElement != null && !markup.isSelfClosingStartTag()) {
+                val rawTextEnd = findRawTextEndTag(rawTextElement, contentStart)
+                if (rawTextEnd < 0) {
+                    normalized.append(substring(contentStart))
+                    cursor = length
+                    continue
+                }
+                normalized.append(substring(contentStart, rawTextEnd))
+                cursor = rawTextEnd
+                continue
+            }
         } else {
             normalized.append(markup)
         }
@@ -141,6 +157,27 @@ internal fun String.normalizeEpubXhtmlForCompatibility(): EpubXhtmlCompatibility
     }
     return EpubXhtmlCompatibilityResult(normalized.toString(), repairedAttributes)
 }
+
+private fun String.findRawTextEndTag(elementName: String, start: Int): Int {
+    val closingPrefix = "</$elementName"
+    var candidate = indexOf(closingPrefix, startIndex = start, ignoreCase = true)
+    while (candidate >= 0) {
+        val boundary = getOrNull(candidate + closingPrefix.length)
+        if (boundary == null || boundary.isWhitespace() || boundary == '>') return candidate
+        candidate = indexOf(closingPrefix, startIndex = candidate + closingPrefix.length, ignoreCase = true)
+    }
+    return -1
+}
+
+private fun String.startTagName(): String? {
+    if (length < 3 || first() != '<' || !this[1].isXmlNameStart()) return null
+    var end = 2
+    while (end < lastIndex && this[end].isXmlNamePart()) end++
+    return substring(1, end)
+}
+
+private fun String.isSelfClosingStartTag(): Boolean =
+    dropLast(1).trimEnd().endsWith('/')
 
 private fun String.findMarkupEnd(tagStart: Int): Int {
     return when {
@@ -248,6 +285,7 @@ private fun Char.isXmlNamePart(): Boolean =
     isXmlNameStart() || this == '-' || this == '.' || isDigit()
 
 private val HTML_FILE_EXTENSIONS = setOf("htm", "html", "xht", "xhtml")
+private val RAW_TEXT_ELEMENT_NAMES = setOf("script", "style")
 private val UTF_8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
 private val UTF_16_BE_BOM = byteArrayOf(0xFE.toByte(), 0xFF.toByte())
 private val UTF_16_LE_BOM = byteArrayOf(0xFF.toByte(), 0xFE.toByte())

--- a/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaEpubPublicationService.kt
@@ -84,7 +84,11 @@ class KomgaEpubPublicationService(
             resource = manifestResource,
         )
 
-        val openedPublication = publicationOpener.open(manifestAsset, allowUserInteraction = false)
+        val openedPublication = publicationOpener.open(
+            manifestAsset,
+            allowUserInteraction = false,
+            onCreatePublication = { installEpubXhtmlCompatibility() },
+        )
             .getOrElse {
                 manifestAsset.close()
                 throw IllegalStateException(it.message)

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -4,6 +4,7 @@ import koharia.epub.cache.EpubCacheManager
 import koharia.epub.injectEpubParagraphIndentStyle
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -123,18 +124,20 @@ private class EpubResourceCacheHttpClient(
             val bytes = response.body.use { it.readBytes() }
             if (persistCache) {
                 prefetchScope.launch {
-                    cacheManager.putResource(
-                        sourceId = sourceId,
-                        publicationKey = publicationKey,
-                        url = request.url.toString(),
-                        mediaType = response.response.mediaType?.toString(),
-                        bytes = bytes,
-                    )
-                    if (response.response.mediaType?.isHtml == true || isHtmlUrl(request.url.toString())) {
-                        prefetchDependencies(
-                            baseUrl = response.response.url.toString(),
-                            content = bytes.toString(Charsets.UTF_8),
+                    prefetchSafely(request.url.toString()) {
+                        cacheManager.putResource(
+                            sourceId = sourceId,
+                            publicationKey = publicationKey,
+                            url = request.url.toString(),
+                            mediaType = response.response.mediaType?.toString(),
+                            bytes = bytes,
                         )
+                        if (response.response.mediaType?.isHtml == true || isHtmlUrl(request.url.toString())) {
+                            prefetchDependencies(
+                                baseUrl = response.response.url.toString(),
+                                content = bytes.toString(Charsets.UTF_8),
+                            )
+                        }
                     }
                 }
             }
@@ -175,34 +178,51 @@ private class EpubResourceCacheHttpClient(
         if (!visited.add(resolved)) return
         val absoluteUrl = AbsoluteUrl(resolved) ?: return
         cacheManager.getResource(sourceId, publicationKey, resolved)?.let { return }
-        delegate.stream(HttpRequest(absoluteUrl)).map { response ->
-            if (response.response.statusCode != HttpStatus(200) ||
-                response.response.contentLength?.let { it > EpubCacheManager.MAX_RESOURCE_BYTES } == true
-            ) {
-                response.body.close()
-                return@map
+        prefetchSafely(resolved) {
+            delegate.stream(HttpRequest(absoluteUrl)).map { response ->
+                if (response.response.statusCode != HttpStatus(200) ||
+                    response.response.contentLength?.let { it > EpubCacheManager.MAX_RESOURCE_BYTES } == true
+                ) {
+                    response.body.close()
+                    return@map
+                }
+                val bytes = response.body.use { it.readBytes() }
+                cacheManager.putResource(
+                    sourceId = sourceId,
+                    publicationKey = publicationKey,
+                    url = resolved,
+                    mediaType = response.response.mediaType?.toString(),
+                    bytes = bytes,
+                )
+                if (parseCssDependencies &&
+                    (
+                        response.response.mediaType?.toString()?.startsWith("text/css") == true ||
+                            resolved.substringBefore('?').endsWith(".css", ignoreCase = true)
+                        )
+                ) {
+                    cssDependency.findAll(bytes.toString(Charsets.UTF_8))
+                        .map { match -> match.groupValues[2] }
+                        .filter(::isFetchableReference)
+                        .take(MAX_PREFETCH_DEPENDENCIES)
+                        .forEach { cssReference ->
+                            prefetchDependency(resolved, cssReference, visited, parseCssDependencies = false)
+                        }
+                }
             }
-            val bytes = response.body.use { it.readBytes() }
-            cacheManager.putResource(
-                sourceId = sourceId,
-                publicationKey = publicationKey,
-                url = resolved,
-                mediaType = response.response.mediaType?.toString(),
-                bytes = bytes,
-            )
-            if (parseCssDependencies &&
-                (
-                    response.response.mediaType?.toString()?.startsWith("text/css") == true ||
-                        resolved.substringBefore('?').endsWith(".css", ignoreCase = true)
-                    )
-            ) {
-                cssDependency.findAll(bytes.toString(Charsets.UTF_8))
-                    .map { match -> match.groupValues[2] }
-                    .filter(::isFetchableReference)
-                    .take(MAX_PREFETCH_DEPENDENCIES)
-                    .forEach { cssReference ->
-                        prefetchDependency(resolved, cssReference, visited, parseCssDependencies = false)
-                    }
+        }
+    }
+
+    private suspend fun prefetchSafely(
+        url: String,
+        block: suspend () -> Unit,
+    ) {
+        try {
+            block()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            logcat(LogPriority.WARN, error) {
+                "Failed to prefetch EPUB resource url=${url.substringBefore('?')}"
             }
         }
     }

--- a/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
+++ b/app/src/main/java/koharia/epub/service/LocalEpubPublicationService.kt
@@ -41,7 +41,11 @@ class LocalEpubPublicationService(
 
         val asset = assetRetriever.retrieve(url, MediaType.EPUB)
             .getOrElse { throw IllegalStateException(it.message) }
-        val openedPublication = publicationOpener.open(asset, allowUserInteraction = false)
+        val openedPublication = publicationOpener.open(
+            asset,
+            allowUserInteraction = false,
+            onCreatePublication = { installEpubXhtmlCompatibility() },
+        )
             .getOrElse {
                 asset.close()
                 throw IllegalStateException(it.message)

--- a/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
+++ b/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
@@ -13,19 +13,26 @@ class EpubPositionsController(
     initialPositions: List<Locator> = emptyList(),
 ) : PositionsService {
     private val refreshMutex = Mutex()
+    private val initialPositionGroups = initialPositions.groupForReadingOrder()
 
     @Volatile
-    private var current: List<List<Locator>> = initialPositions
-        .groupForReadingOrder()
+    private var current: List<List<Locator>> = initialPositionGroups
         .takeIf { groups -> groups.flatten().isNotEmpty() }
         ?: fallbackPositions()
+
+    @Volatile
+    var hasAuthoritativePositions: Boolean = initialPositionGroups.flatten().isNotEmpty()
+        private set
 
     override suspend fun positionsByReadingOrder(): List<List<Locator>> = current
 
     suspend fun refresh(): List<Locator> = refreshMutex.withLock {
         val refreshed = delegate?.positionsByReadingOrder()
             ?.takeIf { groups -> groups.flatten().isNotEmpty() }
-        if (refreshed != null) current = refreshed
+        if (refreshed != null) {
+            current = refreshed
+            hasAuthoritativePositions = true
+        }
         current.flatten()
     }
 

--- a/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
+++ b/app/src/main/java/koharia/epub/session/EpubPositionsController.kt
@@ -1,5 +1,6 @@
 package koharia.epub.session
 
+import koharia.epub.isSameEpubResource
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.readium.r2.shared.publication.Link
@@ -44,12 +45,8 @@ class EpubPositionsController(
 
     private fun List<Locator>.groupForReadingOrder(): List<List<Locator>> =
         readingOrder.map { link ->
-            val linkHref = link.href.toString().resourceKey()
             filter { locator ->
-                val locatorHref = locator.href.toString().resourceKey()
-                linkHref == locatorHref ||
-                    linkHref.endsWith("/$locatorHref") ||
-                    locatorHref.endsWith("/$linkHref")
+                link.href.toString().isSameEpubResource(locator.href.toString())
             }
         }
 
@@ -70,9 +67,4 @@ class EpubPositionsController(
             )
         }
     }
-
-    private fun String.resourceKey(): String =
-        substringBefore('#')
-            .substringBefore('?')
-            .trimStart('/')
 }

--- a/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
+++ b/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
@@ -1,0 +1,47 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubDocumentPreparationTest {
+
+    @Test
+    fun `document preparation combines paragraph and image policies`() {
+        val script = buildEpubDocumentPreparationScript(
+            paragraphIndentOverrideEnabled = true,
+            preserveImageColors = true,
+            parentColorsInverted = true,
+        )
+
+        assertTrue(script.contains(EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE))
+        assertTrue(script.contains("filter: invert(100%) !important"))
+        assertTrue(script.contains("return 'prepared'"))
+    }
+
+    @Test
+    fun `disabled paragraph override removes prior document attributes`() {
+        val script = buildEpubDocumentPreparationScript(
+            paragraphIndentOverrideEnabled = false,
+            preserveImageColors = false,
+            parentColorsInverted = false,
+        )
+
+        assertTrue(script.contains("paragraph.removeAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE')"))
+        assertFalse(script.contains("paragraph.setAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE'"))
+    }
+
+    @Test
+    fun `paragraph policies ignore standalone svg documents`() {
+        assertTrue(
+            APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT.contains(
+                "document.documentElement.localName.toLowerCase() !== 'html'",
+            ),
+        )
+        assertTrue(
+            REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT.contains(
+                "document.documentElement.localName.toLowerCase() !== 'html'",
+            ),
+        )
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
+++ b/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
@@ -42,6 +42,44 @@ class EpubLocatorProgressStabilityTest {
     }
 
     @Test
+    fun `resources with the same filename in different directories stay distinct`() {
+        val restored = locator("chapter.xhtml", 0.25, 21, 0.058)
+        val provisional = locator("appendix/chapter.xhtml", 0.25, 27, 0.35)
+
+        val stable = provisional.preserveProgressMetricsFrom(restored)
+
+        assertSame(provisional, stable)
+    }
+
+    @Test
+    fun `known served resource prefix maps to publication resource`() {
+        val restored = locator("item/chapter.xhtml", 0.25, 21, 0.058)
+        val served = locator(
+            "https://example.invalid/books/1/resource/item/chapter.xhtml",
+            0.25,
+            13,
+            0.32,
+        )
+
+        val stable = served.preserveProgressMetricsFrom(restored)
+
+        assertEquals(21, stable.locations.position)
+        assertEquals(0.058, stable.locations.totalProgression)
+    }
+
+    @Test
+    fun `authoritative positions replace provisional global metrics`() {
+        val provisional = locator("item/chapter.xhtml", 0.5, 99, 0.99)
+        val authoritative = locator("item/chapter.xhtml", 0.5, 11, 0.2)
+
+        val aligned = provisional.alignToEpubPositions(listOf(authoritative))
+
+        assertEquals(0.5, aligned.locations.progression)
+        assertEquals(11, aligned.locations.position)
+        assertEquals(0.2, aligned.locations.totalProgression)
+    }
+
+    @Test
     fun `locator without previous progress is not rewritten`() {
         val provisional = locator("item/xhtml/p-003.xhtml", 0.25, 13, 0.324)
 

--- a/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
+++ b/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
@@ -1,5 +1,7 @@
 package koharia.epub
 
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
@@ -93,13 +95,17 @@ class EpubLocatorProgressStabilityTest {
         progression: Double,
         position: Int,
         totalProgression: Double,
-    ): Locator = Locator(
-        href = checkNotNull(Url(href)),
-        mediaType = MediaType.XHTML,
-        locations = Locator.Locations(
-            progression = progression,
-            position = position,
-            totalProgression = totalProgression,
-        ),
-    )
+    ): Locator {
+        val url = mockk<Url>()
+        every { url.toString() } returns href
+        return Locator(
+            href = url,
+            mediaType = MediaType.XHTML,
+            locations = Locator.Locations(
+                progression = progression,
+                position = position,
+                totalProgression = totalProgression,
+            ),
+        )
+    }
 }

--- a/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
+++ b/app/src/test/java/koharia/epub/EpubLocatorProgressStabilityTest.kt
@@ -1,0 +1,67 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+
+class EpubLocatorProgressStabilityTest {
+
+    @Test
+    fun `provisional locator keeps restored progress metrics for same resource`() {
+        val restored = locator(
+            href = "item/xhtml/p-003.xhtml",
+            progression = 0.25,
+            position = 21,
+            totalProgression = 0.05865102639296188,
+        )
+        val provisional = locator(
+            href = "https://readium_package/item/xhtml/p-003.xhtml",
+            progression = 0.25,
+            position = 13,
+            totalProgression = 0.32432432432432434,
+        )
+
+        val stable = provisional.preserveProgressMetricsFrom(restored)
+
+        assertEquals(0.25, stable.locations.progression)
+        assertEquals(21, stable.locations.position)
+        assertEquals(0.05865102639296188, stable.locations.totalProgression)
+    }
+
+    @Test
+    fun `locator for another resource is not rewritten`() {
+        val restored = locator("item/xhtml/p-003.xhtml", 0.25, 21, 0.058)
+        val provisional = locator("item/xhtml/p-004.xhtml", 0.0, 27, 0.35)
+
+        val stable = provisional.preserveProgressMetricsFrom(restored)
+
+        assertSame(provisional, stable)
+    }
+
+    @Test
+    fun `locator without previous progress is not rewritten`() {
+        val provisional = locator("item/xhtml/p-003.xhtml", 0.25, 13, 0.324)
+
+        val stable = provisional.preserveProgressMetricsFrom(null)
+
+        assertSame(provisional, stable)
+    }
+
+    private fun locator(
+        href: String,
+        progression: Double,
+        position: Int,
+        totalProgression: Double,
+    ): Locator = Locator(
+        href = checkNotNull(Url(href)),
+        mediaType = MediaType.XHTML,
+        locations = Locator.Locations(
+            progression = progression,
+            position = position,
+            totalProgression = totalProgression,
+        ),
+    )
+}

--- a/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
+++ b/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
@@ -1,5 +1,7 @@
 package koharia.epub.progress
 
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
@@ -102,13 +104,17 @@ class KomgaProgressionLocatorTest {
         href: String,
         progression: Double,
         position: Int,
-    ): Locator = Locator(
-        href = checkNotNull(Url(href)),
-        mediaType = MediaType.XHTML,
-        locations = Locator.Locations(
-            progression = progression,
-            position = position,
-            totalProgression = position / 100.0,
-        ),
-    )
+    ): Locator {
+        val url = mockk<Url>()
+        every { url.toString() } returns href
+        return Locator(
+            href = url,
+            mediaType = MediaType.XHTML,
+            locations = Locator.Locations(
+                progression = progression,
+                position = position,
+                totalProgression = position / 100.0,
+            ),
+        )
+    }
 }

--- a/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
+++ b/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
@@ -67,6 +67,28 @@ class KomgaProgressionLocatorTest {
     }
 
     @Test
+    fun `matching progression still replaces stale global position fields`() {
+        val locator = locator("item/chapter.xhtml", progression = 0.5, position = 99)
+        val serverPosition = locator("item/chapter.xhtml", progression = 0.5, position = 11)
+
+        val aligned = locator.alignToKomgaPositions(listOf(serverPosition))
+
+        assertEquals(0.5, aligned.locations.progression)
+        assertEquals(11, aligned.locations.position)
+        assertEquals(0.11, aligned.locations.totalProgression)
+    }
+
+    @Test
+    fun `same filename in another directory is not a matching resource`() {
+        val locator = locator("chapter.xhtml", progression = 0.5, position = 10)
+        val positions = listOf(locator("appendix/chapter.xhtml", progression = 0.5, position = 20))
+
+        val aligned = locator.alignToKomgaPositions(positions)
+
+        assertSame(locator, aligned)
+    }
+
+    @Test
     fun `locator without matching resource remains unchanged`() {
         val locator = locator("item/chapter.xhtml", progression = 1.0, position = 14)
         val positions = listOf(locator("item/other.xhtml", progression = 0.5, position = 11))

--- a/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
+++ b/app/src/test/java/koharia/epub/progress/KomgaProgressionLocatorTest.kt
@@ -1,0 +1,92 @@
+package koharia.epub.progress
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+
+class KomgaProgressionLocatorTest {
+
+    @Test
+    fun `resource end is aligned to last server position`() {
+        val locator = locator("item/chapter.xhtml", progression = 1.0, position = 14)
+        val positions = listOf(
+            locator("item/chapter.xhtml", progression = 0.0, position = 10),
+            locator("item/chapter.xhtml", progression = 0.48, position = 11),
+            locator("item/chapter.xhtml", progression = 0.92, position = 12),
+            locator("item/next.xhtml", progression = 0.0, position = 13),
+        )
+
+        val aligned = locator.alignToKomgaPositions(positions)
+
+        assertEquals(0.92, aligned.locations.progression)
+        assertEquals(12, aligned.locations.position)
+    }
+
+    @Test
+    fun `arbitrary progression uses preceding server position`() {
+        val locator = locator("item/chapter.xhtml", progression = 0.7, position = 12)
+        val positions = listOf(
+            locator("item/chapter.xhtml", progression = 0.2, position = 10),
+            locator("item/chapter.xhtml", progression = 0.6, position = 11),
+            locator("item/chapter.xhtml", progression = 0.8, position = 12),
+        )
+
+        val aligned = locator.alignToKomgaPositions(positions)
+
+        assertEquals(0.6, aligned.locations.progression)
+        assertEquals(11, aligned.locations.position)
+    }
+
+    @Test
+    fun `href aliases with query and fragment share positions`() {
+        val locator = locator(
+            "https://readium_package/item/chapter.xhtml?cache=1#section",
+            progression = 0.75,
+            position = 12,
+        )
+        val positions = listOf(
+            locator("item/chapter.xhtml", progression = 0.5, position = 11),
+        )
+
+        val aligned = locator.alignToKomgaPositions(positions)
+
+        assertEquals(0.5, aligned.locations.progression)
+        assertEquals(11, aligned.locations.position)
+    }
+
+    @Test
+    fun `exact server position remains unchanged`() {
+        val locator = locator("item/chapter.xhtml", progression = 0.5, position = 11)
+
+        val aligned = locator.alignToKomgaPositions(listOf(locator))
+
+        assertSame(locator, aligned)
+    }
+
+    @Test
+    fun `locator without matching resource remains unchanged`() {
+        val locator = locator("item/chapter.xhtml", progression = 1.0, position = 14)
+        val positions = listOf(locator("item/other.xhtml", progression = 0.5, position = 11))
+
+        val aligned = locator.alignToKomgaPositions(positions)
+
+        assertSame(locator, aligned)
+    }
+
+    private fun locator(
+        href: String,
+        progression: Double,
+        position: Int,
+    ): Locator = Locator(
+        href = checkNotNull(Url(href)),
+        mediaType = MediaType.XHTML,
+        locations = Locator.Locations(
+            progression = progression,
+            position = position,
+            totalProgression = position / 100.0,
+        ),
+    )
+}

--- a/app/src/test/java/koharia/epub/service/EpubXhtmlCompatibilityTest.kt
+++ b/app/src/test/java/koharia/epub/service/EpubXhtmlCompatibilityTest.kt
@@ -1,0 +1,89 @@
+package koharia.epub.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.readium.r2.shared.publication.Manifest
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.data.EmptyContainer
+import org.readium.r2.shared.util.resource.Resource
+
+class EpubXhtmlCompatibilityTest {
+
+    @Test
+    fun `publication compatibility installation is idempotent`() {
+        val builder = Publication.Builder(
+            manifest = Manifest(metadata = Metadata()),
+            container = EmptyContainer<Resource>(),
+        )
+
+        builder.installEpubXhtmlCompatibility()
+        val installedContainer = builder.container
+        builder.installEpubXhtmlCompatibility()
+
+        assertSame(installedContainer, builder.container)
+    }
+
+    @Test
+    fun `valueless image alt is repaired for strict xhtml parsing`() {
+        val source = "<p><img src=\"../image/p019.jpg\" class=\"fit\" alt /></p>"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(
+            "<p><img src=\"../image/p019.jpg\" class=\"fit\" alt=\"\" /></p>",
+            result.content,
+        )
+        assertEquals(1, result.repairedAttributes)
+    }
+
+    @Test
+    fun `multiple html boolean attributes are repaired`() {
+        val source = "<input disabled checked data-ready />"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(
+            "<input disabled=\"\" checked=\"\" data-ready=\"\" />",
+            result.content,
+        )
+        assertEquals(3, result.repairedAttributes)
+    }
+
+    @Test
+    fun `valid quoted and namespaced attributes are preserved`() {
+        val source = "<html xmlns=\"http://www.w3.org/1999/xhtml\" epub:type=\"chapter\"><p>Text</p></html>"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(source, result.content)
+        assertEquals(0, result.repairedAttributes)
+    }
+
+    @Test
+    fun `attribute shaped text inside quotes comments and cdata is not changed`() {
+        val source =
+            "<p title=\"keep alt /> here\">Text</p>" +
+                "<!-- <img alt /> -->" +
+                "<![CDATA[<img alt />]]>"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(source, result.content)
+        assertEquals(0, result.repairedAttributes)
+    }
+
+    @Test
+    fun `processing instructions and doctypes are preserved`() {
+        val source =
+            "<?xml version=\"1.0\"?>" +
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" \"xhtml11.dtd\">" +
+                "<html><body /></html>"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(source, result.content)
+        assertEquals(0, result.repairedAttributes)
+    }
+}

--- a/app/src/test/java/koharia/epub/service/EpubXhtmlCompatibilityTest.kt
+++ b/app/src/test/java/koharia/epub/service/EpubXhtmlCompatibilityTest.kt
@@ -86,4 +86,22 @@ class EpubXhtmlCompatibilityTest {
         assertEquals(source, result.content)
         assertEquals(0, result.repairedAttributes)
     }
+
+    @Test
+    fun `tag shaped text inside script and style is not changed`() {
+        val source =
+            "<script>const template = '<input disabled>';</script>" +
+                "<style>.example::before { content: '<img alt>'; }</style>" +
+                "<input disabled>"
+
+        val result = source.normalizeEpubXhtmlForCompatibility()
+
+        assertEquals(
+            "<script>const template = '<input disabled>';</script>" +
+                "<style>.example::before { content: '<img alt>'; }</style>" +
+                "<input disabled=\"\">",
+            result.content,
+        )
+        assertEquals(1, result.repairedAttributes)
+    }
 }

--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -39,6 +39,11 @@ class NetworkHelper(
         if (preferences.verboseLogging.get()) {
             val httpLoggingInterceptor = HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.HEADERS
+                redactHeader("Authorization")
+                redactHeader("Cookie")
+                redactHeader("Set-Cookie")
+                redactHeader("X-API-Key")
+                redactHeader("X-Komga-Api-Key")
             }
             builder.addNetworkInterceptor(httpLoggingInterceptor)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 aboutLibraries = "14.2.0"
 android-desugar = "2.1.5"
-android-gradle = "9.3.0"
+android-gradle = "9.3.1"
 androidx-activity-compose = "1.13.0"
 androidx-annotation = "1.10.0"
 androidx-appCompat = "1.7.1"


### PR DESCRIPTION
## 中文

### 变更内容

- 为本地和 Komga EPUB 安装幂等的 XHTML 兼容容器，修复无值属性等常见非标准 XHTML，避免严格 XML 解析失败。
- 将段落缩进与图片颜色策略合并到首帧文档准备流程，减少翻页后的样式变化和图片反色闪烁。
- 隔离 EPUB 资源预取异常，并让正常的协程取消不再被误报为图片交互安装失败。
- 上传 Komga 阅读进度前对齐服务端 positions，处理资源末尾 `progression=1.0` 导致的 HTTP 400。
- 区分临时 fallback positions 与权威 positions，避免刚进入本地 EPUB 时将正确进度错误改写为 reading-order 索引比例。
- 仅在真实 positions 就绪后同步云端进度，同时保留退出阅读器时的最终进度同步。
- 为详细网络日志中的认证、API Key 和 Cookie Header 增加脱敏。
- 将 Android Gradle Plugin 从 9.3.0 更新至 9.3.1。
- 增加 XHTML 兼容、文档准备、Locator 稳定性和 Komga progression 对齐测试。

### 根因与影响

Readium 3.3.0 不会执行原先使用的构造器级 Publication 回调，导致兼容容器没有安装；方法级回调还会重复调用，需要幂等包装。另一方面，本地缓存 EPUB 在真实 positions 刷新前会使用“每个 reading-order 资源一个位置”的 fallback，Navigator 因此可能把约 6% 的恢复进度临时改写为约 32%，并进一步保存或上传错误值。

本次修改让常见非标准 EPUB 能正常解析，稳定初始样式和图片策略，并防止启动阶段与资源边界的阅读进度跳变或同步失败。

### 检查

- 已通过：`git diff --cached --check`（提交前）
- 未运行 Gradle；按项目约定留给后续验证：
  - `.\gradlew.bat spotlessApply`
  - `.\gradlew.bat spotlessCheck`
  - `.\gradlew.bat :app:testDebugUnitTest --tests "koharia.epub.EpubLocatorProgressStabilityTest" --tests "koharia.epub.progress.KomgaProgressionLocatorTest" --tests "koharia.epub.service.EpubXhtmlCompatibilityTest"`
  - `.\gradlew.bat :app:compileDebugKotlin`

## English

### Changes

- Install an idempotent XHTML compatibility container for both local and Komga EPUBs to repair common malformed XHTML such as valueless attributes.
- Combine paragraph indentation and image color handling into the first-frame document preparation path to reduce layout changes and image inversion flashes after navigation.
- Isolate EPUB prefetch failures and stop reporting normal coroutine cancellation as an image-interaction installation failure.
- Align uploaded Komga locators to server positions, including resource-end `progression=1.0` values that previously returned HTTP 400.
- Distinguish provisional fallback positions from authoritative positions so opening a cached local EPUB cannot replace restored progress with a reading-order index ratio.
- Delay cloud synchronization until authoritative positions are available while preserving final synchronization when leaving the reader.
- Redact authentication, API key, and cookie headers from verbose network logs.
- Update Android Gradle Plugin from 9.3.0 to 9.3.1.
- Add coverage for XHTML repair, document preparation, locator stability, and Komga progression alignment.

### Root cause and impact

Readium 3.3.0 does not invoke the constructor-level Publication callback that previously installed the compatibility layer, while its method-level callback can run more than once and therefore requires idempotent wrapping. Cached local EPUBs also expose one-position-per-resource fallback positions before authoritative positions are refreshed, allowing Navigator to temporarily turn a restored progress near 6% into roughly 32% and persist or upload the incorrect value.

These changes improve malformed EPUB compatibility, stabilize first-frame styling and image handling, and prevent progress jumps or synchronization failures during startup and resource-boundary navigation.

### Validation

- Passed: `git diff --cached --check` before commit.
- Gradle was not run; suggested follow-up commands are listed in the Chinese section above.

Fixes #51