### PR TITLE
支持 EPUB 注释弹窗与非标准脚注兼容 / Add EPUB footnote popups and compatibility

### DIFF
--- a/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
+++ b/app/src/main/java/koharia/epub/EpubContinuousScroll.kt
@@ -27,7 +27,7 @@ internal fun buildEpubContinuousScrollInstallScript(
     currentIndex: Int,
     initialProgression: Double,
     imageInteractionScript: String,
-    paragraphIndentScript: String,
+    contentPreparationScript: String,
 ): String {
     val resourcesJson = buildJsonArray {
         resources.forEach { resource ->
@@ -40,7 +40,7 @@ internal fun buildEpubContinuousScrollInstallScript(
             )
         }
     }
-    val indentScriptJson = JsonPrimitive(paragraphIndentScript)
+    val contentPreparationScriptJson = JsonPrimitive(contentPreparationScript)
     val imageInteractionScriptJson = JsonPrimitive(imageInteractionScript)
     val clampedProgression = initialProgression.coerceIn(0.0, 1.0)
 
@@ -49,11 +49,11 @@ internal fun buildEpubContinuousScrollInstallScript(
             const resources = $resourcesJson;
             const currentIndex = $currentIndex;
             const initialProgression = $clampedProgression;
-            const requestedParagraphIndentScript = $indentScriptJson;
+            const requestedContentPreparationScript = $contentPreparationScriptJson;
             const requestedImageInteractionScript = $imageInteractionScriptJson;
             const existing = window.__kohariaContinuousScroll;
             if (existing && existing.currentIndex === currentIndex) {
-                existing.refresh(requestedParagraphIndentScript, requestedImageInteractionScript);
+                existing.refresh(requestedContentPreparationScript, requestedImageInteractionScript);
                 return 'ready';
             }
             if (!document.body || !resources.length || currentIndex < 0 || currentIndex >= resources.length) {
@@ -69,7 +69,7 @@ internal fun buildEpubContinuousScrollInstallScript(
             let activeIndex = currentIndex;
             let locationFrame = 0;
             let lastLocationSentAt = 0;
-            let paragraphIndentScript = requestedParagraphIndentScript;
+            let contentPreparationScript = requestedContentPreparationScript;
             let imageInteractionScript = requestedImageInteractionScript;
 
             function installImageInteractions(targetWindow, resourceIndex) {
@@ -197,7 +197,7 @@ internal fun buildEpubContinuousScrollInstallScript(
                         doc.body.style.setProperty('height', 'auto', 'important');
                         doc.body.style.setProperty('overflow', 'hidden', 'important');
                     }
-                    try { iframe.contentWindow.eval(paragraphIndentScript); } catch (_) {}
+                    try { iframe.contentWindow.eval(contentPreparationScript); } catch (_) {}
                     installImageInteractions(iframe.contentWindow, index);
                     iframe.style.visibility = 'visible';
                     const height = Math.max(
@@ -346,10 +346,10 @@ internal fun buildEpubContinuousScrollInstallScript(
                 currentIndex: currentIndex,
                 resources: resources,
                 notifyLocation: notifyLocation,
-                refresh: function(nextParagraphIndentScript, nextImageInteractionScript) {
-                    paragraphIndentScript = nextParagraphIndentScript;
+                refresh: function(nextContentPreparationScript, nextImageInteractionScript) {
+                    contentPreparationScript = nextContentPreparationScript;
                     imageInteractionScript = nextImageInteractionScript;
-                    try { window.eval(paragraphIndentScript); } catch (_) {}
+                    try { window.eval(contentPreparationScript); } catch (_) {}
                     installImageInteractions(window, currentIndex);
                     const loadedIndexes = Array.from(liveFrames.keys());
                     loadedIndexes.forEach(unloadSection);

--- a/app/src/main/java/koharia/epub/EpubFootnoteCompatibility.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnoteCompatibility.kt
@@ -1,0 +1,199 @@
+package koharia.epub
+
+/**
+ * Marks reliably identifiable non-standard footnote links as EPUB noterefs so Readium can resolve,
+ * sanitize and report their contents through [org.readium.r2.navigator.HyperlinkNavigator].
+ */
+internal fun buildEpubFootnoteCompatibilityScript(
+    applyReaderStyles: Boolean,
+    readerFontScale: Float,
+): String {
+    val readerSizeRem = readerFontScale.coerceIn(0.5f, 3f)
+    val referenceSizeRem = readerSizeRem * 0.75f
+    val referenceTouchExpansionRem = (readerSizeRem - referenceSizeRem) / 2f
+    val script = """
+        (function() {
+            const root = document.documentElement;
+            if (!root || root.localName.toLowerCase() !== 'html') return 'unsupported';
+
+            const epubNamespace = 'http://www.idpf.org/2007/ops';
+            const applyReaderStyles = $applyReaderStyles;
+            const styleId = 'koharia-footnote-reference-style';
+            const referenceAttribute = 'data-koharia-footnote-reference';
+            const graphicAttribute = 'data-koharia-footnote-graphic';
+            const referenceClasses = new Set([
+                'duokan-footnote',
+                'noteref',
+                'footnote-ref',
+                'endnote-ref',
+            ]);
+            const noteClasses = new Set([
+                'duokan-footnote-item',
+                'footnote-item',
+                'endnote-item',
+            ]);
+
+            function tokens(value) {
+                return String(value || '')
+                    .toLowerCase()
+                    .split(/\s+/)
+                    .filter(Boolean);
+            }
+
+            function epubTypes(element) {
+                return tokens(
+                    element.getAttributeNS(epubNamespace, 'type') ||
+                    element.getAttribute('epub:type'),
+                );
+            }
+
+            function hasAny(values, expected) {
+                return values.some(function(value) { return expected.has(value); });
+            }
+
+            function fragmentTarget(anchor) {
+                const rawHref = anchor.getAttribute('href');
+                if (!rawHref) return null;
+                try {
+                    const url = new URL(rawHref, document.baseURI);
+                    const documentUrl = new URL(document.baseURI);
+                    if (url.origin !== documentUrl.origin || url.pathname !== documentUrl.pathname ||
+                        url.search !== documentUrl.search || !url.hash) {
+                        return null;
+                    }
+                    let id = url.hash.substring(1);
+                    try { id = decodeURIComponent(id); } catch (_) {}
+                    return document.getElementById(id);
+                } catch (_) {
+                    return null;
+                }
+            }
+
+            function isSemanticNoteTarget(target) {
+                if (!target) return false;
+                const role = String(target.getAttribute('role') || '').toLowerCase();
+                if (role === 'doc-footnote' || role === 'doc-endnote') return true;
+                if (epubTypes(target).some(function(type) { return type === 'footnote' || type === 'endnote'; })) {
+                    return true;
+                }
+                return hasAny(tokens(target.getAttribute('class')), noteClasses);
+            }
+
+            function updateReferenceStyle(anchor) {
+                anchor.removeAttribute(referenceAttribute);
+                anchor.removeAttribute(graphicAttribute);
+                if (!applyReaderStyles) return;
+                anchor.setAttribute(referenceAttribute, 'true');
+                const hasGraphic = !!anchor.querySelector(
+                    'img, svg, picture, object, input[type="image"], [role="img"]',
+                );
+                if (hasGraphic || !String(anchor.textContent || '').trim()) {
+                    anchor.setAttribute(graphicAttribute, 'true');
+                }
+            }
+
+            const previousStyle = document.getElementById(styleId);
+            if (previousStyle) previousStyle.remove();
+            if (applyReaderStyles) {
+                const style = document.createElement('style');
+                style.id = styleId;
+                style.textContent = `
+                    a[${'$'}{referenceAttribute}="true"] {
+                        position: relative !important;
+                        box-sizing: content-box !important;
+                        display: inline-block !important;
+                        font-size: ${referenceSizeRem}rem !important;
+                        line-height: 1 !important;
+                        vertical-align: super !important;
+                        overflow: visible !important;
+                        z-index: 1 !important;
+                    }
+                    a[${'$'}{referenceAttribute}="true"]::after {
+                        content: "" !important;
+                        position: absolute !important;
+                        inset: -${referenceTouchExpansionRem}rem !important;
+                    }
+                    a[${'$'}{referenceAttribute}="true"]:not(
+                        [${'$'}{graphicAttribute}="true"]
+                    ) {
+                        padding: 0 !important;
+                        margin: 0 !important;
+                        white-space: nowrap !important;
+                        transform: none !important;
+                    }
+                    a[${'$'}{referenceAttribute}="true"]:not(
+                        [${'$'}{graphicAttribute}="true"]
+                    ) * {
+                        font-size: inherit !important;
+                        line-height: inherit !important;
+                        vertical-align: baseline !important;
+                    }
+                    a[${'$'}{graphicAttribute}="true"] {
+                        padding: 0 !important;
+                        margin: 0 !important;
+                        width: 1em !important;
+                        height: 1em !important;
+                        min-width: 0 !important;
+                        min-height: 0 !important;
+                        max-width: 1em !important;
+                        max-height: 1em !important;
+                        transform: none !important;
+                        background-size: contain !important;
+                        background-position: center !important;
+                        background-repeat: no-repeat !important;
+                    }
+                    a[${'$'}{graphicAttribute}="true"] :is(
+                        img, svg, picture, object, input[type="image"], [role="img"]
+                    ) {
+                        position: static !important;
+                        display: block !important;
+                        box-sizing: border-box !important;
+                        padding: 0 !important;
+                        margin: 0 !important;
+                        width: 100% !important;
+                        height: 100% !important;
+                        min-width: 0 !important;
+                        min-height: 0 !important;
+                        max-width: 100% !important;
+                        max-height: 100% !important;
+                        object-fit: contain !important;
+                        transform: none !important;
+                    }
+                    a[${'$'}{graphicAttribute}="true"] > * {
+                        width: 100% !important;
+                        height: 100% !important;
+                        max-width: 100% !important;
+                        max-height: 100% !important;
+                    }
+                `;
+                (document.head || root).appendChild(style);
+            }
+
+            let marked = 0;
+            Array.from(document.querySelectorAll('a[href]')).forEach(function(anchor) {
+                const isStandardReference = epubTypes(anchor).includes('noteref');
+                const role = String(anchor.getAttribute('role') || '').toLowerCase();
+                const isReference = isStandardReference || role === 'doc-noteref' ||
+                    hasAny(tokens(anchor.getAttribute('class')), referenceClasses) ||
+                    isSemanticNoteTarget(fragmentTarget(anchor));
+                if (!isReference) {
+                    anchor.removeAttribute(referenceAttribute);
+                    anchor.removeAttribute(graphicAttribute);
+                    return;
+                }
+                if (!isStandardReference) {
+                    try {
+                        anchor.setAttributeNS(epubNamespace, 'epub:type', 'noteref');
+                    } catch (_) {
+                        anchor.setAttribute('epub:type', 'noteref');
+                    }
+                    marked += 1;
+                }
+                updateReferenceStyle(anchor);
+            });
+            root.setAttribute('data-koharia-footnotes-prepared', 'true');
+            return marked;
+        })()
+    """.trimIndent()
+    return script
+}

--- a/app/src/main/java/koharia/epub/EpubFootnoteCompatibility.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnoteCompatibility.kt
@@ -17,6 +17,7 @@ internal fun buildEpubFootnoteCompatibilityScript(
             if (!root || root.localName.toLowerCase() !== 'html') return 'unsupported';
 
             const epubNamespace = 'http://www.idpf.org/2007/ops';
+            const xhtmlNamespace = 'http://www.w3.org/1999/xhtml';
             const applyReaderStyles = $applyReaderStyles;
             const styleId = 'koharia-footnote-reference-style';
             const referenceAttribute = 'data-koharia-footnote-reference';
@@ -49,6 +50,21 @@ internal fun buildEpubFootnoteCompatibilityScript(
 
             function hasAny(values, expected) {
                 return values.some(function(value) { return expected.has(value); });
+            }
+
+            function addEpubType(element, type) {
+                const current = element.getAttributeNS(epubNamespace, 'type') ||
+                    element.getAttribute('epub:type') || '';
+                const values = String(current).trim().split(/\s+/).filter(Boolean);
+                if (!values.some(function(value) { return value.toLowerCase() === type; })) {
+                    values.push(type);
+                }
+                const updated = values.join(' ');
+                try {
+                    element.setAttributeNS(epubNamespace, 'epub:type', updated);
+                } catch (_) {
+                    element.setAttribute('epub:type', updated);
+                }
             }
 
             function fragmentTarget(anchor) {
@@ -95,8 +111,9 @@ internal fun buildEpubFootnoteCompatibilityScript(
             const previousStyle = document.getElementById(styleId);
             if (previousStyle) previousStyle.remove();
             if (applyReaderStyles) {
-                const style = document.createElement('style');
+                const style = document.createElementNS(root.namespaceURI || xhtmlNamespace, 'style');
                 style.id = styleId;
+                style.setAttribute('type', 'text/css');
                 style.textContent = `
                     a[${'$'}{referenceAttribute}="true"] {
                         position: relative !important;
@@ -182,11 +199,7 @@ internal fun buildEpubFootnoteCompatibilityScript(
                     return;
                 }
                 if (!isStandardReference) {
-                    try {
-                        anchor.setAttributeNS(epubNamespace, 'epub:type', 'noteref');
-                    } catch (_) {
-                        anchor.setAttribute('epub:type', 'noteref');
-                    }
+                    addEpubType(anchor, 'noteref');
                     marked += 1;
                 }
                 updateReferenceStyle(anchor);

--- a/app/src/main/java/koharia/epub/EpubFootnoteImageLoader.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnoteImageLoader.kt
@@ -1,0 +1,59 @@
+package koharia.epub
+
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import org.jsoup.Jsoup
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.util.Url
+import java.net.URI
+
+internal data class EpubFootnoteImageContent(
+    val bytes: ByteString,
+    val isSvg: Boolean,
+)
+
+internal fun epubFootnoteImageSources(contentHtml: String): List<String> =
+    Jsoup.parseBodyFragment(contentHtml)
+        .select("img[src]")
+        .mapNotNull { element -> element.attr("src").trim().takeIf(String::isNotEmpty) }
+        .distinct()
+        .take(MAX_EPUB_FOOTNOTE_IMAGES)
+
+internal suspend fun loadEpubFootnoteImages(
+    publication: Publication,
+    documentHref: String,
+    contentHtml: String,
+): Map<String, EpubFootnoteImageContent> {
+    val images = linkedMapOf<String, EpubFootnoteImageContent>()
+    var totalBytes = 0
+
+    for (source in epubFootnoteImageSources(contentHtml)) {
+        for (candidate in epubImageCandidateHrefs(documentHref, source, source)) {
+            val candidateUri = runCatching { URI(candidate) }.getOrNull() ?: continue
+            if (candidateUri.scheme != null || candidateUri.rawAuthority != null) continue
+            val resource = Url(candidate)?.let(publication::get) ?: continue
+            try {
+                val declaredLength = resource.length().getOrNull()
+                if (declaredLength != null && declaredLength > MAX_EPUB_FOOTNOTE_IMAGE_BYTES) continue
+
+                val bytes = resource.read(0L..MAX_EPUB_FOOTNOTE_IMAGE_BYTES).getOrNull() ?: continue
+                if (bytes.isEmpty() || bytes.size > MAX_EPUB_FOOTNOTE_IMAGE_BYTES) continue
+                if (totalBytes + bytes.size > MAX_EPUB_FOOTNOTE_TOTAL_IMAGE_BYTES) return images
+
+                images[source] = EpubFootnoteImageContent(
+                    bytes = bytes.toByteString(),
+                    isSvg = bytes.isSvgImage(),
+                )
+                totalBytes += bytes.size
+                break
+            } finally {
+                resource.close()
+            }
+        }
+    }
+    return images
+}
+
+private const val MAX_EPUB_FOOTNOTE_IMAGES = 8
+private const val MAX_EPUB_FOOTNOTE_IMAGE_BYTES = 4L * 1024L * 1024L
+private const val MAX_EPUB_FOOTNOTE_TOTAL_IMAGE_BYTES = 12 * 1024 * 1024

--- a/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
@@ -12,19 +12,34 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import androidx.core.text.HtmlCompat
 import coil3.asDrawable
@@ -38,6 +53,8 @@ import kotlin.math.roundToInt
 internal data class EpubFootnoteUiState(
     val href: String,
     val contentHtml: String,
+    val anchorXFraction: Float? = null,
+    val anchorYFraction: Float? = null,
     val images: Map<String, EpubFootnoteImageContent> = emptyMap(),
 )
 
@@ -55,15 +72,53 @@ internal fun EpubFootnotePopup(
     } else {
         Color(0xFFF1EEE7)
     }
+    val configuration = LocalConfiguration.current
     val widthFraction = if (applyReaderStyles) 0.78f else 0.86f
     val maxWidth = if (applyReaderStyles) 480.dp else 560.dp
-    val popupWidth = minOf(LocalConfiguration.current.screenWidthDp.dp * widthFraction, maxWidth)
-    val maxHeight = if (applyReaderStyles) 320.dp else 380.dp
+    val popupWidth = minOf(configuration.screenWidthDp.dp * widthFraction, maxWidth)
+    val preferredMaxHeight = if (applyReaderStyles) 320.dp else 380.dp
     val horizontalPadding = if (applyReaderStyles) 14.dp else 20.dp
     val verticalPadding = if (applyReaderStyles) 12.dp else 18.dp
     val textSizeSp = if (applyReaderStyles) readerFontSizeSp else 17f
     val context = LocalContext.current
     val density = LocalDensity.current
+    val anchorYFraction = state.anchorYFraction?.coerceIn(0f, 1f) ?: 0.5f
+    val edgeMarginPx = with(density) { FOOTNOTE_POPUP_EDGE_MARGIN_DP.dp.roundToPx() }
+    val anchorGapPx = with(density) { FOOTNOTE_POPUP_ANCHOR_GAP_DP.dp.roundToPx() }
+    val anchorLineRadiusPx = with(density) {
+        (textSizeSp.sp.toPx() * FOOTNOTE_ANCHOR_LINE_RADIUS_MULTIPLIER).roundToInt()
+    }
+    val popupVerticalReserveDp = with(density) {
+        (edgeMarginPx + anchorGapPx + anchorLineRadiusPx).toDp()
+    }
+    val availableSideHeight = (
+        maxOf(anchorYFraction, 1f - anchorYFraction) * configuration.screenHeightDp
+        ).dp - popupVerticalReserveDp
+    val maxHeight = minOf(
+        preferredMaxHeight,
+        availableSideHeight.coerceAtLeast(FOOTNOTE_POPUP_MIN_HEIGHT_DP.dp),
+    )
+    val positionProvider = remember(
+        state.href,
+        state.anchorXFraction,
+        state.anchorYFraction,
+        edgeMarginPx,
+        anchorGapPx,
+        anchorLineRadiusPx,
+    ) {
+        EpubFootnotePopupPositionProvider(
+            anchorXFraction = state.anchorXFraction ?: 0.5f,
+            anchorYFraction = anchorYFraction,
+            edgeMarginPx = edgeMarginPx,
+            anchorGapPx = anchorGapPx,
+            anchorLineRadiusPx = anchorLineRadiusPx,
+        )
+    }
+    val placement = positionProvider.placement
+    val bubbleShape = remember(placement) { EpubFootnoteBubbleShape(placement) }
+    val tailHeight = FOOTNOTE_BUBBLE_TAIL_HEIGHT_DP.dp
+    val contentTopPadding = verticalPadding + if (placement.isAboveAnchor) 0.dp else tailHeight
+    val contentBottomPadding = verticalPadding + if (placement.isAboveAnchor) tailHeight else 0.dp
     val maxImageWidthPx = with(density) {
         (popupWidth - horizontalPadding * 2).roundToPx().coerceAtLeast(1)
     }
@@ -93,7 +148,7 @@ internal fun EpubFootnotePopup(
     }
 
     Popup(
-        alignment = Alignment.Center,
+        popupPositionProvider = positionProvider,
         onDismissRequest = onDismissRequest,
         properties = PopupProperties(
             focusable = true,
@@ -106,14 +161,19 @@ internal fun EpubFootnotePopup(
             modifier = Modifier.width(popupWidth),
             color = backgroundColor,
             contentColor = contentColor,
-            shape = androidx.compose.material3.MaterialTheme.shapes.medium,
+            shape = bubbleShape,
             shadowElevation = 12.dp,
         ) {
             AndroidView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .heightIn(max = maxHeight)
-                    .padding(horizontal = horizontalPadding, vertical = verticalPadding),
+                    .padding(
+                        start = horizontalPadding,
+                        top = contentTopPadding,
+                        end = horizontalPadding,
+                        bottom = contentBottomPadding,
+                    ),
                 factory = { context ->
                     TextView(context).apply {
                         includeFontPadding = false
@@ -131,6 +191,119 @@ internal fun EpubFootnotePopup(
             )
         }
     }
+}
+
+private data class EpubFootnotePopupPlacement(
+    val isAboveAnchor: Boolean,
+    val tailCenterPx: Int,
+)
+
+private class EpubFootnotePopupPositionProvider(
+    anchorXFraction: Float,
+    anchorYFraction: Float,
+    private val edgeMarginPx: Int,
+    private val anchorGapPx: Int,
+    private val anchorLineRadiusPx: Int,
+) : PopupPositionProvider {
+
+    private val anchorXFraction = anchorXFraction.coerceIn(0f, 1f)
+    private val anchorYFraction = anchorYFraction.coerceIn(0f, 1f)
+
+    var placement by mutableStateOf(
+        EpubFootnotePopupPlacement(
+            isAboveAnchor = anchorYFraction >= 0.5f,
+            tailCenterPx = 0,
+        ),
+    )
+        private set
+
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val anchorX = (windowSize.width * anchorXFraction).roundToInt()
+        val anchorY = (windowSize.height * anchorYFraction).roundToInt()
+        val anchorTop = anchorY - anchorLineRadiusPx
+        val anchorBottom = anchorY + anchorLineRadiusPx
+        val availableAbove = anchorTop - anchorGapPx - edgeMarginPx
+        val availableBelow = windowSize.height - anchorBottom - anchorGapPx - edgeMarginPx
+        val fitsAbove = popupContentSize.height <= availableAbove
+        val fitsBelow = popupContentSize.height <= availableBelow
+        val isAboveAnchor = when {
+            fitsAbove -> true
+            fitsBelow -> false
+            else -> availableAbove >= availableBelow
+        }
+
+        val preferredX = anchorX - popupContentSize.width / 2
+        val popupX = preferredX.coerceToWindow(
+            contentSize = popupContentSize.width,
+            windowSize = windowSize.width,
+            edgeMargin = edgeMarginPx,
+        )
+        val preferredY = if (isAboveAnchor) {
+            anchorTop - anchorGapPx - popupContentSize.height
+        } else {
+            anchorBottom + anchorGapPx
+        }
+        val popupY = preferredY.coerceToWindow(
+            contentSize = popupContentSize.height,
+            windowSize = windowSize.height,
+            edgeMargin = edgeMarginPx,
+        )
+        val updatedPlacement = EpubFootnotePopupPlacement(
+            isAboveAnchor = isAboveAnchor,
+            tailCenterPx = (anchorX - popupX).coerceIn(0, popupContentSize.width),
+        )
+        if (placement != updatedPlacement) {
+            placement = updatedPlacement
+        }
+        return IntOffset(popupX, popupY)
+    }
+}
+
+private class EpubFootnoteBubbleShape(
+    private val placement: EpubFootnotePopupPlacement,
+) : Shape {
+
+    override fun createOutline(size: Size, layoutDirection: LayoutDirection, density: Density): Outline {
+        val tailHeight = with(density) { FOOTNOTE_BUBBLE_TAIL_HEIGHT_DP.dp.toPx() }
+        val tailHalfWidth = with(density) { FOOTNOTE_BUBBLE_TAIL_HALF_WIDTH_DP.dp.toPx() }
+        val cornerRadius = with(density) { FOOTNOTE_BUBBLE_CORNER_RADIUS_DP.dp.toPx() }
+        val bodyTop = if (placement.isAboveAnchor) 0f else tailHeight
+        val bodyBottom = if (placement.isAboveAnchor) size.height - tailHeight else size.height
+        val tailCenter = placement.tailCenterPx.toFloat().coerceIn(
+            cornerRadius + tailHalfWidth,
+            (size.width - cornerRadius - tailHalfWidth).coerceAtLeast(cornerRadius + tailHalfWidth),
+        )
+        val path = Path().apply {
+            addRoundRect(
+                RoundRect(
+                    rect = Rect(0f, bodyTop, size.width, bodyBottom),
+                    cornerRadius = CornerRadius(cornerRadius),
+                ),
+            )
+            if (placement.isAboveAnchor) {
+                moveTo(tailCenter - tailHalfWidth, bodyBottom)
+                lineTo(tailCenter, size.height)
+                lineTo(tailCenter + tailHalfWidth, bodyBottom)
+            } else {
+                moveTo(tailCenter - tailHalfWidth, bodyTop)
+                lineTo(tailCenter, 0f)
+                lineTo(tailCenter + tailHalfWidth, bodyTop)
+            }
+            close()
+        }
+        return Outline.Generic(path)
+    }
+}
+
+private fun Int.coerceToWindow(contentSize: Int, windowSize: Int, edgeMargin: Int): Int {
+    val maximum = (windowSize - contentSize - edgeMargin).coerceAtLeast(0)
+    val minimum = edgeMargin.coerceAtMost(maximum)
+    return coerceIn(minimum, maximum)
 }
 
 private suspend fun decodeFootnoteImages(
@@ -175,3 +348,11 @@ private fun Drawable.setFootnoteBounds(maxWidthPx: Int, maxHeightPx: Int, fallba
         (sourceHeight * scale).roundToInt().coerceAtLeast(1),
     )
 }
+
+private const val FOOTNOTE_POPUP_EDGE_MARGIN_DP = 8
+private const val FOOTNOTE_POPUP_ANCHOR_GAP_DP = 2
+private const val FOOTNOTE_ANCHOR_LINE_RADIUS_MULTIPLIER = 0.7f
+private const val FOOTNOTE_POPUP_MIN_HEIGHT_DP = 96
+private const val FOOTNOTE_BUBBLE_TAIL_HEIGHT_DP = 8
+private const val FOOTNOTE_BUBBLE_TAIL_HALF_WIDTH_DP = 7
+private const val FOOTNOTE_BUBBLE_CORNER_RADIUS_DP = 12

--- a/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
@@ -1,0 +1,93 @@
+package koharia.epub
+
+import android.text.method.ScrollingMovementMethod
+import android.util.TypedValue
+import android.widget.TextView
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.core.text.HtmlCompat
+
+internal data class EpubFootnoteUiState(
+    val href: String,
+    val contentHtml: String,
+)
+
+@Composable
+internal fun EpubFootnotePopup(
+    state: EpubFootnoteUiState?,
+    backgroundColor: Color,
+    readerFontSizeSp: Float,
+    applyReaderStyles: Boolean,
+    onDismissRequest: () -> Unit,
+) {
+    state ?: return
+    val contentColor = if (backgroundColor.luminance() >= 0.45f) {
+        Color(0xFF24221E)
+    } else {
+        Color(0xFFF1EEE7)
+    }
+    val widthFraction = if (applyReaderStyles) 0.78f else 0.86f
+    val maxWidth = if (applyReaderStyles) 480.dp else 560.dp
+    val popupWidth = minOf(LocalConfiguration.current.screenWidthDp.dp * widthFraction, maxWidth)
+    val maxHeight = if (applyReaderStyles) 320.dp else 380.dp
+    val horizontalPadding = if (applyReaderStyles) 14.dp else 20.dp
+    val verticalPadding = if (applyReaderStyles) 12.dp else 18.dp
+    val textSizeSp = if (applyReaderStyles) readerFontSizeSp else 17f
+
+    Popup(
+        alignment = Alignment.Center,
+        onDismissRequest = onDismissRequest,
+        properties = PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            clippingEnabled = true,
+        ),
+    ) {
+        Surface(
+            modifier = Modifier.width(popupWidth),
+            color = backgroundColor,
+            contentColor = contentColor,
+            shape = androidx.compose.material3.MaterialTheme.shapes.medium,
+            shadowElevation = 12.dp,
+        ) {
+            AndroidView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = maxHeight)
+                    .padding(horizontal = horizontalPadding, vertical = verticalPadding),
+                factory = { context ->
+                    TextView(context).apply {
+                        includeFontPadding = false
+                        setLineSpacing(0f, 1.2f)
+                        movementMethod = ScrollingMovementMethod()
+                        isVerticalScrollBarEnabled = true
+                        linksClickable = false
+                    }
+                },
+                update = { textView ->
+                    textView.setTextColor(contentColor.toArgb())
+                    textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp)
+                    textView.text = HtmlCompat.fromHtml(
+                        state.contentHtml,
+                        HtmlCompat.FROM_HTML_MODE_COMPACT,
+                    )
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
+++ b/app/src/main/java/koharia/epub/EpubFootnotePopup.kt
@@ -1,5 +1,7 @@
 package koharia.epub
 
+import android.content.Context
+import android.graphics.drawable.Drawable
 import android.text.method.ScrollingMovementMethod
 import android.util.TypedValue
 import android.widget.TextView
@@ -9,21 +11,34 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.core.text.HtmlCompat
+import coil3.asDrawable
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import coil3.svg.SvgDecoder
+import okio.Buffer
+import kotlin.math.roundToInt
 
 internal data class EpubFootnoteUiState(
     val href: String,
     val contentHtml: String,
+    val images: Map<String, EpubFootnoteImageContent> = emptyMap(),
 )
 
 @Composable
@@ -47,6 +62,35 @@ internal fun EpubFootnotePopup(
     val horizontalPadding = if (applyReaderStyles) 14.dp else 20.dp
     val verticalPadding = if (applyReaderStyles) 12.dp else 18.dp
     val textSizeSp = if (applyReaderStyles) readerFontSizeSp else 17f
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val maxImageWidthPx = with(density) {
+        (popupWidth - horizontalPadding * 2).roundToPx().coerceAtLeast(1)
+    }
+    val maxImageHeightPx = with(density) {
+        (maxHeight - verticalPadding * 2).roundToPx().coerceAtLeast(1)
+    }
+    val fallbackImageSizePx = with(density) { textSizeSp.sp.roundToPx().coerceAtLeast(1) }
+    val renderedContent by produceState<CharSequence>(
+        initialValue = HtmlCompat.fromHtml(state.contentHtml, HtmlCompat.FROM_HTML_MODE_COMPACT),
+        key1 = state,
+        key2 = Triple(maxImageWidthPx, maxImageHeightPx, fallbackImageSizePx),
+    ) {
+        if (state.images.isEmpty()) return@produceState
+        val drawables = decodeFootnoteImages(
+            context = context,
+            images = state.images,
+            maxWidthPx = maxImageWidthPx,
+            maxHeightPx = maxImageHeightPx,
+            fallbackSizePx = fallbackImageSizePx,
+        )
+        value = HtmlCompat.fromHtml(
+            state.contentHtml,
+            HtmlCompat.FROM_HTML_MODE_COMPACT,
+            { source -> drawables[source] },
+            null,
+        )
+    }
 
     Popup(
         alignment = Alignment.Center,
@@ -82,12 +126,52 @@ internal fun EpubFootnotePopup(
                 update = { textView ->
                     textView.setTextColor(contentColor.toArgb())
                     textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp)
-                    textView.text = HtmlCompat.fromHtml(
-                        state.contentHtml,
-                        HtmlCompat.FROM_HTML_MODE_COMPACT,
-                    )
+                    textView.text = renderedContent
                 },
             )
         }
     }
+}
+
+private suspend fun decodeFootnoteImages(
+    context: Context,
+    images: Map<String, EpubFootnoteImageContent>,
+    maxWidthPx: Int,
+    maxHeightPx: Int,
+    fallbackSizePx: Int,
+): Map<String, Drawable> = buildMap {
+    images.forEach { (sourceName, content) ->
+        val source = Buffer().write(content.bytes)
+        val drawable = try {
+            val request = ImageRequest.Builder(context)
+                .data(source)
+                .size(maxWidthPx, maxHeightPx)
+                .crossfade(false)
+                .apply {
+                    if (content.isSvg) decoderFactory(SvgDecoder.Factory())
+                }
+                .build()
+            context.imageLoader.execute(request).image?.asDrawable(context.resources)
+        } finally {
+            source.close()
+        } ?: return@forEach
+        drawable.setFootnoteBounds(maxWidthPx, maxHeightPx, fallbackSizePx)
+        put(sourceName, drawable)
+    }
+}
+
+private fun Drawable.setFootnoteBounds(maxWidthPx: Int, maxHeightPx: Int, fallbackSizePx: Int) {
+    val sourceWidth = intrinsicWidth.takeIf { it > 0 } ?: fallbackSizePx
+    val sourceHeight = intrinsicHeight.takeIf { it > 0 } ?: fallbackSizePx
+    val scale = minOf(
+        1f,
+        maxWidthPx.toFloat() / sourceWidth,
+        maxHeightPx.toFloat() / sourceHeight,
+    )
+    setBounds(
+        0,
+        0,
+        (sourceWidth * scale).roundToInt().coerceAtLeast(1),
+        (sourceHeight * scale).roundToInt().coerceAtLeast(1),
+    )
 }

--- a/app/src/main/java/koharia/epub/EpubImageResourceLoader.kt
+++ b/app/src/main/java/koharia/epub/EpubImageResourceLoader.kt
@@ -105,7 +105,7 @@ internal fun epubImageCandidateHrefs(
     addCandidate(rawSource)
 }.filter(String::isNotBlank).distinct()
 
-private fun ByteArray.isSvgImage(): Boolean {
+internal fun ByteArray.isSvgImage(): Boolean {
     val prefix = copyOfRange(0, size.coerceAtMost(SVG_PREFIX_BYTES))
         .toString(StandardCharsets.UTF_8)
         .trimStart('\uFEFF')

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -223,6 +223,7 @@ internal fun buildEpubDocumentPreparationScript(
     chapterBreaksEnabled: Boolean,
     preserveImageColors: Boolean,
     parentColorsInverted: Boolean,
+    readerFontScale: Float,
 ): String {
     val layoutPreparationScript = buildEpubLayoutPreparationScript(
         paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
@@ -233,6 +234,10 @@ internal fun buildEpubDocumentPreparationScript(
     return """
         (function() {
             $layoutPreparationScript;
+            ${buildEpubFootnoteCompatibilityScript(
+        applyReaderStyles = paragraphIndentOverrideEnabled,
+        readerFontScale = readerFontScale,
+    )};
             ${buildEpubImageColorPolicyScript(preserveImageColors, parentColorsInverted)};
             return 'prepared';
         })()

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -101,6 +101,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.Locator
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.toUri
@@ -233,6 +234,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         setComposeContent {
             val state by viewModel.state.collectAsState()
             val imageState by viewModel.imageState.collectAsState()
+            val footnoteState by viewModel.footnoteState.collectAsState()
             val tocEntries =
                 remember(state.chapterId, state.sessionToken, state.isReady) { viewModel.tableOfContents() }
             val adjacentTocEntries = remember(tocEntries, state.currentPosition, state.currentHref) {
@@ -251,6 +253,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 .collectAsState(epubLayoutPreferences.pageDirection.get())
             val currentVerticalMargins by epubLayoutPreferences.verticalMargins.changes()
                 .collectAsState(epubLayoutPreferences.verticalMargins.get())
+            val currentFontScale by epubLayoutPreferences.fontSize.changes()
+                .collectAsState(epubLayoutPreferences.fontSize.get())
+            val publisherStylesEnabled by epubLayoutPreferences.publisherStyles.changes()
+                .collectAsState(epubLayoutPreferences.publisherStyles.get())
             val fullscreenVerticalPadding = remember(currentVerticalMargins) {
                 readerVerticalPaddingDp(currentVerticalMargins).dp
             }
@@ -779,6 +785,14 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                 onShare = { viewModel.shareSelectedImage(copyToClipboard = false) },
                 onCopy = { viewModel.shareSelectedImage(copyToClipboard = true) },
             )
+
+            EpubFootnotePopup(
+                state = footnoteState,
+                backgroundColor = currentReaderBackgroundColor,
+                readerFontSizeSp = EpubLayoutPreferences.fontSizeFromScale(currentFontScale).toFloat(),
+                applyReaderStyles = !publisherStylesEnabled,
+                onDismissRequest = viewModel::dismissFootnote,
+            )
         }
 
         viewModel.imageEvents
@@ -899,7 +913,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     override fun onTap(positionX: Float, positionY: Float): Boolean {
-        if (viewModel.imageState.value.isVisible) return true
+        if (viewModel.imageState.value.isVisible || viewModel.footnoteState.value != null) return true
         val isRightToLeft = epubLayoutPreferences.readingMode.get() == EpubLayoutPreferences.ReadingMode.PAGINATED &&
             epubLayoutPreferences.pageDirection.get() == EpubLayoutPreferences.PageDirection.RIGHT_TO_LEFT
         return when (resolveNavigationAction(positionX, positionY)) {
@@ -981,6 +995,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         openInBrowser(url.toUri(), forceDefaultBrowser = false)
     }
 
+    override fun onFootnoteActivated(link: Link, contentHtml: String) {
+        viewModel.showFootnote(link, contentHtml)
+    }
+
     override fun onImageInteraction(reference: EpubImageReference, interaction: EpubImageInteraction) {
         if (interaction == EpubImageInteraction.PREVIEW && viewModel.state.value.menuVisible) {
             viewModel.showMenus(false)
@@ -1005,7 +1023,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             event.keyCode == KeyEvent.KEYCODE_VOLUME_UP
         val state = viewModel.state.value
         if (!isVolumeKey || !epubLayoutPreferences.readWithVolumeKeys.get() ||
-            state.menuVisible || state.isSearchActive || viewModel.imageState.value.isVisible
+            state.menuVisible || state.isSearchActive || viewModel.imageState.value.isVisible ||
+            viewModel.footnoteState.value != null
         ) {
             return super.dispatchKeyEvent(event)
         }

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -12,7 +12,9 @@ import android.graphics.Paint
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.KeyEvent
+import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
 import androidx.activity.compose.BackHandler
@@ -128,6 +130,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
         private const val PAGINATION_SETTINGS_DEBOUNCE_MS = 250L
         private const val PAGINATION_VIEWPORT_DEBOUNCE_MS = 250L
         private const val PROGRESSION_SEEK_DEBOUNCE_MS = 100L
+        private const val FOOTNOTE_TOUCH_POSITION_MAX_AGE_MS = 10_000L
 
         fun newIntent(
             context: Context,
@@ -205,6 +208,9 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     private var currentPublisherStyles: Boolean? = null
     private var readerFragment: EpubReaderFragment? = null
     private var imagePreviewVisible = false
+    private var lastTouchXFraction: Float? = null
+    private var lastTouchYFraction: Float? = null
+    private var lastTouchPositionTimeMs = 0L
 
     override fun onCreate(savedInstanceState: Bundle?) {
         registerSecureActivity(this)
@@ -996,7 +1002,17 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     }
 
     override fun onFootnoteActivated(link: Link, contentHtml: String) {
-        viewModel.showFootnote(link, contentHtml)
+        val hasRecentTouch = lastTouchPositionTimeMs != 0L &&
+            SystemClock.elapsedRealtime() - lastTouchPositionTimeMs <= FOOTNOTE_TOUCH_POSITION_MAX_AGE_MS
+        viewModel.showFootnote(
+            link = link,
+            contentHtml = contentHtml,
+            anchorXFraction = lastTouchXFraction.takeIf { hasRecentTouch },
+            anchorYFraction = lastTouchYFraction.takeIf { hasRecentTouch },
+        )
+        lastTouchXFraction = null
+        lastTouchYFraction = null
+        lastTouchPositionTimeMs = 0L
     }
 
     override fun onImageInteraction(reference: EpubImageReference, interaction: EpubImageInteraction) {
@@ -1016,6 +1032,18 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     override fun onSessionMissing(chapterId: Long) {
         viewModel.onSessionMissing(chapterId)
+    }
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+            val decorView = window.decorView
+            if (decorView.width > 0 && decorView.height > 0) {
+                lastTouchXFraction = (event.x / decorView.width).coerceIn(0f, 1f)
+                lastTouchYFraction = (event.y / decorView.height).coerceIn(0f, 1f)
+                lastTouchPositionTimeMs = SystemClock.elapsedRealtime()
+            }
+        }
+        return super.dispatchTouchEvent(event)
     }
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -66,6 +66,8 @@ class EpubReaderFragment : Fragment() {
 
         fun onExternalLinkActivated(url: AbsoluteUrl)
 
+        fun onFootnoteActivated(link: Link, contentHtml: String)
+
         fun onImageInteraction(reference: EpubImageReference, interaction: EpubImageInteraction)
 
         fun onNavigatorReady(fragment: EpubReaderFragment)
@@ -94,6 +96,7 @@ class EpubReaderFragment : Fragment() {
     private var navigatorInputListener: InputListener? = null
     private var paragraphIndentDebugGeneration = 0L
     private var paragraphIndentOverrideEnabled = false
+    private var readerFontScale = 1f
     private var textAlignmentOverride: EpubLayoutPreferences.TextAlignment? = null
     private var tocHrefs: List<String> = emptyList()
     private var chapterBreaksEnabled = false
@@ -108,6 +111,7 @@ class EpubReaderFragment : Fragment() {
         chapterBreaksEnabled = chapterBreaksEnabled,
         preserveImageColors = preserveImageColors,
         parentColorsInverted = parentColorsInverted,
+        readerFontScale = readerFontScale,
     )
     private var imageColorPolicyGeneration = 0L
     private var imageColorPolicyRoot: View? = null
@@ -127,7 +131,11 @@ class EpubReaderFragment : Fragment() {
             link: Link,
             context: HyperlinkNavigator.LinkContext?,
         ): Boolean {
-            return true
+            val footnote = context as? HyperlinkNavigator.FootnoteContext ?: return true
+            val contentHtml = footnote.noteContent.trim().takeIf { it.isNotEmpty() } ?: return true
+            val currentHost = host ?: return true
+            currentHost.onFootnoteActivated(link, contentHtml)
+            return false
         }
     }
 
@@ -147,6 +155,7 @@ class EpubReaderFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         val session = sessionRepository.get(chapterId)
         paragraphIndentOverrideEnabled = epubLayoutPreferences.publisherStyles.get().not()
+        readerFontScale = epubLayoutPreferences.fontSize.get()
         textAlignmentOverride = epubLayoutPreferences.textAlignment.get()
             .takeIf { paragraphIndentOverrideEnabled }
         tocHrefs = session?.publication?.tableOfContents?.flattenEpubTocHrefs().orEmpty()
@@ -304,14 +313,17 @@ class EpubReaderFragment : Fragment() {
             clearContinuousScrollState()
         }
         val paragraphOverrideEnabled = preferences.publisherStyles == false
+        val nextReaderFontScale = preferences.fontSize?.toFloat() ?: readerFontScale
         val nextTextAlignmentOverride = epubLayoutPreferences.textAlignment.get()
             .takeIf { paragraphOverrideEnabled }
         val nextChapterBreaksEnabled = preferences.scroll != true
         val documentPolicyChanged =
             paragraphIndentOverrideEnabled != paragraphOverrideEnabled ||
                 textAlignmentOverride != nextTextAlignmentOverride ||
-                chapterBreaksEnabled != nextChapterBreaksEnabled
+                chapterBreaksEnabled != nextChapterBreaksEnabled ||
+                (paragraphOverrideEnabled && readerFontScale != nextReaderFontScale)
         paragraphIndentOverrideEnabled = paragraphOverrideEnabled
+        readerFontScale = nextReaderFontScale
         textAlignmentOverride = nextTextAlignmentOverride
         chapterBreaksEnabled = nextChapterBreaksEnabled
         navigator?.submitPreferences(preferences)
@@ -411,6 +423,7 @@ class EpubReaderFragment : Fragment() {
             chapterBreaksEnabled = chapterBreaksEnabled,
             preserveImageColors = preserveImageColors,
             parentColorsInverted = parentColorsInverted,
+            readerFontScale = readerFontScale,
         )
         imageColorPolicyGeneration++
         installedImageColorPolicies.clear()
@@ -682,10 +695,19 @@ class EpubReaderFragment : Fragment() {
                             preserveImageColors = preserveImageColors,
                             parentColorsInverted = parentColorsInverted,
                         ),
-                        paragraphIndentScript = buildEpubTypographyPreparationScript(
+                        contentPreparationScript = """
+                            (function() {
+                                ${buildEpubTypographyPreparationScript(
                             paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
                             textAlignment = textAlignmentOverride,
-                        ),
+                        )};
+                                ${buildEpubFootnoteCompatibilityScript(
+                            applyReaderStyles = paragraphIndentOverrideEnabled,
+                            readerFontScale = readerFontScale,
+                        )};
+                                return true;
+                            })()
+                        """.trimIndent(),
                     ),
                 )
             }.getOrNull()

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -670,13 +670,20 @@ class EpubReaderViewModel @JvmOverloads constructor(
         mutableState.update { it.copy(menuVisible = visible) }
     }
 
-    internal fun showFootnote(link: Link, contentHtml: String) {
+    internal fun showFootnote(
+        link: Link,
+        contentHtml: String,
+        anchorXFraction: Float?,
+        anchorYFraction: Float?,
+    ) {
         closeImagePreview()
         footnoteLoadJob?.cancel()
         val href = link.href.toString()
         mutableFootnoteState.value = EpubFootnoteUiState(
             href = href,
             contentHtml = contentHtml,
+            anchorXFraction = anchorXFraction,
+            anchorYFraction = anchorYFraction,
         )
         showMenus(false)
         footnoteLoadJob = viewModelScope.launch {

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -212,6 +212,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var completionMarkedThisSession = false
     private var searchIterator: SearchIterator? = null
     private var imageLoadJob: Job? = null
+    private var footnoteLoadJob: Job? = null
     private var incognitoSession = basePreferences.incognitoMode.get()
     private val locatorPersistenceJob = viewModelScope.launch {
         locatorUpdates
@@ -671,14 +672,39 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     internal fun showFootnote(link: Link, contentHtml: String) {
         closeImagePreview()
+        footnoteLoadJob?.cancel()
+        val href = link.href.toString()
         mutableFootnoteState.value = EpubFootnoteUiState(
-            href = link.href.toString(),
+            href = href,
             contentHtml = contentHtml,
         )
         showMenus(false)
+        footnoteLoadJob = viewModelScope.launch {
+            val images = try {
+                withIOContext {
+                    val publication = sessionRepository.get(chapterId)?.publication
+                        ?: return@withIOContext emptyMap()
+                    loadEpubFootnoteImages(publication, href, contentHtml)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                logcat(LogPriority.WARN, error) { "Failed to load EPUB footnote images" }
+                emptyMap()
+            }
+            mutableFootnoteState.update { state ->
+                if (state?.href == href && state.contentHtml == contentHtml) {
+                    state.copy(images = images)
+                } else {
+                    state
+                }
+            }
+        }
     }
 
     internal fun dismissFootnote() {
+        footnoteLoadJob?.cancel()
+        footnoteLoadJob = null
         mutableFootnoteState.value = null
     }
 
@@ -1786,6 +1812,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     override fun onCleared() {
         imageLoadJob?.cancel()
+        footnoteLoadJob?.cancel()
         imageRequestTracker.invalidate()
         searchIterator?.close()
         searchIterator = null

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -145,6 +145,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
     val state = mutableState.asStateFlow()
     private val mutableImageState = MutableStateFlow(EpubImageUiState())
     internal val imageState = mutableImageState.asStateFlow()
+    private val mutableFootnoteState = MutableStateFlow<EpubFootnoteUiState?>(null)
+    internal val footnoteState = mutableFootnoteState.asStateFlow()
     private val mutableImageEvents = MutableSharedFlow<EpubImageEvent>(extraBufferCapacity = 1)
     internal val imageEvents = mutableImageEvents.asSharedFlow()
     private val imageRequestTracker = EpubImageRequestTracker()
@@ -665,6 +667,19 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun showMenus(visible: Boolean) {
         mutableState.update { it.copy(menuVisible = visible) }
+    }
+
+    internal fun showFootnote(link: Link, contentHtml: String) {
+        closeImagePreview()
+        mutableFootnoteState.value = EpubFootnoteUiState(
+            href = link.href.toString(),
+            contentHtml = contentHtml,
+        )
+        showMenus(false)
+    }
+
+    internal fun dismissFootnote() {
+        mutableFootnoteState.value = null
     }
 
     internal fun onImageInteraction(
@@ -1747,6 +1762,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun releaseSession() {
         closeImagePreview()
+        dismissFootnote()
         locatorPersistenceJob.cancel()
         val finalPositions = authoritativePublicationPositions()
         sessionRepository.remove(chapterId)?.close()

--- a/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
+++ b/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
@@ -24,7 +24,7 @@ class EpubDocumentPreparationTest {
         assertTrue(script.contains("hyphens: auto !important"))
         assertTrue(script.contains("break-before: column !important"))
         assertTrue(script.contains("'duokan-footnote'"))
-        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', 'noteref')"))
+        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', updated)"))
         assertTrue(script.contains("font-size: 1.125rem !important"))
         assertTrue(script.contains("filter: invert(100%) !important"))
         assertTrue(script.contains("return 'prepared'"))

--- a/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
+++ b/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
@@ -16,12 +16,16 @@ class EpubDocumentPreparationTest {
             chapterBreaksEnabled = true,
             preserveImageColors = true,
             parentColorsInverted = true,
+            readerFontScale = 1.5f,
         )
 
         assertTrue(script.contains(EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE))
         assertTrue(script.contains("text-align: justify !important"))
         assertTrue(script.contains("hyphens: auto !important"))
         assertTrue(script.contains("break-before: column !important"))
+        assertTrue(script.contains("'duokan-footnote'"))
+        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', 'noteref')"))
+        assertTrue(script.contains("font-size: 1.125rem !important"))
         assertTrue(script.contains("filter: invert(100%) !important"))
         assertTrue(script.contains("return 'prepared'"))
     }
@@ -35,6 +39,7 @@ class EpubDocumentPreparationTest {
             chapterBreaksEnabled = false,
             preserveImageColors = false,
             parentColorsInverted = false,
+            readerFontScale = 1f,
         )
 
         assertTrue(script.contains("paragraph.removeAttribute('$EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE')"))

--- a/app/src/test/java/koharia/epub/EpubFootnoteCompatibilityTest.kt
+++ b/app/src/test/java/koharia/epub/EpubFootnoteCompatibilityTest.kt
@@ -37,8 +37,16 @@ class EpubFootnoteCompatibilityTest {
     @Test
     fun `script marks xhtml links using the epub namespace`() {
         assertTrue(script.contains("root.localName.toLowerCase() !== 'html'"))
-        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', 'noteref')"))
+        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', updated)"))
         assertTrue(script.contains("data-koharia-footnotes-prepared"))
+    }
+
+    @Test
+    fun `script preserves existing epub type tokens and creates an xhtml style element`() {
+        assertTrue(script.contains("const values = String(current).trim().split(/\\s+/).filter(Boolean)"))
+        assertTrue(script.contains("values.push(type)"))
+        assertTrue(script.contains("values.join(' ')"))
+        assertTrue(script.contains("createElementNS(root.namespaceURI || xhtmlNamespace, 'style')"))
     }
 
     @Test

--- a/app/src/test/java/koharia/epub/EpubFootnoteCompatibilityTest.kt
+++ b/app/src/test/java/koharia/epub/EpubFootnoteCompatibilityTest.kt
@@ -1,0 +1,69 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubFootnoteCompatibilityTest {
+
+    private val script = buildEpubFootnoteCompatibilityScript(
+        applyReaderStyles = true,
+        readerFontScale = 1f,
+    )
+
+    @Test
+    fun `script preserves standard noterefs and recognizes accessibility roles`() {
+        assertTrue(script.contains("epubTypes(anchor).includes('noteref')"))
+        assertTrue(script.contains("role === 'doc-noteref'"))
+        assertTrue(script.contains("role === 'doc-footnote'"))
+        assertTrue(script.contains("role === 'doc-endnote'"))
+    }
+
+    @Test
+    fun `script recognizes duokan and common footnote classes`() {
+        assertTrue(script.contains("'duokan-footnote'"))
+        assertTrue(script.contains("'duokan-footnote-item'"))
+        assertTrue(script.contains("'footnote-ref'"))
+        assertTrue(script.contains("'endnote-ref'"))
+    }
+
+    @Test
+    fun `script only inspects same document fragment targets`() {
+        assertTrue(script.contains("url.origin !== documentUrl.origin"))
+        assertTrue(script.contains("url.pathname !== documentUrl.pathname"))
+        assertTrue(script.contains("url.search !== documentUrl.search"))
+        assertTrue(script.contains("document.getElementById(id)"))
+    }
+
+    @Test
+    fun `script marks xhtml links using the epub namespace`() {
+        assertTrue(script.contains("root.localName.toLowerCase() !== 'html'"))
+        assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', 'noteref')"))
+        assertTrue(script.contains("data-koharia-footnotes-prepared"))
+    }
+
+    @Test
+    fun `reader styles place text and common graphics as three quarter inline superscripts`() {
+        assertTrue(script.contains("font-size: 0.75rem !important"))
+        assertTrue(script.contains("vertical-align: super !important"))
+        assertTrue(script.contains("inset: -0.125rem !important"))
+        assertTrue(script.contains("transform: none !important"))
+        assertTrue(script.contains("img, svg, picture, object, input[type=\"image\"], [role=\"img\"]"))
+        assertTrue(script.contains("width: 1em !important"))
+        assertTrue(script.contains("height: 1em !important"))
+        assertTrue(script.contains("] > *"))
+        assertTrue(script.contains("padding: 0 !important"))
+        assertTrue(script.contains("margin: 0 !important"))
+    }
+
+    @Test
+    fun `publisher styles remove reader footnote overrides`() {
+        val publisherScript = buildEpubFootnoteCompatibilityScript(
+            applyReaderStyles = false,
+            readerFontScale = 2f,
+        )
+
+        assertTrue(publisherScript.contains("const applyReaderStyles = false"))
+        assertTrue(publisherScript.contains("if (previousStyle) previousStyle.remove()"))
+        assertTrue(publisherScript.contains("anchor.removeAttribute(referenceAttribute)"))
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubFootnoteImageLoaderTest.kt
+++ b/app/src/test/java/koharia/epub/EpubFootnoteImageLoaderTest.kt
@@ -1,0 +1,26 @@
+package koharia.epub
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class EpubFootnoteImageLoaderTest {
+
+    @Test
+    fun `image sources retain relative paths and remove duplicates`() {
+        val sources = epubFootnoteImageSources(
+            """
+            <p>Formula <img src="../images/formula.svg" alt="formula"></p>
+            <p><img src="symbols/note.png"><img src="../images/formula.svg"></p>
+            """.trimIndent(),
+        )
+
+        assertEquals(listOf("../images/formula.svg", "symbols/note.png"), sources)
+    }
+
+    @Test
+    fun `image source count is bounded`() {
+        val html = (0..9).joinToString(separator = "") { index -> "<img src=\"image-$index.png\">" }
+
+        assertEquals(8, epubFootnoteImageSources(html).size)
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageInteractionTest.kt
@@ -67,7 +67,7 @@ class EpubImageInteractionTest {
             currentIndex = 0,
             initialProgression = 0.0,
             imageInteractionScript = script,
-            paragraphIndentScript = "",
+            contentPreparationScript = "",
         )
 
         assertTrue(continuousScript.contains("iframe.style.visibility = 'hidden'"))


### PR DESCRIPTION
## 中文

### 改动内容

- 接入 Readium `HyperlinkNavigator.FootnoteContext`，点击 EPUB 正文注释后在阅读页中央显示可滚动的小窗。
- 兼容标准 `epub:type="noteref"`、无障碍角色以及多看等常见非标准脚注类名，并仅转换可确认的同文档脚注链接。
- 在分页与连续滚动模式中统一安装脚注兼容脚本，连续滚动 iframe 在内容准备完成后再显示。
- 注释弹窗沿用当前阅读背景和正文设置字号；开启出版商样式时保留出版物自身的图标及内容样式策略。
- 阅读器样式下将文字、图片、SVG 等注释标记统一为当前字号的 3/4，以正常行内上标定位，避免遮挡正文；透明扩展点击区域不参与排版。
- 注释打开期间拦截翻页点击和音量键翻页，关闭阅读菜单，并在会话释放时清理状态。

### 问题原因与影响

此前 EPUB 阅读器未处理 Readium 提供的脚注上下文，非标准脚注链接也没有转换为可识别的 noteref，因此点击后无法展示注释。修复后，标准和常见非标准 EPUB 均可在不离开当前阅读位置的情况下查看注释。

### 验证

- `.\gradlew.bat spotlessApply`
- `.\gradlew.bat spotlessCheck`
- `.\gradlew.bat :app:testDebugUnitTest --tests koharia.epub.EpubFootnoteCompatibilityTest --tests koharia.epub.EpubDocumentPreparationTest`
- `.\gradlew.bat :app:testDebugUnitTest --tests koharia.epub.EpubImageInteractionTest`
- 测试过程执行并通过 `:app:compileDebugKotlin`

## English

### What changed

- Integrated Readium's `HyperlinkNavigator.FootnoteContext` so tapping an EPUB note reference opens a compact, scrollable popup centered over the reader.
- Added compatibility for standard `epub:type="noteref"`, accessibility roles, and common non-standard footnote classes such as Duokan, while converting only reliably identified same-document note links.
- Applied the same content preparation to paginated and continuous-scroll documents, keeping continuous-scroll iframes hidden until preparation finishes.
- Matched popup colors and text size to the active reader settings, while preserving publisher-controlled behavior when publisher styles are enabled.
- Sized text, image, and SVG note markers to three quarters of the reader font and placed them as normal inline superscripts without covering body text; an expanded transparent hit area does not affect layout.
- Suppressed reader navigation while a footnote is open and cleared popup state when the reading session is released.

### Root cause and impact

The EPUB reader did not consume Readium's footnote link context, and common non-standard footnote references were not exposed as recognizable noterefs. Readers can now inspect standard and compatible non-standard EPUB notes without leaving their current reading position.

### Validation

- `.\gradlew.bat spotlessApply`
- `.\gradlew.bat spotlessCheck`
- `.\gradlew.bat :app:testDebugUnitTest --tests koharia.epub.EpubFootnoteCompatibilityTest --tests koharia.epub.EpubDocumentPreparationTest`
- `.\gradlew.bat :app:testDebugUnitTest --tests koharia.epub.EpubImageInteractionTest`
- `:app:compileDebugKotlin` executed and passed as part of the test tasks