### PR TITLE
优化 EPUB 文本对齐与作品元数据换行 / Improve EPUB text alignment and metadata wrapping

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/components/MangaInfoHeader.kt
@@ -601,22 +601,14 @@ private fun ColumnScope.KomgaMetadataRow(
 
     if (infoParts.isEmpty()) return
 
-    Row(
-        modifier = Modifier.secondaryItemAlpha(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        ProvideTextStyle(MaterialTheme.typography.bodySmall) {
-            infoParts.forEachIndexed { index, part ->
-                if (index > 0) DotSeparatorText()
-                Text(
-                    text = part,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1,
-                    textAlign = textAlign,
-                )
-            }
-        }
-    }
+    Text(
+        text = infoParts.joinToString(" • "),
+        modifier = Modifier
+            .fillMaxWidth()
+            .secondaryItemAlpha(),
+        style = MaterialTheme.typography.bodySmall,
+        textAlign = textAlign,
+    )
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsReaderScreen.kt
@@ -260,6 +260,27 @@ object SettingsReaderScreen : SearchableSettings {
                 )
                 add(
                     Preference.PreferenceItem.ListPreference(
+                        preference = epubLayoutPreferences.textAlignment,
+                        entries = persistentMapOf(
+                            EpubLayoutPreferences.TextAlignment.START to
+                                stringResource(MR.strings.pref_epub_text_align_start),
+                            EpubLayoutPreferences.TextAlignment.LEFT to
+                                stringResource(MR.strings.pref_epub_text_align_left),
+                            EpubLayoutPreferences.TextAlignment.RIGHT to
+                                stringResource(MR.strings.pref_epub_text_align_right),
+                            EpubLayoutPreferences.TextAlignment.JUSTIFY to
+                                stringResource(MR.strings.pref_epub_text_align_justify),
+                        ),
+                        title = stringResource(MR.strings.pref_epub_text_alignment),
+                        enabled = !publisherStyles,
+                        onValueChanged = { alignment ->
+                            epubLayoutPreferences.applyTextAlignment(alignment)
+                            true
+                        },
+                    ),
+                )
+                add(
+                    Preference.PreferenceItem.ListPreference(
                         preference = epubLayoutPreferences.spacingMode,
                         entries = persistentMapOf(
                             EpubLayoutPreferences.SpacingMode.COMPACT to

--- a/app/src/main/java/koharia/epub/EpubChapterBreakOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubChapterBreakOverride.kt
@@ -1,0 +1,87 @@
+package koharia.epub
+
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import org.readium.r2.shared.publication.Link
+
+internal const val EPUB_CHAPTER_BREAK_STYLE_ID = "koharia-chapter-break"
+internal const val EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE = "data-koharia-chapter-break-target"
+
+internal fun List<Link>.flattenEpubTocHrefs(): List<String> =
+    flatMap { link ->
+        buildList {
+            add(link.href.toString())
+            addAll(link.children.flattenEpubTocHrefs())
+        }
+    }.distinct()
+
+internal fun buildEpubChapterBreakOverrideScript(
+    tocHrefs: List<String>,
+    enabled: Boolean,
+): String {
+    val resetScript = """
+        var style = document.getElementById('$EPUB_CHAPTER_BREAK_STYLE_ID');
+        if (style) style.remove();
+        Array.from(document.querySelectorAll('[$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE]')).forEach(function(element) {
+            element.removeAttribute('$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE');
+        });
+    """.trimIndent()
+    if (!enabled || tocHrefs.isEmpty()) {
+        return """
+            (function() {
+                if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
+                $resetScript
+                return true;
+            })()
+        """.trimIndent()
+    }
+
+    val tocHrefsJson = buildJsonArray {
+        tocHrefs.forEach { add(JsonPrimitive(it)) }
+    }
+    return """
+        (function() {
+            if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
+            $resetScript
+            style = document.createElementNS('http://www.w3.org/1999/xhtml', 'style');
+            style.id = '$EPUB_CHAPTER_BREAK_STYLE_ID';
+            style.setAttribute('type', 'text/css');
+            style.textContent =
+                'html:root:root:root [$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE] { ' +
+                '-webkit-column-break-before: always !important; break-before: column !important; }';
+            (document.head || document.documentElement).appendChild(style);
+
+            var tocHrefs = $tocHrefsJson;
+            function decodeComponent(value) {
+                try { return decodeURIComponent(value); } catch (_) { return value; }
+            }
+            function normalizeResource(value) {
+                return decodeComponent(String(value || '').split('#')[0].split('?')[0])
+                    .replace(/\\/g, '/')
+                    .replace(/^\/+/, '');
+            }
+            function isSameResource(first, second) {
+                if (!first || !second) return false;
+                return first === second || first.endsWith('/' + second) || second.endsWith('/' + first);
+            }
+            var currentResource = normalizeResource(location.pathname);
+            var headingSelector = 'h1, h2, h3, h4, h5, h6, [role="heading"]';
+            var blockSelector = headingSelector + ', section, article, header, div, p, li, dt, dd';
+            tocHrefs.forEach(function(href) {
+                var hashIndex = href.indexOf('#');
+                if (hashIndex < 0 || !isSameResource(currentResource, normalizeResource(href))) return;
+                var fragment = decodeComponent(href.slice(hashIndex + 1));
+                if (!fragment) return;
+                var target = document.getElementById(fragment) || document.getElementsByName(fragment)[0];
+                if (!target || target === document.body || target === document.documentElement) return;
+                var nextHeading = target.nextElementSibling && target.nextElementSibling.matches(headingSelector)
+                    ? target.nextElementSibling
+                    : null;
+                var marker = nextHeading || target.closest(blockSelector) || target;
+                if (marker === document.body || marker === document.documentElement) return;
+                marker.setAttribute('$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE', '');
+            });
+            return true;
+        })()
+    """.trimIndent()
+}

--- a/app/src/main/java/koharia/epub/EpubPaginationModels.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationModels.kt
@@ -26,6 +26,7 @@ internal data class EpubPaginationLayoutSnapshot(
     val pageMargins: Float,
     val verticalMargins: Float,
     val fontFamily: String,
+    val textAlignment: String,
     val publisherStyles: Boolean,
     val viewportWidthPx: Int,
     val viewportHeightPx: Int,
@@ -46,6 +47,7 @@ internal data class EpubPaginationLayoutSnapshot(
             put("pageMargins", pageMargins.toDouble())
             put("verticalMargins", verticalMargins.toDouble())
             put("fontFamily", fontFamily)
+            put("textAlignment", textAlignment)
             put("publisherStyles", publisherStyles)
             put("viewportWidthPx", viewportWidthPx)
             put("viewportHeightPx", viewportHeightPx)
@@ -72,6 +74,7 @@ internal data class EpubPaginationLayoutSnapshot(
                 pageMargins = preferences.pageMargins.get(),
                 verticalMargins = preferences.verticalMargins.get(),
                 fontFamily = preferences.fontFamily.get().name,
+                textAlignment = preferences.textAlignment.get().name,
                 publisherStyles = preferences.publisherStyles.get(),
                 viewportWidthPx = viewport.widthPx,
                 viewportHeightPx = viewport.heightPx,
@@ -122,5 +125,5 @@ private fun String.sha256(): String {
         .joinToString("") { byte -> "%02x".format(byte) }
 }
 
-private const val PAGINATION_ALGORITHM_VERSION = 5
+private const val PAGINATION_ALGORITHM_VERSION = 6
 private const val READIUM_VERSION = "3.3.0"

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -45,6 +45,13 @@ internal class EpubPaginationScannerFragment : Fragment() {
     private var scanStarted = false
     private var awaitingMeasuredCallback = false
     private var readinessJob: Job? = null
+    private val tocHrefs by lazy {
+        sessionRepository.getForPagination(chapterId)
+            ?.publication
+            ?.tableOfContents
+            ?.flattenEpubTocHrefs()
+            .orEmpty()
+    }
     private val beginScanRunnable = Runnable {
         if (!isAdded || view == null || scanStarted) return@Runnable
         beginScan()
@@ -66,9 +73,15 @@ internal class EpubPaginationScannerFragment : Fragment() {
                 recordPageCount(totalPages, locator)
             } else if (readinessJob == null) {
                 readinessJob = viewLifecycleOwner.lifecycleScope.launch {
-                    if (!epubLayoutPreferences.publisherStyles.get()) {
-                        navigatorFragment()?.evaluateJavascript(APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT)
-                    }
+                    val publisherStyles = epubLayoutPreferences.publisherStyles.get()
+                    navigatorFragment()?.evaluateJavascript(
+                        buildEpubLayoutPreparationScript(
+                            paragraphIndentOverrideEnabled = !publisherStyles,
+                            textAlignment = epubLayoutPreferences.textAlignment.get().takeIf { !publisherStyles },
+                            tocHrefs = tocHrefs,
+                            chapterBreaksEnabled = true,
+                        ),
+                    )
                     val ready = awaitStableLayout()
                     readinessJob = null
                     if (!ready) {

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -1,8 +1,13 @@
 package koharia.epub
 
+import koharia.epub.settings.EpubLayoutPreferences
+
 internal const val EPUB_PARAGRAPH_INDENT_STYLE_ID = "koharia-paragraph-indent"
 internal const val EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE = "data-koharia-no-paragraph-indent"
 internal const val EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE = "data-koharia-orphaned-inline-padding"
+internal const val EPUB_TEXT_ALIGNMENT_STYLE_ID = "koharia-text-alignment"
+internal const val EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE = "data-koharia-text-alignment-target"
+internal const val EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE = "data-koharia-right-indent-spacer"
 
 // Readium's paragraph preference targets every <p>. A higher-specificity exception keeps
 // paragraph-shaped headings, signatures and media containers from inheriting body indentation.
@@ -33,10 +38,12 @@ internal const val APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT =
             var textAlign = (computed.textAlign || '').toLowerCase();
             var role = (paragraph.getAttribute('role') || '').toLowerCase();
             var epubType = (paragraph.getAttribute('epub:type') || '').toLowerCase();
+            var className = typeof paragraph.className === 'string' ? paragraph.className : '';
+            var structuralClasses = /(^|[-_ ])(title|subtitle|heading|headline|caption|credit|signature|author|date|center|right)([-_ ]|${'$'})/i;
             var hasOnlyMedia = paragraph.textContent.trim() === '' &&
                 paragraph.querySelector('img, svg, picture, video, audio, figure, table');
             var isStructuralParagraph =
-                textAlign === 'center' || textAlign === 'right' || textAlign === 'end' ||
+                textAlign === 'center' || structuralClasses.test(className) ||
                 role === 'heading' || epubType.indexOf('title') !== -1 || hasOnlyMedia;
             if (isStructuralParagraph) {
                 paragraph.setAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE', '');
@@ -72,10 +79,114 @@ internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
         return true;
     })()"""
 
-internal fun buildEpubDocumentPreparationScript(
+internal fun buildEpubTextAlignmentOverrideScript(
+    textAlignment: EpubLayoutPreferences.TextAlignment?,
+): String {
+    if (textAlignment == null) {
+        return """
+            (function() {
+                if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
+                var style = document.getElementById('$EPUB_TEXT_ALIGNMENT_STYLE_ID');
+                if (style) style.remove();
+                Array.from(document.querySelectorAll('[$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE]')).forEach(function(element) {
+                    element.removeAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE');
+                    element.removeAttribute('$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE');
+                });
+                return true;
+            })()
+        """.trimIndent()
+    }
+    val alignmentCss = when (textAlignment) {
+        EpubLayoutPreferences.TextAlignment.START ->
+            "text-align: start !important; " +
+                "-webkit-hyphens: none !important; hyphens: none !important;"
+        EpubLayoutPreferences.TextAlignment.LEFT ->
+            "text-align: left !important; " +
+                "-webkit-hyphens: none !important; hyphens: none !important;"
+        EpubLayoutPreferences.TextAlignment.RIGHT ->
+            "text-align: right !important; " +
+                "-webkit-hyphens: none !important; hyphens: none !important;"
+        EpubLayoutPreferences.TextAlignment.JUSTIFY ->
+            "text-align: justify !important; text-justify: auto !important; " +
+                "-webkit-hyphens: auto !important; hyphens: auto !important;"
+    }
+    val rightIndentCss = if (textAlignment == EpubLayoutPreferences.TextAlignment.RIGHT) {
+        " html:root:root:root p[$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE]" +
+            ":not([$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE]) { text-indent: 0 !important; }" +
+            " html:root:root:root p[$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE]" +
+            "[$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE]:not([$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE])::before { " +
+            "content: \"\" !important; float: right !important; " +
+            "width: var(--USER__paraIndent, 2rem) !important; height: 1em !important; " +
+            "pointer-events: none !important; }"
+    } else {
+        ""
+    }
+    return """
+        (function() {
+            if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
+            var style = document.getElementById('$EPUB_TEXT_ALIGNMENT_STYLE_ID');
+            if (style) style.remove();
+            Array.from(document.querySelectorAll('[$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE]')).forEach(function(element) {
+                element.removeAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE');
+                element.removeAttribute('$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE');
+            });
+            style = document.createElementNS('http://www.w3.org/1999/xhtml', 'style');
+            style.id = '$EPUB_TEXT_ALIGNMENT_STYLE_ID';
+            style.setAttribute('type', 'text/css');
+            style.textContent =
+                'html:root:root:root [$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE] { $alignmentCss }' +
+                '$rightIndentCss';
+            (document.head || document.documentElement).appendChild(style);
+
+            var blockTags = /^(p|li|dd|blockquote|div|section)$/;
+            var nestedBlockTags = /^(p|li|dd|blockquote|div|section|article|aside|header|footer|nav|main)$/;
+            var structuralClasses = /(^|[-_ ])(title|subtitle|heading|headline|caption|credit|signature|author|date|center|right)([-_ ]|${'$'})/i;
+            Array.from(document.querySelectorAll('p, li, dd, blockquote, div, section')).forEach(function(element) {
+                var tagName = element.localName.toLowerCase();
+                if (!blockTags.test(tagName)) return;
+                var role = (element.getAttribute('role') || '').toLowerCase();
+                var epubType = (
+                    element.getAttribute('epub:type') ||
+                    element.getAttributeNS('http://www.idpf.org/2007/ops', 'type') ||
+                    ''
+                ).toLowerCase();
+                var className = typeof element.className === 'string' ? element.className : '';
+                var computed = window.getComputedStyle(element);
+                var originalAlignment = (computed.textAlign || '').toLowerCase();
+                var text = (element.textContent || '').trim();
+                var hasOnlyMedia = text === '' && element.querySelector(
+                    'img, svg, picture, video, audio, figure, table, canvas',
+                );
+                var hasNestedBlock = Array.from(element.children).some(function(child) {
+                    return nestedBlockTags.test(child.localName.toLowerCase());
+                });
+                var isStructural =
+                    role === 'heading' ||
+                    epubType.indexOf('title') !== -1 ||
+                    epubType.indexOf('subtitle') !== -1 ||
+                    epubType.indexOf('heading') !== -1 ||
+                    structuralClasses.test(className) ||
+                    originalAlignment === 'center' ||
+                    element.closest('h1, h2, h3, h4, h5, h6, figure, figcaption, table, pre, code, nav');
+                if (!text || hasOnlyMedia || hasNestedBlock || isStructural) return;
+                element.setAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE', '');
+                if (${textAlignment == EpubLayoutPreferences.TextAlignment.RIGHT} && tagName === 'p') {
+                    var beforeContent = window.getComputedStyle(element, '::before').content;
+                    var hasGeneratedBeforeContent =
+                        beforeContent && beforeContent !== 'none' && beforeContent !== 'normal' && beforeContent !== '""';
+                    if (!hasGeneratedBeforeContent) {
+                        element.setAttribute('$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE', '');
+                    }
+                }
+            });
+            return true;
+        })()
+    """.trimIndent()
+}
+
+internal fun buildEpubTypographyPreparationScript(
     paragraphIndentOverrideEnabled: Boolean,
-    preserveImageColors: Boolean,
-    parentColorsInverted: Boolean,
+    textAlignment: EpubLayoutPreferences.TextAlignment?,
 ): String {
     val paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
         APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
@@ -85,6 +196,43 @@ internal fun buildEpubDocumentPreparationScript(
     return """
         (function() {
             $paragraphIndentScript;
+            ${buildEpubTextAlignmentOverrideScript(textAlignment)};
+            return true;
+        })()
+    """.trimIndent()
+}
+
+internal fun buildEpubLayoutPreparationScript(
+    paragraphIndentOverrideEnabled: Boolean,
+    textAlignment: EpubLayoutPreferences.TextAlignment?,
+    tocHrefs: List<String>,
+    chapterBreaksEnabled: Boolean,
+): String =
+    """
+        (function() {
+            ${buildEpubTypographyPreparationScript(paragraphIndentOverrideEnabled, textAlignment)};
+            ${buildEpubChapterBreakOverrideScript(tocHrefs, chapterBreaksEnabled)};
+            return true;
+        })()
+    """.trimIndent()
+
+internal fun buildEpubDocumentPreparationScript(
+    paragraphIndentOverrideEnabled: Boolean,
+    textAlignment: EpubLayoutPreferences.TextAlignment?,
+    tocHrefs: List<String>,
+    chapterBreaksEnabled: Boolean,
+    preserveImageColors: Boolean,
+    parentColorsInverted: Boolean,
+): String {
+    val layoutPreparationScript = buildEpubLayoutPreparationScript(
+        paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
+        textAlignment = textAlignment,
+        tocHrefs = tocHrefs,
+        chapterBreaksEnabled = chapterBreaksEnabled,
+    )
+    return """
+        (function() {
+            $layoutPreparationScript;
             ${buildEpubImageColorPolicyScript(preserveImageColors, parentColorsInverted)};
             return 'prepared';
         })()

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -1114,6 +1114,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             epubLayoutPreferences.pageMargins.changes().map { it as Any },
             epubLayoutPreferences.verticalMargins.changes().map { it as Any },
             epubLayoutPreferences.fontFamily.changes().map { it as Any },
+            epubLayoutPreferences.textAlignment.changes().map { it as Any },
             epubLayoutPreferences.publisherStyles.changes().map { it as Any },
         )
         combine(paginationAffectingChanges) { values -> values.toList() }

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -94,12 +94,18 @@ class EpubReaderFragment : Fragment() {
     private var navigatorInputListener: InputListener? = null
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
+    private var textAlignmentOverride: EpubLayoutPreferences.TextAlignment? = null
+    private var tocHrefs: List<String> = emptyList()
+    private var chapterBreaksEnabled = false
     private var continuousScrollInstallJob: Job? = null
     private var imageInteractionInstallJob: Job? = null
     private var preserveImageColors = true
     private var parentColorsInverted = false
     private var imageColorPolicyScript = buildEpubDocumentPreparationScript(
         paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
+        textAlignment = textAlignmentOverride,
+        tocHrefs = tocHrefs,
+        chapterBreaksEnabled = chapterBreaksEnabled,
         preserveImageColors = preserveImageColors,
         parentColorsInverted = parentColorsInverted,
     )
@@ -141,6 +147,11 @@ class EpubReaderFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val session = sessionRepository.get(chapterId)
         paragraphIndentOverrideEnabled = epubLayoutPreferences.publisherStyles.get().not()
+        textAlignmentOverride = epubLayoutPreferences.textAlignment.get()
+            .takeIf { paragraphIndentOverrideEnabled }
+        tocHrefs = session?.publication?.tableOfContents?.flattenEpubTocHrefs().orEmpty()
+        chapterBreaksEnabled =
+            epubLayoutPreferences.readingMode.get() == EpubLayoutPreferences.ReadingMode.PAGINATED
         refreshDocumentPreparationPolicy()
         logcat(LogPriority.DEBUG) {
             "EPUB fragment onCreate chapterId=$chapterId hasSession=${session != null}"
@@ -293,10 +304,18 @@ class EpubReaderFragment : Fragment() {
             clearContinuousScrollState()
         }
         val paragraphOverrideEnabled = preferences.publisherStyles == false
-        val paragraphPolicyChanged = paragraphIndentOverrideEnabled != paragraphOverrideEnabled
+        val nextTextAlignmentOverride = epubLayoutPreferences.textAlignment.get()
+            .takeIf { paragraphOverrideEnabled }
+        val nextChapterBreaksEnabled = preferences.scroll != true
+        val documentPolicyChanged =
+            paragraphIndentOverrideEnabled != paragraphOverrideEnabled ||
+                textAlignmentOverride != nextTextAlignmentOverride ||
+                chapterBreaksEnabled != nextChapterBreaksEnabled
         paragraphIndentOverrideEnabled = paragraphOverrideEnabled
+        textAlignmentOverride = nextTextAlignmentOverride
+        chapterBreaksEnabled = nextChapterBreaksEnabled
         navigator?.submitPreferences(preferences)
-        if (paragraphPolicyChanged) {
+        if (documentPolicyChanged) {
             refreshDocumentPreparationPolicy()
         }
         scheduleImageInteractionsInstall(navigator)
@@ -308,6 +327,7 @@ class EpubReaderFragment : Fragment() {
         logcat(LogPriority.DEBUG) {
             "EPUB paragraph indent submitted chapterId=$chapterId " +
                 "publisherStyles=${preferences.publisherStyles} " +
+                "textAlign=${preferences.textAlign} " +
                 "paragraphIndent=${preferences.paragraphIndent} " +
                 "paragraphSpacing=${preferences.paragraphSpacing} lineHeight=${preferences.lineHeight}"
         }
@@ -386,6 +406,9 @@ class EpubReaderFragment : Fragment() {
     private fun refreshDocumentPreparationPolicy() {
         imageColorPolicyScript = buildEpubDocumentPreparationScript(
             paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
+            textAlignment = textAlignmentOverride,
+            tocHrefs = tocHrefs,
+            chapterBreaksEnabled = chapterBreaksEnabled,
             preserveImageColors = preserveImageColors,
             parentColorsInverted = parentColorsInverted,
         )
@@ -659,11 +682,10 @@ class EpubReaderFragment : Fragment() {
                             preserveImageColors = preserveImageColors,
                             parentColorsInverted = parentColorsInverted,
                         ),
-                        paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
-                            APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
-                        } else {
-                            REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT
-                        },
+                        paragraphIndentScript = buildEpubTypographyPreparationScript(
+                            paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
+                            textAlignment = textAlignmentOverride,
+                        ),
                     ),
                 )
             }.getOrNull()
@@ -900,6 +922,10 @@ class EpubReaderFragment : Fragment() {
                         className: String(element.className || ''),
                         inlineStyle: element.getAttribute('style') || '',
                         textIndent: style.textIndent,
+                        textAlign: style.textAlign,
+                        direction: style.direction,
+                        alignmentTarget: element.hasAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE'),
+                        rightIndentSpacer: element.hasAttribute('$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE'),
                         display: style.display,
                         firstChildTag: element.firstElementChild ? element.firstElementChild.tagName : '',
                         text: String(element.textContent || '').trim().slice(0, 24)
@@ -912,6 +938,7 @@ class EpubReaderFragment : Fragment() {
                     advancedSettings: rootStyle.getPropertyValue('--USER__advancedSettings').trim(),
                     paragraphIndentVariable: rootStyle.getPropertyValue('--USER__paraIndent').trim(),
                     paragraphCount: paragraphs.length,
+                    chapterBreakCount: document.querySelectorAll('[$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE]').length,
                     paragraphs: paragraphs.slice(0, 8).map(describe),
                     bodyBlocks: Array.from(document.body ? document.body.children : []).slice(0, 8).map(describe)
                 });

--- a/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubLayoutPreferences.kt
@@ -51,6 +51,9 @@ class EpubLayoutPreferences(
     val fontFamily: Preference<FontFamily> =
         preferenceStore.getEnum("epub_layout_font_family", FontFamily.ORIGINAL)
 
+    val textAlignment: Preference<TextAlignment> =
+        preferenceStore.getEnum("epub_layout_text_alignment", TextAlignment.START)
+
     val publisherStyles: Preference<Boolean> =
         preferenceStore.getBoolean("epub_layout_publisher_styles", true)
 
@@ -92,6 +95,13 @@ class EpubLayoutPreferences(
         OPEN_DYSLEXIC,
     }
 
+    enum class TextAlignment {
+        START,
+        LEFT,
+        RIGHT,
+        JUSTIFY,
+    }
+
     enum class SpacingMode(
         val lineHeight: Float?,
         val paragraphSpacing: Float?,
@@ -115,6 +125,11 @@ class EpubLayoutPreferences(
         paragraphIndent.set(checkNotNull(mode.paragraphIndent))
         verticalMargins.set(checkNotNull(mode.verticalMargins))
         pageMargins.set(checkNotNull(mode.horizontalMargins))
+    }
+
+    fun applyTextAlignment(alignment: TextAlignment) {
+        textAlignment.set(alignment)
+        publisherStyles.set(false)
     }
 
     companion object {

--- a/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
@@ -58,6 +58,10 @@ class EpubPreferencesBridge {
             pageDirectionExplicit = pageDirectionExplicit,
             publicationMetadata = publicationMetadata,
         )
+        val textAlignmentPreferences = resolveReadiumTextAlignmentPreferences(
+            textAlignment = textAlignment,
+            publisherStyles = publisherStyles,
+        )
         return EpubPreferences(
             scroll = flowPreferences.scroll,
             readingProgression = flowPreferences.readingProgression,
@@ -71,8 +75,8 @@ class EpubPreferencesBridge {
             paragraphIndent = paragraphIndent.toDouble(),
             pageMargins = pageMargins.toDouble(),
             fontFamily = fontFamily.toReadiumFontFamily(),
-            textAlign = textAlignment.toReadiumTextAlign(),
-            hyphens = textAlignment == EpubLayoutPreferences.TextAlignment.JUSTIFY,
+            textAlign = textAlignmentPreferences.textAlign,
+            hyphens = textAlignmentPreferences.hyphens,
             publisherStyles = publisherStyles,
         )
     }
@@ -124,14 +128,30 @@ class EpubPreferencesBridge {
             EpubLayoutPreferences.FontFamily.OPEN_DYSLEXIC -> ReadiumFontFamily.OPEN_DYSLEXIC
         }
     }
+}
 
-    private fun EpubLayoutPreferences.TextAlignment.toReadiumTextAlign(): ReadiumTextAlign {
-        return when (this) {
-            EpubLayoutPreferences.TextAlignment.START -> ReadiumTextAlign.START
-            EpubLayoutPreferences.TextAlignment.LEFT -> ReadiumTextAlign.LEFT
-            EpubLayoutPreferences.TextAlignment.RIGHT -> ReadiumTextAlign.RIGHT
-            EpubLayoutPreferences.TextAlignment.JUSTIFY -> ReadiumTextAlign.JUSTIFY
-        }
+internal data class ReadiumTextAlignmentPreferences(
+    val textAlign: ReadiumTextAlign?,
+    val hyphens: Boolean?,
+)
+
+internal fun resolveReadiumTextAlignmentPreferences(
+    textAlignment: EpubLayoutPreferences.TextAlignment,
+    publisherStyles: Boolean,
+): ReadiumTextAlignmentPreferences {
+    val textAlignmentOverride = textAlignment.takeUnless { publisherStyles }
+    return ReadiumTextAlignmentPreferences(
+        textAlign = textAlignmentOverride?.toReadiumTextAlign(),
+        hyphens = textAlignmentOverride?.let { it == EpubLayoutPreferences.TextAlignment.JUSTIFY },
+    )
+}
+
+private fun EpubLayoutPreferences.TextAlignment.toReadiumTextAlign(): ReadiumTextAlign {
+    return when (this) {
+        EpubLayoutPreferences.TextAlignment.START -> ReadiumTextAlign.START
+        EpubLayoutPreferences.TextAlignment.LEFT -> ReadiumTextAlign.LEFT
+        EpubLayoutPreferences.TextAlignment.RIGHT -> ReadiumTextAlign.RIGHT
+        EpubLayoutPreferences.TextAlignment.JUSTIFY -> ReadiumTextAlign.JUSTIFY
     }
 }
 

--- a/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubPreferencesBridge.kt
@@ -7,6 +7,7 @@ import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.navigator.preferences.Color as ReadiumColor
 import org.readium.r2.navigator.preferences.FontFamily as ReadiumFontFamily
+import org.readium.r2.navigator.preferences.TextAlign as ReadiumTextAlign
 import org.readium.r2.navigator.preferences.Theme as ReadiumTheme
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 
@@ -29,6 +30,7 @@ class EpubPreferencesBridge {
             paragraphIndent = preferences.paragraphIndent.get(),
             pageMargins = preferences.pageMargins.get(),
             fontFamily = preferences.fontFamily.get(),
+            textAlignment = preferences.textAlignment.get(),
             publisherStyles = preferences.publisherStyles.get(),
             customBackgroundColor = preferences.customBackgroundColor.get(),
         )
@@ -44,6 +46,7 @@ class EpubPreferencesBridge {
         paragraphIndent: Float,
         pageMargins: Float,
         fontFamily: EpubLayoutPreferences.FontFamily,
+        textAlignment: EpubLayoutPreferences.TextAlignment,
         publisherStyles: Boolean,
         customBackgroundColor: Int = EpubLayoutPreferences.DEFAULT_CUSTOM_BACKGROUND_COLOR,
         pageDirectionExplicit: Boolean = true,
@@ -68,6 +71,8 @@ class EpubPreferencesBridge {
             paragraphIndent = paragraphIndent.toDouble(),
             pageMargins = pageMargins.toDouble(),
             fontFamily = fontFamily.toReadiumFontFamily(),
+            textAlign = textAlignment.toReadiumTextAlign(),
+            hyphens = textAlignment == EpubLayoutPreferences.TextAlignment.JUSTIFY,
             publisherStyles = publisherStyles,
         )
     }
@@ -117,6 +122,15 @@ class EpubPreferencesBridge {
             EpubLayoutPreferences.FontFamily.SANS_SERIF -> ReadiumFontFamily.SANS_SERIF
             EpubLayoutPreferences.FontFamily.MONOSPACE -> ReadiumFontFamily.MONOSPACE
             EpubLayoutPreferences.FontFamily.OPEN_DYSLEXIC -> ReadiumFontFamily.OPEN_DYSLEXIC
+        }
+    }
+
+    private fun EpubLayoutPreferences.TextAlignment.toReadiumTextAlign(): ReadiumTextAlign {
+        return when (this) {
+            EpubLayoutPreferences.TextAlignment.START -> ReadiumTextAlign.START
+            EpubLayoutPreferences.TextAlignment.LEFT -> ReadiumTextAlign.LEFT
+            EpubLayoutPreferences.TextAlignment.RIGHT -> ReadiumTextAlign.RIGHT
+            EpubLayoutPreferences.TextAlignment.JUSTIFY -> ReadiumTextAlign.JUSTIFY
         }
     }
 }

--- a/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
+++ b/app/src/main/java/koharia/epub/settings/EpubReaderSettingsSheet.kt
@@ -1216,6 +1216,7 @@ private fun TypographySettingsSheet(
                 )
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp))
                 FontFamilySection(preferences)
+                TextAlignmentSection(preferences)
                 PublisherStylesSection(preferences)
             }
         }
@@ -1700,6 +1701,23 @@ private fun FontFamilySection(preferences: EpubLayoutPreferences) {
 }
 
 @Composable
+private fun TextAlignmentSection(preferences: EpubLayoutPreferences) {
+    val currentAlignment by preferences.textAlignment.changes()
+        .collectAsState(preferences.textAlignment.get())
+
+    ChipSection(title = stringResource(MR.strings.pref_epub_text_alignment)) {
+        EpubLayoutPreferences.TextAlignment.entries.forEach { alignment ->
+            FilterChip(
+                selected = currentAlignment == alignment,
+                onClick = { preferences.applyTextAlignment(alignment) },
+                label = { Text(alignment.label()) },
+                modifier = Modifier.semantics { role = Role.RadioButton },
+            )
+        }
+    }
+}
+
+@Composable
 private fun PublisherStylesSection(preferences: EpubLayoutPreferences) {
     val publisherStyles by preferences.publisherStyles.changes().collectAsState(preferences.publisherStyles.get())
 
@@ -1770,6 +1788,16 @@ private fun EpubLayoutPreferences.FontFamily.label(): String {
         EpubLayoutPreferences.FontFamily.SANS_SERIF -> stringResource(MR.strings.pref_epub_font_sans_serif)
         EpubLayoutPreferences.FontFamily.MONOSPACE -> stringResource(MR.strings.pref_epub_font_monospace)
         EpubLayoutPreferences.FontFamily.OPEN_DYSLEXIC -> stringResource(MR.strings.pref_epub_font_open_dyslexic)
+    }
+}
+
+@Composable
+private fun EpubLayoutPreferences.TextAlignment.label(): String {
+    return when (this) {
+        EpubLayoutPreferences.TextAlignment.START -> stringResource(MR.strings.pref_epub_text_align_start)
+        EpubLayoutPreferences.TextAlignment.LEFT -> stringResource(MR.strings.pref_epub_text_align_left)
+        EpubLayoutPreferences.TextAlignment.RIGHT -> stringResource(MR.strings.pref_epub_text_align_right)
+        EpubLayoutPreferences.TextAlignment.JUSTIFY -> stringResource(MR.strings.pref_epub_text_align_justify)
     }
 }
 

--- a/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
+++ b/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
@@ -1,5 +1,6 @@
 package koharia.epub
 
+import koharia.epub.settings.EpubLayoutPreferences
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -10,11 +11,17 @@ class EpubDocumentPreparationTest {
     fun `document preparation combines paragraph and image policies`() {
         val script = buildEpubDocumentPreparationScript(
             paragraphIndentOverrideEnabled = true,
+            textAlignment = EpubLayoutPreferences.TextAlignment.JUSTIFY,
+            tocHrefs = listOf("OEBPS/chapter.xhtml#chapter-2"),
+            chapterBreaksEnabled = true,
             preserveImageColors = true,
             parentColorsInverted = true,
         )
 
         assertTrue(script.contains(EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE))
+        assertTrue(script.contains("text-align: justify !important"))
+        assertTrue(script.contains("hyphens: auto !important"))
+        assertTrue(script.contains("break-before: column !important"))
         assertTrue(script.contains("filter: invert(100%) !important"))
         assertTrue(script.contains("return 'prepared'"))
     }
@@ -23,12 +30,83 @@ class EpubDocumentPreparationTest {
     fun `disabled paragraph override removes prior document attributes`() {
         val script = buildEpubDocumentPreparationScript(
             paragraphIndentOverrideEnabled = false,
+            textAlignment = null,
+            tocHrefs = emptyList(),
+            chapterBreaksEnabled = false,
             preserveImageColors = false,
             parentColorsInverted = false,
         )
 
         assertTrue(script.contains("paragraph.removeAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE')"))
         assertFalse(script.contains("paragraph.setAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE'"))
+        assertTrue(script.contains("element.removeAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE')"))
+        assertFalse(script.contains("element.setAttribute('$EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE'"))
+    }
+
+    @Test
+    fun `paginated chapter breaks target toc fragments`() {
+        val script = buildEpubChapterBreakOverrideScript(
+            tocHrefs = listOf("OEBPS/chapter.xhtml#chapter-2"),
+            enabled = true,
+        )
+
+        assertTrue(script.contains("break-before: column !important"))
+        assertTrue(script.contains("OEBPS/chapter.xhtml#chapter-2"))
+        assertTrue(script.contains("document.getElementById(fragment)"))
+        assertTrue(script.contains("target.nextElementSibling.matches(headingSelector)"))
+    }
+
+    @Test
+    fun `scroll layout removes paginated chapter breaks`() {
+        val script = buildEpubChapterBreakOverrideScript(
+            tocHrefs = listOf("chapter.xhtml#chapter-2"),
+            enabled = false,
+        )
+
+        assertTrue(script.contains("style.remove()"))
+        assertTrue(script.contains("element.removeAttribute('$EPUB_CHAPTER_BREAK_TARGET_ATTRIBUTE')"))
+        assertFalse(script.contains("break-before: column !important"))
+    }
+
+    @Test
+    fun `start alignment overrides body text without hyphenation`() {
+        val script = buildEpubTextAlignmentOverrideScript(EpubLayoutPreferences.TextAlignment.START)
+
+        assertTrue(script.contains("text-align: start !important"))
+        assertTrue(script.contains("hyphens: none !important"))
+        assertTrue(script.contains("p, li, dd, blockquote, div, section"))
+    }
+
+    @Test
+    fun `physical edge alignment overrides use explicit sides`() {
+        val left = buildEpubTextAlignmentOverrideScript(EpubLayoutPreferences.TextAlignment.LEFT)
+        val right = buildEpubTextAlignmentOverrideScript(EpubLayoutPreferences.TextAlignment.RIGHT)
+
+        assertTrue(left.contains("text-align: left !important"))
+        assertTrue(left.contains("hyphens: none !important"))
+        assertTrue(right.contains("text-align: right !important"))
+        assertTrue(right.contains("hyphens: none !important"))
+        assertTrue(right.contains("float: right !important"))
+        assertTrue(right.contains("width: var(--USER__paraIndent, 2rem) !important"))
+        assertTrue(right.contains("text-indent: 0 !important"))
+        assertTrue(left.contains("element.removeAttribute('$EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE')"))
+    }
+
+    @Test
+    fun `paragraph indentation does not classify global right alignment as structural`() {
+        assertFalse(APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT.contains("textAlign === 'right'"))
+        assertFalse(APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT.contains("textAlign === 'end'"))
+        assertTrue(APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT.contains("structuralClasses.test(className)"))
+    }
+
+    @Test
+    fun `alignment override preserves structural and media elements`() {
+        val script = buildEpubTextAlignmentOverrideScript(EpubLayoutPreferences.TextAlignment.JUSTIFY)
+
+        assertTrue(script.contains("role === 'heading'"))
+        assertTrue(script.contains("originalAlignment === 'center'"))
+        assertTrue(script.contains("img, svg, picture, video, audio, figure, table, canvas"))
+        assertTrue(script.contains("element.closest('h1, h2, h3, h4, h5, h6"))
     }
 
     @Test
@@ -40,6 +118,11 @@ class EpubDocumentPreparationTest {
         )
         assertTrue(
             REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT.contains(
+                "document.documentElement.localName.toLowerCase() !== 'html'",
+            ),
+        )
+        assertTrue(
+            buildEpubTextAlignmentOverrideScript(EpubLayoutPreferences.TextAlignment.JUSTIFY).contains(
                 "document.documentElement.localName.toLowerCase() !== 'html'",
             ),
         )

--- a/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
+++ b/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
@@ -22,6 +22,7 @@ class EpubPaginationModelsTest {
         assertNotEquals(original.key, snapshot(fontSize = 1.25f).key)
         assertNotEquals(original.key, snapshot(paragraphSpacing = 0.5f).key)
         assertNotEquals(original.key, snapshot(verticalMargins = 1.3f).key)
+        assertNotEquals(original.key, snapshot(textAlignment = "JUSTIFY").key)
         assertNotEquals(original.key, snapshot(viewportWidthPx = 1080).key)
         assertNotEquals(original.key, snapshot(webViewVersion = "2").key)
     }
@@ -40,6 +41,7 @@ class EpubPaginationModelsTest {
         fontSize: Float = 1.0f,
         paragraphSpacing: Float = 0.0f,
         verticalMargins: Float = 1.0f,
+        textAlignment: String = "START",
         viewportWidthPx: Int = 720,
         webViewVersion: String = "1",
     ): EpubPaginationLayoutSnapshot {
@@ -53,6 +55,7 @@ class EpubPaginationModelsTest {
             pageMargins = 1.0f,
             verticalMargins = verticalMargins,
             fontFamily = "ORIGINAL",
+            textAlignment = textAlignment,
             publisherStyles = true,
             viewportWidthPx = viewportWidthPx,
             viewportHeightPx = 1280,

--- a/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
@@ -4,16 +4,14 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.readium.r2.navigator.preferences.ReadingProgression
 import org.readium.r2.navigator.preferences.TextAlign
-import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 
-@OptIn(ExperimentalReadiumApi::class)
 class EpubPreferencesBridgeTest {
 
     @Test
     fun `start alignment disables Readium hyphenation`() {
-        val preferences = readiumPreferences(EpubLayoutPreferences.TextAlignment.START)
+        val preferences = textAlignmentPreferences(EpubLayoutPreferences.TextAlignment.START)
 
         assertEquals(TextAlign.START, preferences.textAlign)
         assertEquals(false, preferences.hyphens)
@@ -21,7 +19,7 @@ class EpubPreferencesBridgeTest {
 
     @Test
     fun `justified alignment enables Readium hyphenation`() {
-        val preferences = readiumPreferences(EpubLayoutPreferences.TextAlignment.JUSTIFY)
+        val preferences = textAlignmentPreferences(EpubLayoutPreferences.TextAlignment.JUSTIFY)
 
         assertEquals(TextAlign.JUSTIFY, preferences.textAlign)
         assertEquals(true, preferences.hyphens)
@@ -29,13 +27,24 @@ class EpubPreferencesBridgeTest {
 
     @Test
     fun `physical edge alignments are submitted without hyphenation`() {
-        val left = readiumPreferences(EpubLayoutPreferences.TextAlignment.LEFT)
-        val right = readiumPreferences(EpubLayoutPreferences.TextAlignment.RIGHT)
+        val left = textAlignmentPreferences(EpubLayoutPreferences.TextAlignment.LEFT)
+        val right = textAlignmentPreferences(EpubLayoutPreferences.TextAlignment.RIGHT)
 
         assertEquals(TextAlign.LEFT, left.textAlign)
         assertEquals(false, left.hyphens)
         assertEquals(TextAlign.RIGHT, right.textAlign)
         assertEquals(false, right.hyphens)
+    }
+
+    @Test
+    fun `publisher styles omit saved alignment and hyphenation overrides`() {
+        val preferences = textAlignmentPreferences(
+            textAlignment = EpubLayoutPreferences.TextAlignment.JUSTIFY,
+            publisherStyles = true,
+        )
+
+        assertEquals(null, preferences.textAlign)
+        assertEquals(null, preferences.hyphens)
     }
 
     @Test
@@ -108,18 +117,11 @@ class EpubPreferencesBridgeTest {
         assertEquals(false, preferences.verticalText)
     }
 
-    private fun readiumPreferences(textAlignment: EpubLayoutPreferences.TextAlignment) =
-        EpubPreferencesBridge().toReadiumPreferences(
-            readingMode = EpubLayoutPreferences.ReadingMode.PAGINATED,
-            pageDirection = EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT,
-            theme = EpubLayoutPreferences.Theme.LIGHT,
-            fontSize = 1.0f,
-            lineHeight = 1.7f,
-            paragraphSpacing = 0.05f,
-            paragraphIndent = 2.0f,
-            pageMargins = 1.0f,
-            fontFamily = EpubLayoutPreferences.FontFamily.ORIGINAL,
-            textAlignment = textAlignment,
-            publisherStyles = false,
-        )
+    private fun textAlignmentPreferences(
+        textAlignment: EpubLayoutPreferences.TextAlignment,
+        publisherStyles: Boolean = false,
+    ) = resolveReadiumTextAlignmentPreferences(
+        textAlignment = textAlignment,
+        publisherStyles = publisherStyles,
+    )
 }

--- a/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubPreferencesBridgeTest.kt
@@ -3,10 +3,40 @@ package koharia.epub.settings
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.readium.r2.navigator.preferences.ReadingProgression
+import org.readium.r2.navigator.preferences.TextAlign
+import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.shared.publication.ReadingProgression as PublicationReadingProgression
 
+@OptIn(ExperimentalReadiumApi::class)
 class EpubPreferencesBridgeTest {
+
+    @Test
+    fun `start alignment disables Readium hyphenation`() {
+        val preferences = readiumPreferences(EpubLayoutPreferences.TextAlignment.START)
+
+        assertEquals(TextAlign.START, preferences.textAlign)
+        assertEquals(false, preferences.hyphens)
+    }
+
+    @Test
+    fun `justified alignment enables Readium hyphenation`() {
+        val preferences = readiumPreferences(EpubLayoutPreferences.TextAlignment.JUSTIFY)
+
+        assertEquals(TextAlign.JUSTIFY, preferences.textAlign)
+        assertEquals(true, preferences.hyphens)
+    }
+
+    @Test
+    fun `physical edge alignments are submitted without hyphenation`() {
+        val left = readiumPreferences(EpubLayoutPreferences.TextAlignment.LEFT)
+        val right = readiumPreferences(EpubLayoutPreferences.TextAlignment.RIGHT)
+
+        assertEquals(TextAlign.LEFT, left.textAlign)
+        assertEquals(false, left.hyphens)
+        assertEquals(TextAlign.RIGHT, right.textAlign)
+        assertEquals(false, right.hyphens)
+    }
 
     @Test
     fun `left to right mode is submitted to Readium`() {
@@ -77,4 +107,19 @@ class EpubPreferencesBridgeTest {
         assertEquals(ReadingProgression.LTR, preferences.readingProgression)
         assertEquals(false, preferences.verticalText)
     }
+
+    private fun readiumPreferences(textAlignment: EpubLayoutPreferences.TextAlignment) =
+        EpubPreferencesBridge().toReadiumPreferences(
+            readingMode = EpubLayoutPreferences.ReadingMode.PAGINATED,
+            pageDirection = EpubLayoutPreferences.PageDirection.LEFT_TO_RIGHT,
+            theme = EpubLayoutPreferences.Theme.LIGHT,
+            fontSize = 1.0f,
+            lineHeight = 1.7f,
+            paragraphSpacing = 0.05f,
+            paragraphIndent = 2.0f,
+            pageMargins = 1.0f,
+            fontFamily = EpubLayoutPreferences.FontFamily.ORIGINAL,
+            textAlignment = textAlignment,
+            publisherStyles = false,
+        )
 }

--- a/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
+++ b/app/src/test/java/koharia/epub/settings/EpubReaderPreferenceDefaultsTest.kt
@@ -29,7 +29,18 @@ class EpubReaderPreferenceDefaultsTest {
         assertEquals(EpubLayoutPreferences.SpacingMode.STANDARD, preferences.spacingMode.get())
         assertEquals(1.7f, preferences.lineHeight.get())
         assertEquals(0.05f, preferences.paragraphSpacing.get())
+        assertEquals(EpubLayoutPreferences.TextAlignment.START, preferences.textAlignment.get())
         assertTrue(preferences.publisherStyles.get())
+    }
+
+    @Test
+    fun `selecting text alignment disables publisher styles`() {
+        val preferences = EpubLayoutPreferences(InMemoryPreferenceStore())
+
+        preferences.applyTextAlignment(EpubLayoutPreferences.TextAlignment.JUSTIFY)
+
+        assertEquals(EpubLayoutPreferences.TextAlignment.JUSTIFY, preferences.textAlignment.get())
+        assertFalse(preferences.publisherStyles.get())
     }
 
     @Test

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -991,6 +991,8 @@
     <string name="epub_reader_delete_custom_color">Delete background color</string>
     <string name="pref_epub_text_alignment">Text alignment</string>
     <string name="pref_epub_text_align_justify">Justify</string>
+    <string name="pref_epub_text_align_left">Left</string>
+    <string name="pref_epub_text_align_right">Right</string>
     <string name="pref_epub_text_align_start">Start</string>
     <string name="pref_epub_font_size">Font size</string>
     <string name="pref_epub_line_height">Line height</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -634,6 +634,8 @@
     <string name="epub_reader_delete_custom_color">删除背景颜色</string>
     <string name="pref_epub_text_alignment">文本对齐</string>
     <string name="pref_epub_text_align_justify">两端对齐</string>
+    <string name="pref_epub_text_align_left">左对齐</string>
+    <string name="pref_epub_text_align_right">右对齐</string>
     <string name="pref_epub_text_align_start">起始对齐</string>
     <string name="pref_epub_font_size">字号</string>
     <string name="pref_epub_line_height">行高</string>


### PR DESCRIPTION
## 中文

### 变更内容

- 为 EPUB 阅读器增加起始、左、右和两端对齐选项，并在两端对齐时启用英文断词。
- 将对齐设置同步应用到 Readium、分页扫描器和连续滚动 iframe；对齐变化会使分页缓存失效并重新计算。
- 增加非标准 EPUB 样式兼容，保留标题、居中内容和媒体元素原有布局，并正确处理左右对齐下的首行缩进。
- 根据 EPUB 目录锚点在分页模式中保持章节边界，避免排版变化后章节标题前残留上一章内容。
- 允许 Komga 作品详情中的出版社、语言、年龄分级和册数信息自然换行，长出版社名称不再将后续信息挤出屏幕。
- 增加英文及简体中文文案和相关单元测试覆盖。

### 原因与影响

Readium 原有设置未向用户暴露文本对齐，也无法可靠覆盖部分 EPUB 的出版社样式；排版变化还可能复用不兼容的分页缓存。作品元数据此前由多个单行文本组成，长出版社名称会占满横向空间。此次修改让英文图书可以使用带断词的两端对齐，同时保证其他对齐方式、章节分页和长元数据在不同屏幕宽度下正常显示。

### 验证

- `git diff --cached --check`（提交前通过）
- ADB/虚拟机手工验证起始、左、右、两端对齐及章节分页
- 按项目协作约定，本次提交阶段未额外运行 Gradle；建议 CI/复核时执行：
  - `.\gradlew.bat spotlessCheck`
  - `.\gradlew.bat :app:compileDebugKotlin`

Closes #52
Fixes #54

---

## English

### Changes

- Added Start, Left, Right, and Justify alignment options to the EPUB reader, with hyphenation enabled for justified text.
- Applied alignment consistently across Readium, pagination scanning, and continuous-scroll iframes; alignment changes now invalidate the pagination cache.
- Added compatibility overrides for non-standard EPUB styles while preserving headings, centered content, and media layouts, including correct first-line indentation for left and right alignment.
- Preserved chapter boundaries in paginated mode using EPUB TOC anchors so re-pagination does not leave content from the previous chapter before a chapter heading.
- Allowed Komga publisher, language, age rating, and volume-count metadata to wrap naturally so long publisher names no longer push information off-screen.
- Added English and Simplified Chinese strings and focused unit-test coverage.

### Why and impact

The existing Readium configuration did not expose text alignment and could not reliably override publisher CSS in some EPUBs. Layout changes could also reuse incompatible pagination data. Book metadata was rendered as separate single-line labels, allowing long publisher names to consume all horizontal space. This change provides print-style justified English text with hyphenation while keeping other alignments, chapter pagination, and long metadata readable across screen sizes.

### Validation

- `git diff --cached --check` passed before commit
- Manually validated Start, Left, Right, and Justify alignment plus chapter pagination through ADB/emulator inspection
- Per the project workflow agreement, Gradle was not run again during publishing. Suggested CI/review commands:
  - `.\gradlew.bat spotlessCheck`
  - `.\gradlew.bat :app:compileDebugKotlin`
