### PR TITLE
修复章节缓存与小组件更新崩溃 / Fix chapter cache and widget update crashes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -150,6 +150,13 @@
             android:exported="false"
             android:theme="@android:style/Theme.NoDisplay" />
 
+        <!-- The current widgets use direct actions in a static grid. Keeping Glance's list
+             trampoline registered allows stale launcher PendingIntents without a target Intent
+             to start it and crash the app. -->
+        <activity
+            android:name="androidx.glance.appwidget.action.ActionTrampolineActivity"
+            tools:node="remove" />
+
         <receiver
             android:name=".data.notification.NotificationReceiver"
             android:exported="false" />

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -32,16 +32,50 @@ class ChapterCache(
 ) {
 
     /** Cache class used for cache management. */
-    private val diskCache = DiskLruCache.open(
-        LocalTempCacheDirectoryProvider.chapterCacheDir(context),
-        PARAMETER_APP_VERSION,
-        PARAMETER_VALUE_COUNT,
-        calculateCacheSize(context),
-    )
+    private val diskCache = openDiskCache(context)
 
-    private fun calculateCacheSize(context: Context): Long {
+    private fun openDiskCache(context: Context): DiskLruCache {
+        val directoryProviders = listOf<() -> File>(
+            { LocalTempCacheDirectoryProvider.chapterCacheDir(context) },
+            { LocalTempCacheDirectoryProvider.internalChapterCacheDir(context) },
+        )
+        val attemptedPaths = mutableSetOf<String>()
+        var lastFailure: Exception? = null
+
+        for (directoryProvider in directoryProviders) {
+            val directory = try {
+                directoryProvider()
+            } catch (error: Exception) {
+                lastFailure = error
+                logcat(LogPriority.WARN, error) { "Failed to prepare a chapter cache directory" }
+                continue
+            }
+            if (!attemptedPaths.add(directory.absolutePath)) continue
+
+            try {
+                if (!directory.isDirectory && !directory.mkdirs()) {
+                    throw IOException("Unable to create chapter cache directory: $directory")
+                }
+                return DiskLruCache.open(
+                    directory,
+                    PARAMETER_APP_VERSION,
+                    PARAMETER_VALUE_COUNT,
+                    calculateCacheSize(directory),
+                )
+            } catch (error: Exception) {
+                lastFailure = error
+                logcat(LogPriority.WARN, error) {
+                    "Failed to open chapter cache at $directory"
+                }
+            }
+        }
+
+        throw IOException("Unable to open the chapter cache", lastFailure)
+    }
+
+    private fun calculateCacheSize(directory: File): Long {
         return try {
-            val stat = android.os.StatFs(LocalTempCacheDirectoryProvider.chapterCacheDir(context).absolutePath)
+            val stat = android.os.StatFs(directory.absolutePath)
             val totalBytes = stat.blockCountLong * stat.blockSizeLong
             val availableBytes = stat.availableBlocksLong * stat.blockSizeLong
             val minCacheBytes = 100L * 1024 * 1024

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/ChapterCache.kt
@@ -233,6 +233,7 @@ class ChapterCache(
                 deletedFiles++
             }
         }
+        deletedFiles += LocalTempCacheDirectoryProvider.clearInactiveChapterCaches(context, cacheDir)
         return deletedFiles
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalCacheCleaner.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/cache/LocalCacheCleaner.kt
@@ -26,7 +26,7 @@ class LocalCacheCleaner(
     }
 
     fun clearChapterCache(): Int {
-        return chapterCache.clear() + LocalTempCacheDirectoryProvider.clearLegacyChapterCache(context)
+        return chapterCache.clear()
     }
 
     fun clearCoverCache(): Int {

--- a/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
@@ -59,13 +59,15 @@ object LocalTempCacheDirectoryProvider {
         )
     }
 
-    fun clearLegacyChapterCache(context: Context): Int {
-        val legacy = legacyDirectory(context, CHAPTER_CACHE_DIR)
-        return if (legacy.absolutePath == chapterCacheDir(context).absolutePath) {
-            0
-        } else {
-            clearDirectoryContents(legacy, recreate = false)
-        }
+    fun clearInactiveChapterCaches(context: Context, activeDirectory: File): Int {
+        return listOf(
+            chapterCacheDir(context),
+            internalChapterCacheDir(context),
+            legacyDirectory(context, CHAPTER_CACHE_DIR),
+        )
+            .distinctBy { it.absolutePath }
+            .filterNot { it.absolutePath == activeDirectory.absolutePath }
+            .sumOf(::deleteEntry)
     }
 
     fun countNetworkCacheFiles(context: Context): Int {

--- a/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
+++ b/core/common/src/main/kotlin/tachiyomi/core/common/storage/LocalTempCacheDirectoryProvider.kt
@@ -20,6 +20,8 @@ object LocalTempCacheDirectoryProvider {
 
     fun chapterCacheDir(context: Context): File = prepareDirectory(context, CHAPTER_CACHE_DIR)
 
+    fun internalChapterCacheDir(context: Context): File = prepareInternalDirectory(context, CHAPTER_CACHE_DIR)
+
     fun metadataCacheDir(context: Context): File = prepareDirectory(context, METADATA_CACHE_DIR)
 
     fun epubCacheDir(context: Context): File = prepareDirectory(context, EPUB_CACHE_DIR)
@@ -95,6 +97,7 @@ object LocalTempCacheDirectoryProvider {
     private fun temporaryCacheEntries(context: Context): List<File> {
         return listOf(
             chapterCacheDir(context),
+            internalChapterCacheDir(context),
             metadataCacheDir(context),
             epubCacheDir(context),
             networkCacheDir(context),
@@ -137,7 +140,13 @@ object LocalTempCacheDirectoryProvider {
 
     private fun rootDir(context: Context): File {
         return context.getExternalFilesDir(ROOT_DIR)
-            ?: File(context.filesDir, ROOT_DIR).also { it.mkdirs() }
+            ?: internalRootDir(context)
+    }
+
+    private fun internalRootDir(context: Context): File = File(context.filesDir, ROOT_DIR).also { it.mkdirs() }
+
+    private fun prepareInternalDirectory(context: Context, name: String): File {
+        return File(internalRootDir(context), name).also { it.mkdirs() }
     }
 
     private fun legacyDirectory(context: Context, name: String): File = File(context.cacheDir, name)

--- a/presentation-widget/src/main/AndroidManifest.xml
+++ b/presentation-widget/src/main/AndroidManifest.xml
@@ -35,5 +35,14 @@
                 android:value="true" />
         </receiver>
 
+        <receiver
+            android:name="tachiyomi.presentation.widget.WidgetRefreshReceiver"
+            android:enabled="@bool/glance_appwidget_available"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/presentation-widget/src/main/java/tachiyomi/presentation/widget/WidgetRefreshReceiver.kt
+++ b/presentation-widget/src/main/java/tachiyomi/presentation/widget/WidgetRefreshReceiver.kt
@@ -1,0 +1,31 @@
+package tachiyomi.presentation.widget
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.glance.appwidget.updateAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import logcat.LogPriority
+import tachiyomi.core.common.util.system.logcat
+
+class WidgetRefreshReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_MY_PACKAGE_REPLACED) return
+
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+            try {
+                UpdatesGridGlanceWidget().updateAll(context)
+                UpdatesGridCoverScreenGlanceWidget().updateAll(context)
+            } catch (error: Exception) {
+                logcat(LogPriority.ERROR, error) { "Failed to refresh widgets after an app update" }
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 中文

### 修改内容

- 章节磁盘缓存无法使用外部目录时，自动回退到应用内部临时缓存目录。
- 按实际缓存目录计算容量，并把内部回退目录纳入临时缓存统计。
- 应用更新后刷新 Glance 小组件，重建桌面 PendingIntent。
- 移除当前静态网格小组件不使用的 `ActionTrampolineActivity`，避免旧或不完整的 PendingIntent 触发 Glance 崩溃。

### 问题原因

- 外部章节缓存目录可能在运行环境中丢失、不可创建或暂时不可用，导致 `DiskLruCache.open()` 初始化失败并终止应用启动。
- 系统或桌面可能保留旧版 Glance PendingIntent；缺少目标 Intent 时启动列表跳板 Activity 会抛出 `IllegalArgumentException`。

### 验证

- `.\gradlew.bat spotlessApply spotlessCheck :app:compileDebugKotlin`
- `.\gradlew.bat :app:installDebug`
- Android 17 / API 37 虚拟机正常冷启动，无致命异常。
- 使用同名普通文件模拟外部章节缓存目录不可创建，确认应用记录受控警告、创建内部回退缓存并保持运行。
- 恢复外部缓存后再次冷启动，确认重新使用外部目录。
- 覆盖安装触发 `MY_PACKAGE_REPLACED`，未发现小组件刷新异常。
- ADB 确认 `ActionTrampolineActivity` 无法解析或启动。

## English

### Changes

- Fall back to an internal temporary directory when the external chapter disk cache cannot be opened.
- Calculate cache capacity from the directory actually in use and include the internal fallback in temporary-cache accounting.
- Refresh Glance widgets after an application update so launcher PendingIntents are rebuilt.
- Remove the unused `ActionTrampolineActivity` from the current static-grid widget configuration, preventing stale or incomplete PendingIntents from entering the Glance crash path.

### Root causes

- The external chapter cache directory can disappear, become unavailable, or fail to be recreated, causing `DiskLruCache.open()` to abort application startup.
- Launchers may retain old Glance PendingIntents. If the list trampoline is invoked without its target Intent, Glance throws an `IllegalArgumentException`.

### Validation

- `.\gradlew.bat spotlessApply spotlessCheck :app:compileDebugKotlin`
- `.\gradlew.bat :app:installDebug`
- Successful cold start on an Android 17 / API 37 emulator with no fatal exception.
- Replaced the external chapter cache directory with a regular file to simulate an unusable path; verified controlled logging, internal fallback creation, and continued application operation.
- Restored the external cache and verified that a subsequent cold start uses it again.
- Triggered `MY_PACKAGE_REPLACED` through an APK replacement install without widget refresh errors.
- Verified through ADB that `ActionTrampolineActivity` can no longer be resolved or launched.