### PR TITLE
优化应用更新下载稳定性 / Improve app update download reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,19 @@ Use Windows commands:
 - Do not hardcode user-facing strings in composables when an `MR.strings.*` resource fits.
 - Compile after i18n edits to regenerate moko-resources accessors.
 
+### GitHub Release Notes
+
+- Release bodies are the source for localized in-app update notes: Chinese app locales use the Chinese block, while every other locale uses English.
+- Write both blocks with the exact markers below. Do not place `---` between them; put checksums or other non-changelog content after the end marker.
+
+```markdown
+<!-- koharia-release-notes:zh -->
+中文更新说明
+<!-- koharia-release-notes:en -->
+English release notes
+<!-- koharia-release-notes:end -->
+```
+
 ## Project Map
 
 | Path | Purpose |

--- a/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.NewReleases
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,34 +28,51 @@ import tachiyomi.presentation.core.screens.InfoScreen
 fun NewUpdateScreen(
     versionName: String,
     changelogInfo: String,
+    updateAvailable: Boolean,
     onOpenInBrowser: () -> Unit,
     onRejectUpdate: () -> Unit,
     onAcceptUpdate: () -> Unit,
 ) {
     InfoScreen(
-        icon = Icons.Outlined.NewReleases,
-        headingText = stringResource(MR.strings.update_check_notification_update_available),
-        subtitleText = versionName,
-        acceptText = stringResource(MR.strings.update_check_confirm),
-        onAcceptClick = onAcceptUpdate,
-        rejectText = stringResource(MR.strings.action_not_now),
-        onRejectClick = onRejectUpdate,
+        icon = if (updateAvailable) Icons.Outlined.NewReleases else Icons.Outlined.CheckCircle,
+        headingText = stringResource(
+            if (updateAvailable) {
+                MR.strings.update_check_notification_update_available
+            } else {
+                MR.strings.update_check_no_new_updates
+            },
+        ),
+        subtitleText = if (updateAvailable) {
+            versionName
+        } else {
+            stringResource(MR.strings.update_check_current_version, versionName)
+        },
+        acceptText = stringResource(
+            if (updateAvailable) MR.strings.update_check_confirm else MR.strings.action_close,
+        ),
+        onAcceptClick = if (updateAvailable) onAcceptUpdate else onRejectUpdate,
+        rejectText = if (updateAvailable) stringResource(MR.strings.action_not_now) else null,
+        onRejectClick = if (updateAvailable) onRejectUpdate else null,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = MaterialTheme.padding.large),
         ) {
-            MarkdownRender(
-                content = changelogInfo,
-                flavour = GFMFlavourDescriptor(),
-            )
+            if (changelogInfo.isNotBlank()) {
+                MarkdownRender(
+                    content = changelogInfo,
+                    flavour = GFMFlavourDescriptor(),
+                )
+            } else {
+                Text(text = stringResource(MR.strings.update_check_release_notes_unavailable))
+            }
 
             TextButton(
                 onClick = onOpenInBrowser,
                 modifier = Modifier.padding(top = MaterialTheme.padding.small),
             ) {
-                Text(text = stringResource(MR.strings.update_check_open))
+                Text(text = stringResource(MR.strings.update_check_open_release_page))
                 Spacer(modifier = Modifier.width(MaterialTheme.padding.extraSmall))
                 Icon(imageVector = Icons.AutoMirrored.Outlined.OpenInNew, contentDescription = null)
             }
@@ -68,6 +86,7 @@ private fun NewUpdateScreenPreview() {
     TachiyomiPreviewTheme {
         NewUpdateScreen(
             versionName = "v0.99.9",
+            updateAvailable = true,
             changelogInfo = """
                 ## Yay
                 Foobar

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -120,7 +120,11 @@ object AboutScreen : Screen() {
                                             context = context,
                                             onResult = { release, updateAvailable ->
                                                 val updateScreen = NewUpdateScreen(
-                                                    versionName = release?.version ?: BuildConfig.VERSION_NAME,
+                                                    versionName = if (updateAvailable) {
+                                                        release?.version ?: BuildConfig.VERSION_NAME
+                                                    } else {
+                                                        BuildConfig.VERSION_NAME
+                                                    },
                                                     changelogInfo = release?.info.orEmpty(),
                                                     downloadLinks = release?.downloadLinks.orEmpty(),
                                                     expectedSize = release?.expectedSize,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -45,6 +45,7 @@ import tachiyomi.core.common.util.lang.withIOContext
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.release.interactor.GetApplicationRelease
+import tachiyomi.domain.release.model.Release
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LinkIcon
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
@@ -117,13 +118,14 @@ object AboutScreen : Screen() {
 
                                         checkVersion(
                                             context = context,
-                                            onAvailableUpdate = { result ->
+                                            onResult = { release, updateAvailable ->
                                                 val updateScreen = NewUpdateScreen(
-                                                    versionName = result.release.version,
-                                                    changelogInfo = result.release.info,
-                                                    downloadLinks = result.release.downloadLinks,
-                                                    expectedSize = result.release.expectedSize,
-                                                    expectedSha256 = result.release.expectedSha256,
+                                                    versionName = release?.version ?: BuildConfig.VERSION_NAME,
+                                                    changelogInfo = release?.info.orEmpty(),
+                                                    downloadLinks = release?.downloadLinks.orEmpty(),
+                                                    expectedSize = release?.expectedSize,
+                                                    expectedSha256 = release?.expectedSha256,
+                                                    updateAvailable = updateAvailable,
                                                 )
                                                 navigator.push(updateScreen)
                                             },
@@ -189,7 +191,7 @@ object AboutScreen : Screen() {
      */
     private suspend fun checkVersion(
         context: Context,
-        onAvailableUpdate: (GetApplicationRelease.Result.NewUpdate) -> Unit,
+        onResult: (release: Release?, updateAvailable: Boolean) -> Unit,
         onFinish: () -> Unit,
     ) {
         val updateChecker = AppUpdateChecker()
@@ -197,10 +199,10 @@ object AboutScreen : Screen() {
             try {
                 when (val result = withIOContext { updateChecker.checkForUpdate(context, forceCheck = true) }) {
                     is GetApplicationRelease.Result.NewUpdate -> {
-                        onAvailableUpdate(result)
+                        onResult(result.release, true)
                     }
                     is GetApplicationRelease.Result.NoNewUpdate -> {
-                        context.toast(MR.strings.update_check_no_new_updates)
+                        onResult(result.release, false)
                     }
                     is GetApplicationRelease.Result.OsTooOld -> {
                         context.toast(MR.strings.update_check_eol)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -121,7 +121,9 @@ object AboutScreen : Screen() {
                                                 val updateScreen = NewUpdateScreen(
                                                     versionName = result.release.version,
                                                     changelogInfo = result.release.info,
-                                                    downloadLink = result.release.downloadLink,
+                                                    downloadLinks = result.release.downloadLinks,
+                                                    expectedSize = result.release.expectedSize,
+                                                    expectedSha256 = result.release.expectedSha256,
                                                 )
                                                 navigator.push(updateScreen)
                                             },

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -190,8 +190,19 @@ class NotificationReceiver : BroadcastReceiver() {
     }
 
     private fun startDownloadAppUpdate(context: Context, intent: Intent) {
-        val url = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL) ?: return
-        AppUpdateDownloadJob.start(context, url)
+        val urls = intent.getStringArrayExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URLS)
+            ?.filter(String::isNotBlank)
+            ?.takeIf { it.isNotEmpty() }
+            ?: listOfNotNull(intent.getStringExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL))
+        if (urls.isEmpty()) return
+
+        AppUpdateDownloadJob.start(
+            context = context,
+            urls = urls,
+            title = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_TITLE),
+            expectedSize = intent.getLongExtra(AppUpdateDownloadJob.EXTRA_EXPECTED_SIZE, -1L).takeIf { it > 0L },
+            expectedSha256 = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_EXPECTED_SHA256),
+        )
     }
 
     private fun cancelDownloadAppUpdate(context: Context) {
@@ -560,13 +571,18 @@ class NotificationReceiver : BroadcastReceiver() {
          */
         internal fun downloadAppUpdatePendingBroadcast(
             context: Context,
-            url: String,
+            urls: List<String>,
             title: String? = null,
+            expectedSize: Long? = null,
+            expectedSha256: String? = null,
         ): PendingIntent {
             return Intent(context, NotificationReceiver::class.java).run {
                 action = ACTION_START_APP_UPDATE
-                putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL, url)
+                putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL, urls.firstOrNull())
+                putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URLS, urls.toTypedArray())
                 title?.let { putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_TITLE, it) }
+                expectedSize?.let { putExtra(AppUpdateDownloadJob.EXTRA_EXPECTED_SIZE, it) }
+                expectedSha256?.let { putExtra(AppUpdateDownloadJob.EXTRA_EXPECTED_SHA256, it) }
                 PendingIntent.getBroadcast(
                     context,
                     0,
@@ -574,6 +590,14 @@ class NotificationReceiver : BroadcastReceiver() {
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
                 )
             }
+        }
+
+        internal fun downloadAppUpdatePendingBroadcast(
+            context: Context,
+            url: String,
+            title: String? = null,
+        ): PendingIntent {
+            return downloadAppUpdatePendingBroadcast(context, listOf(url), title)
         }
 
         /**

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
@@ -1,33 +1,48 @@
 package eu.kanade.tachiyomi.data.updater
 
 import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
+import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkerParameters
-import androidx.work.workDataOf
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.ProgressListener
 import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.newCachelessCallWithProgress
+import eu.kanade.tachiyomi.util.lang.Hash
 import eu.kanade.tachiyomi.util.storage.getUriCompat
-import eu.kanade.tachiyomi.util.storage.saveTo
 import eu.kanade.tachiyomi.util.system.setForegroundSafely
 import eu.kanade.tachiyomi.util.system.workManager
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import logcat.LogPriority
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.Response
 import okhttp3.internal.http2.ErrorCode
 import okhttp3.internal.http2.StreamResetException
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.lang.withIOContext
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
 import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
 import kotlin.coroutines.cancellation.CancellationException
 
 class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerParameters) :
@@ -35,22 +50,52 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
 
     private val notifier = AppUpdateNotifier(context)
     private val network: NetworkHelper by injectLazy()
+    private val downloadClient by lazy {
+        network.client.newBuilder()
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .readTimeout(60, TimeUnit.SECONDS)
+            .build()
+    }
 
     override suspend fun doWork(): Result {
-        val url = inputData.getString(EXTRA_DOWNLOAD_URL)
-        val title = inputData.getString(EXTRA_DOWNLOAD_TITLE) ?: context.stringResource(MR.strings.app_name)
-
-        if (url.isNullOrEmpty()) {
-            return Result.failure()
-        }
+        val spec = inputData.toDownloadSpec(context.stringResource(MR.strings.app_name)) ?: return Result.failure()
 
         setForegroundSafely()
 
-        withIOContext {
-            downloadApk(title, url)
+        return try {
+            downloadMutex.withLock {
+                withIOContext {
+                    downloadApk(spec)
+                }
+            }
+            Result.success()
+        } catch (error: CancellationException) {
+            notifier.cancel()
+            throw error
+        } catch (error: RetryableDownloadException) {
+            logcat(LogPriority.WARN, error) { "App update download failed temporarily" }
+            if (runAttemptCount < MAX_AUTO_RETRIES) {
+                notifier.onDownloadRetrying(spec.title)
+                Result.retry()
+            } else {
+                notifier.onDownloadError(
+                    urls = spec.urls,
+                    title = spec.title,
+                    expectedSize = spec.expectedSize,
+                    expectedSha256 = spec.expectedSha256,
+                )
+                Result.failure()
+            }
+        } catch (error: Exception) {
+            logcat(LogPriority.ERROR, error) { "App update download failed" }
+            notifier.onDownloadError(
+                urls = spec.urls,
+                title = spec.title,
+                expectedSize = spec.expectedSize,
+                expectedSha256 = spec.expectedSha256,
+            )
+            Result.failure()
         }
-
-        return Result.success()
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
@@ -65,92 +110,334 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
         )
     }
 
-    /**
-     * Called to start downloading apk of new update
-     *
-     * @param url url location of file
-     */
-    private suspend fun downloadApk(title: String, url: String) {
-        // Show notification download starting.
-        notifier.onDownloadStarted(title)
+    private suspend fun downloadApk(spec: DownloadSpec) {
+        notifier.onDownloadStarted(spec.title)
 
-        val progressListener = object : ProgressListener {
-            // Progress of the download
-            var savedProgress = 0
+        val cacheDirectory = context.externalCacheDir ?: context.cacheDir
+        val partialKey = Hash.sha256(spec.expectedSha256 ?: spec.urls.first()).take(16)
+        val partialFile = File(cacheDirectory, "$UPDATE_PART_FILE_PREFIX$partialKey$UPDATE_PART_FILE_SUFFIX")
+        val apkFile = File(cacheDirectory, UPDATE_FILE_NAME)
+        cacheDirectory.listFiles()
+            .orEmpty()
+            .filter { file ->
+                file != partialFile &&
+                    (
+                        file.name == LEGACY_UPDATE_PART_FILE_NAME ||
+                            (
+                                file.name.startsWith(UPDATE_PART_FILE_PREFIX) &&
+                                    file.name.endsWith(UPDATE_PART_FILE_SUFFIX)
+                                )
+                        )
+            }
+            .forEach { it.delete() }
+        apkFile.delete()
 
-            // Keep track of the last notification sent to avoid posting too many.
-            var lastTick = 0L
-            var hasShownIndeterminateProgress = false
+        if (spec.expectedSize != null && partialFile.length() == spec.expectedSize) {
+            try {
+                validateApk(partialFile, spec)
+                completeDownload(partialFile, apkFile)
+                return
+            } catch (error: DownloadIntegrityException) {
+                partialFile.delete()
+                logcat(LogPriority.WARN, error) { "Discarding an invalid completed update download" }
+            }
+        } else if (spec.expectedSize != null && partialFile.length() > spec.expectedSize) {
+            partialFile.delete()
+        }
 
-            override fun update(bytesRead: Long, contentLength: Long, done: Boolean) {
-                val currentTime = System.currentTimeMillis()
-                if (contentLength <= 0L) {
-                    if (!hasShownIndeterminateProgress || done) {
-                        hasShownIndeterminateProgress = true
-                        lastTick = currentTime
-                        notifier.onProgressChange(null)
-                    }
-                    return
+        var lastFailure: Throwable? = null
+        spec.urls.forEachIndexed { index, url ->
+            try {
+                downloadFromSource(
+                    url = url,
+                    sourceIndex = index,
+                    partialFile = partialFile,
+                    expectedSize = spec.expectedSize,
+                )
+                validateApk(partialFile, spec)
+                completeDownload(partialFile, apkFile)
+                return
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: TerminalDownloadException) {
+                throw error
+            } catch (error: Exception) {
+                if (isStopped || error.isCancellation()) {
+                    throw CancellationException("App update download cancelled").apply { initCause(error) }
                 }
-
-                val progress = ((100 * bytesRead) / contentLength)
-                    .toInt()
-                    .coerceIn(0, 100)
-                if ((progress > savedProgress && currentTime - 200 > lastTick) || done) {
-                    savedProgress = progress
-                    lastTick = currentTime
-                    notifier.onProgressChange(progress)
+                if (error is DownloadIntegrityException) {
+                    partialFile.delete()
+                }
+                lastFailure = error
+                logcat(LogPriority.WARN, error) {
+                    "App update source ${index + 1}/${spec.urls.size} failed (${url.safeHost()})"
                 }
             }
         }
 
-        try {
-            // Download the new update.
-            val response = network.client.newCachelessCallWithProgress(GET(url), progressListener)
-                .await()
+        throw RetryableDownloadException("All app update download sources failed", lastFailure)
+    }
 
-            // File where the apk will be saved.
-            val apkFile = File(context.externalCacheDir, "update.apk")
+    private suspend fun downloadFromSource(
+        url: String,
+        sourceIndex: Int,
+        partialFile: File,
+        expectedSize: Long?,
+    ) {
+        val requestedOffset = partialFile.length().coerceAtLeast(0L)
+        val request = try {
+            GET(url).newBuilder().apply {
+                header("Accept-Encoding", "identity")
+                if (requestedOffset > 0L) {
+                    header("Range", "bytes=$requestedOffset-")
+                }
+            }.build()
+        } catch (error: IllegalArgumentException) {
+            throw TerminalDownloadException("Invalid app update URL", error)
+        }
 
-            if (response.isSuccessful) {
-                response.body.source().saveTo(apkFile)
-            } else {
-                response.close()
-                throw Exception("Unsuccessful response")
+        val progressListener = DownloadProgressListener()
+        val response = downloadClient
+            .newCachelessCallWithProgress(request, progressListener)
+            .await()
+
+        response.use {
+            logResponse(it, sourceIndex, url)
+            val contentType = it.body.contentType()
+            if (it.code in 200..299 && contentType != null &&
+                (contentType.type == "text" || contentType.subtype.contains("json", ignoreCase = true))
+            ) {
+                partialFile.delete()
+                throw RetryableDownloadException("Update source returned non-APK content")
             }
-            notifier.cancel()
-            notifier.promptInstall(apkFile.getUriCompat(context))
-        } catch (e: Exception) {
-            val shouldCancel = e is CancellationException ||
-                (e is StreamResetException && e.errorCode == ErrorCode.CANCEL)
-            if (shouldCancel) {
-                notifier.cancel()
-            } else {
-                notifier.onDownloadError(url)
+
+            val append: Boolean
+            val writeOffset: Long
+            val totalSize: Long?
+            when (it.code) {
+                200 -> {
+                    append = false
+                    writeOffset = 0L
+                    totalSize = expectedSize ?: it.body.contentLength().takeIf { length -> length > 0L }
+                }
+                206 -> {
+                    val contentRange = AppUpdateDownloadPolicy.parseContentRange(it.header("Content-Range"))
+                    if (contentRange == null || contentRange.start != requestedOffset) {
+                        partialFile.delete()
+                        throw RetryableDownloadException("Invalid Content-Range from update source")
+                    }
+                    if (expectedSize != null && contentRange.total != null && contentRange.total != expectedSize) {
+                        partialFile.delete()
+                        throw DownloadIntegrityException("Content-Range size does not match release metadata")
+                    }
+                    append = true
+                    writeOffset = requestedOffset
+                    totalSize = expectedSize ?: contentRange.total
+                }
+                416 -> {
+                    if (expectedSize != null && requestedOffset == expectedSize) return
+                    partialFile.delete()
+                    throw RetryableDownloadException("Update source rejected the resume offset")
+                }
+                else -> if (AppUpdateDownloadPolicy.isRetryableHttpCode(it.code)) {
+                    throw RetryableDownloadException("Temporary HTTP ${it.code} from update source")
+                } else {
+                    throw TerminalDownloadException("HTTP ${it.code} from update source")
+                }
+            }
+
+            progressListener.setRange(writeOffset, totalSize)
+            partialFile.parentFile?.mkdirs()
+            it.body.source().use { source ->
+                FileOutputStream(partialFile, append).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        currentCoroutineContext().ensureActive()
+                        val read = source.read(buffer)
+                        if (read < 0L) break
+                        output.write(buffer, 0, read)
+                    }
+                    output.flush()
+                }
+            }
+        }
+
+        expectedSize?.let { size ->
+            when {
+                partialFile.length() < size -> {
+                    throw RetryableDownloadException("App update download ended before the expected size")
+                }
+                partialFile.length() > size -> {
+                    partialFile.delete()
+                    throw DownloadIntegrityException("App update download exceeded the expected size")
+                }
             }
         }
     }
 
+    private fun validateApk(file: File, spec: DownloadSpec) {
+        spec.expectedSize?.let { expectedSize ->
+            if (file.length() != expectedSize) {
+                throw DownloadIntegrityException("App update size does not match release metadata")
+            }
+        }
+
+        spec.expectedSha256?.let { expectedSha256 ->
+            val actualSha256 = file.sha256()
+            if (!actualSha256.equals(expectedSha256, ignoreCase = true)) {
+                throw DownloadIntegrityException("App update SHA-256 does not match release metadata")
+            }
+        }
+
+        val packageManager = context.packageManager
+        val archive = packageManager.getPackageArchiveInfo(file.absolutePath, PACKAGE_FLAGS)
+            ?: throw DownloadIntegrityException("Downloaded file is not a valid APK")
+        if (archive.packageName != context.packageName) {
+            throw TerminalDownloadException("Downloaded APK package does not match the installed app")
+        }
+
+        val installed = packageManager.getPackageInfo(context.packageName, PACKAGE_FLAGS)
+        val installedSignatures = installed.signaturesSha256()
+        val archiveSignatures = archive.signaturesSha256()
+        if (installedSignatures.isEmpty() || !archiveSignatures.containsAll(installedSignatures)) {
+            throw TerminalDownloadException("Downloaded APK signature does not match the installed app")
+        }
+    }
+
+    private fun completeDownload(partialFile: File, apkFile: File) {
+        if (!partialFile.renameTo(apkFile)) {
+            partialFile.copyTo(apkFile, overwrite = true)
+            partialFile.delete()
+        }
+        notifier.cancel()
+        notifier.promptInstall(apkFile.getUriCompat(context))
+    }
+
+    private fun logResponse(response: Response, sourceIndex: Int, url: String) {
+        logcat(LogPriority.DEBUG) {
+            buildString {
+                append("App update response source=")
+                append(sourceIndex + 1)
+                append(" host=")
+                append(url.safeHost())
+                append(" code=")
+                append(response.code)
+                append(" cache=")
+                append(response.header("X-Koharia-Cache"))
+                append(" upstream=")
+                append(response.header("X-Koharia-Source"))
+                append(" rangePolicy=")
+                append(response.header("X-Koharia-Range-Policy"))
+                append(" contentLength=")
+                append(response.header("Content-Length"))
+                append(" contentRange=")
+                append(response.header("Content-Range"))
+                append(" etag=")
+                append(response.header("ETag"))
+            }
+        }
+    }
+
+    private inner class DownloadProgressListener : ProgressListener {
+        private var offset = 0L
+        private var totalSize: Long? = null
+        private var savedProgress = -1
+        private var lastTick = 0L
+        private var hasShownIndeterminateProgress = false
+
+        fun setRange(offset: Long, totalSize: Long?) {
+            this.offset = offset
+            this.totalSize = totalSize
+        }
+
+        override fun update(bytesRead: Long, contentLength: Long, done: Boolean) {
+            val currentTime = System.currentTimeMillis()
+            val total = totalSize ?: contentLength.takeIf { it > 0L }?.let { offset + it }
+            if (total == null || total <= 0L) {
+                if (!hasShownIndeterminateProgress || done) {
+                    hasShownIndeterminateProgress = true
+                    lastTick = currentTime
+                    notifier.onProgressChange(null)
+                }
+                return
+            }
+
+            val progress = ((100 * (offset + bytesRead)) / total)
+                .toInt()
+                .coerceIn(0, 100)
+            if ((progress > savedProgress && currentTime - NOTIFICATION_UPDATE_INTERVAL > lastTick) || done) {
+                savedProgress = progress
+                lastTick = currentTime
+                notifier.onProgressChange(progress)
+            }
+        }
+    }
+
+    private data class DownloadSpec(
+        val urls: List<String>,
+        val title: String,
+        val expectedSize: Long?,
+        val expectedSha256: String?,
+    )
+
+    private class RetryableDownloadException(message: String, cause: Throwable? = null) :
+        IOException(message, cause)
+
+    private class DownloadIntegrityException(message: String) : IOException(message)
+
+    private class TerminalDownloadException(message: String, cause: Throwable? = null) :
+        IllegalStateException(message, cause)
+
     companion object {
         private const val TAG = "AppUpdateDownload"
+        private const val UPDATE_FILE_NAME = "update.apk"
+        private const val LEGACY_UPDATE_PART_FILE_NAME = "update.apk.part"
+        private const val UPDATE_PART_FILE_PREFIX = "update-"
+        private const val UPDATE_PART_FILE_SUFFIX = ".apk.part"
+        private const val MAX_AUTO_RETRIES = 2
+        private const val NOTIFICATION_UPDATE_INTERVAL = 200L
+        private val downloadMutex = Mutex()
+
+        @Suppress("DEPRECATION")
+        private val PACKAGE_FLAGS = PackageManager.GET_SIGNATURES or
+            (if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) PackageManager.GET_SIGNING_CERTIFICATES else 0)
 
         const val EXTRA_DOWNLOAD_URL = "DOWNLOAD_URL"
+        const val EXTRA_DOWNLOAD_URLS = "DOWNLOAD_URLS"
         const val EXTRA_DOWNLOAD_TITLE = "DOWNLOAD_TITLE"
+        const val EXTRA_EXPECTED_SIZE = "EXPECTED_SIZE"
+        const val EXTRA_EXPECTED_SHA256 = "EXPECTED_SHA256"
 
         fun start(context: Context, url: String, title: String? = null) {
+            start(context, listOf(url), title)
+        }
+
+        fun start(
+            context: Context,
+            urls: List<String>,
+            title: String? = null,
+            expectedSize: Long? = null,
+            expectedSha256: String? = null,
+        ) {
+            val normalizedUrls = urls.filter(String::isNotBlank).distinct()
+            if (normalizedUrls.isEmpty()) return
+
             val constraints = Constraints(
                 requiredNetworkType = NetworkType.CONNECTED,
             )
+            val inputData = Data.Builder()
+                .putString(EXTRA_DOWNLOAD_URL, normalizedUrls.first())
+                .putStringArray(EXTRA_DOWNLOAD_URLS, normalizedUrls.toTypedArray())
+                .putString(EXTRA_DOWNLOAD_TITLE, title)
+                .putLong(EXTRA_EXPECTED_SIZE, expectedSize ?: -1L)
+                .putString(EXTRA_EXPECTED_SHA256, expectedSha256)
+                .build()
 
             val request = OneTimeWorkRequestBuilder<AppUpdateDownloadJob>()
                 .setConstraints(constraints)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 10, TimeUnit.SECONDS)
                 .addTag(TAG)
-                .setInputData(
-                    workDataOf(
-                        EXTRA_DOWNLOAD_URL to url,
-                        EXTRA_DOWNLOAD_TITLE to title,
-                    ),
-                )
+                .setInputData(inputData)
                 .build()
 
             context.workManager.enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)
@@ -158,6 +445,58 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
 
         fun stop(context: Context) {
             context.workManager.cancelUniqueWork(TAG)
+        }
+
+        private fun Data.toDownloadSpec(defaultTitle: String): DownloadSpec? {
+            val urls = getStringArray(EXTRA_DOWNLOAD_URLS)
+                ?.filter(String::isNotBlank)
+                ?.takeIf { it.isNotEmpty() }
+                ?: listOfNotNull(getString(EXTRA_DOWNLOAD_URL))
+            if (urls.isEmpty()) return null
+
+            return DownloadSpec(
+                urls = urls.distinct(),
+                title = getString(EXTRA_DOWNLOAD_TITLE).orEmpty().ifBlank { defaultTitle },
+                expectedSize = getLong(EXTRA_EXPECTED_SIZE, -1L).takeIf { it > 0L },
+                expectedSha256 = getString(EXTRA_EXPECTED_SHA256)
+                    ?.takeIf { SHA256_REGEX.matches(it) },
+            )
+        }
+
+        private val SHA256_REGEX = Regex("[0-9a-fA-F]{64}")
+
+        private fun String.safeHost(): String = toHttpUrlOrNull()?.host ?: "invalid"
+
+        private fun Throwable.isCancellation(): Boolean {
+            return this is StreamResetException && errorCode == ErrorCode.CANCEL
+        }
+
+        private fun File.sha256(): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            inputStream().buffered().use { input ->
+                val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            return digest.digest().joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+        }
+
+        private fun PackageInfo.signaturesSha256(): List<String> {
+            val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                val info = signingInfo ?: return emptyList()
+                if (info.hasMultipleSigners()) {
+                    info.apkContentsSigners
+                } else {
+                    info.signingCertificateHistory
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                signatures
+            }
+            return signatures.orEmpty().map { Hash.sha256(it.toByteArray()) }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
@@ -140,12 +140,16 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
             } catch (error: DownloadIntegrityException) {
                 partialFile.delete()
                 logcat(LogPriority.WARN, error) { "Discarding an invalid completed update download" }
+            } catch (error: TerminalDownloadException) {
+                partialFile.delete()
+                throw error
             }
         } else if (spec.expectedSize != null && partialFile.length() > spec.expectedSize) {
             partialFile.delete()
         }
 
         var lastFailure: Throwable? = null
+        var hasRetryableFailure = false
         spec.urls.forEachIndexed { index, url ->
             try {
                 downloadFromSource(
@@ -159,7 +163,13 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                 return
             } catch (error: CancellationException) {
                 throw error
+            } catch (error: SourceDownloadException) {
+                lastFailure = error
+                logcat(LogPriority.WARN, error) {
+                    "App update source ${index + 1}/${spec.urls.size} rejected (${url.safeHost()})"
+                }
             } catch (error: TerminalDownloadException) {
+                partialFile.delete()
                 throw error
             } catch (error: Exception) {
                 if (isStopped || error.isCancellation()) {
@@ -168,6 +178,7 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                 if (error is DownloadIntegrityException) {
                     partialFile.delete()
                 }
+                hasRetryableFailure = true
                 lastFailure = error
                 logcat(LogPriority.WARN, error) {
                     "App update source ${index + 1}/${spec.urls.size} failed (${url.safeHost()})"
@@ -175,7 +186,10 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
             }
         }
 
-        throw RetryableDownloadException("All app update download sources failed", lastFailure)
+        if (hasRetryableFailure) {
+            throw RetryableDownloadException("All app update download sources failed", lastFailure)
+        }
+        throw TerminalDownloadException("All app update download sources were rejected", lastFailure)
     }
 
     private suspend fun downloadFromSource(
@@ -193,7 +207,7 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                 }
             }.build()
         } catch (error: IllegalArgumentException) {
-            throw TerminalDownloadException("Invalid app update URL", error)
+            throw SourceDownloadException("Invalid app update URL", error)
         }
 
         val progressListener = DownloadProgressListener()
@@ -242,7 +256,7 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                 else -> if (AppUpdateDownloadPolicy.isRetryableHttpCode(it.code)) {
                     throw RetryableDownloadException("Temporary HTTP ${it.code} from update source")
                 } else {
-                    throw TerminalDownloadException("HTTP ${it.code} from update source")
+                    throw SourceDownloadException("HTTP ${it.code} from update source")
                 }
             }
 
@@ -384,6 +398,9 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
         IOException(message, cause)
 
     private class DownloadIntegrityException(message: String) : IOException(message)
+
+    private class SourceDownloadException(message: String, cause: Throwable? = null) :
+        IOException(message, cause)
 
     private class TerminalDownloadException(message: String, cause: Throwable? = null) :
         IllegalStateException(message, cause)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadPolicy.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadPolicy.kt
@@ -1,0 +1,25 @@
+package eu.kanade.tachiyomi.data.updater
+
+internal object AppUpdateDownloadPolicy {
+
+    private val retryableHttpCodes = setOf(408, 429, 500, 502, 503, 504)
+    private val contentRangeRegex = Regex("bytes (\\d+)-(\\d+)/(\\d+|\\*)", RegexOption.IGNORE_CASE)
+
+    fun isRetryableHttpCode(code: Int): Boolean = code in retryableHttpCodes
+
+    fun parseContentRange(value: String?): ContentRange? {
+        val match = value?.let(contentRangeRegex::matchEntire) ?: return null
+        val start = match.groupValues[1].toLongOrNull() ?: return null
+        val endInclusive = match.groupValues[2].toLongOrNull() ?: return null
+        if (endInclusive < start) return null
+        val total = match.groupValues[3].takeUnless { it == "*" }?.toLongOrNull()
+        if (total != null && endInclusive >= total) return null
+        return ContentRange(start, endInclusive, total)
+    }
+
+    data class ContentRange(
+        val start: Long,
+        val endInclusive: Long,
+        val total: Long?,
+    )
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateNotifier.kt
@@ -39,8 +39,10 @@ internal class AppUpdateNotifier(private val context: Context) {
     fun promptUpdate(release: Release) {
         val updateIntent = NotificationReceiver.downloadAppUpdatePendingBroadcast(
             context,
-            release.downloadLink,
-            release.version,
+            urls = release.downloadLinks,
+            title = release.version,
+            expectedSize = release.expectedSize,
+            expectedSha256 = release.expectedSha256,
         )
 
         val releaseIntent = Intent(
@@ -119,6 +121,25 @@ internal class AppUpdateNotifier(private val context: Context) {
         notificationBuilder.show()
     }
 
+    fun onDownloadRetrying(title: String) {
+        with(notificationBuilder) {
+            setContentTitle(title)
+            setContentText(context.stringResource(MR.strings.update_check_notification_download_retrying))
+            setSmallIcon(android.R.drawable.stat_sys_download)
+            setProgress(100, 0, true)
+            setOnlyAlertOnce(true)
+            setOngoing(true)
+
+            clearActions()
+            addAction(
+                R.drawable.ic_close_24dp,
+                context.stringResource(MR.strings.action_cancel),
+                NotificationReceiver.cancelDownloadAppUpdatePendingBroadcast(context),
+            )
+        }
+        notificationBuilder.show()
+    }
+
     /**
      * Call when apk download is finished.
      *
@@ -152,10 +173,16 @@ internal class AppUpdateNotifier(private val context: Context) {
     /**
      * Call when apk download throws a error
      *
-     * @param url web location of apk to download.
+     * @param urls web locations of apk to download.
      */
-    fun onDownloadError(url: String) {
+    fun onDownloadError(
+        urls: List<String>,
+        title: String,
+        expectedSize: Long?,
+        expectedSha256: String?,
+    ) {
         with(notificationBuilder) {
+            setContentTitle(title)
             setContentText(context.stringResource(MR.strings.update_check_notification_download_error))
             setSmallIcon(R.drawable.ic_warning_white_24dp)
             setOnlyAlertOnce(false)
@@ -165,7 +192,13 @@ internal class AppUpdateNotifier(private val context: Context) {
             addAction(
                 R.drawable.ic_refresh_24dp,
                 context.stringResource(MR.strings.action_retry),
-                NotificationReceiver.downloadAppUpdatePendingBroadcast(context, url),
+                NotificationReceiver.downloadAppUpdatePendingBroadcast(
+                    context = context,
+                    urls = urls,
+                    title = title,
+                    expectedSize = expectedSize,
+                    expectedSha256 = expectedSha256,
+                ),
             )
             addAction(
                 R.drawable.ic_close_24dp,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateReleaseNotes.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateReleaseNotes.kt
@@ -1,0 +1,64 @@
+package eu.kanade.tachiyomi.data.updater
+
+internal object AppUpdateReleaseNotes {
+
+    fun select(content: String, language: String): String {
+        val normalized = content.replace("\r\n", "\n").replace('\r', '\n').trim()
+        if (normalized.isEmpty()) return normalized
+
+        val selected = selectMarked(normalized, language)
+            ?: selectLegacy(normalized, language)
+            ?: normalized
+        return selected
+            .removeChecksumSection()
+            .trimEdgeHorizontalRules()
+    }
+
+    private fun selectMarked(content: String, language: String): String? {
+        val chineseStart = content.indexOf(CHINESE_MARKER)
+        val englishStart = content.indexOf(ENGLISH_MARKER)
+        val end = content.indexOf(END_MARKER)
+        if (chineseStart < 0 || englishStart <= chineseStart || end <= englishStart) return null
+
+        val chinese = content.substring(chineseStart + CHINESE_MARKER.length, englishStart).trim()
+        val english = content.substring(englishStart + ENGLISH_MARKER.length, end).trim()
+        return if (language.equals(CHINESE_LANGUAGE, ignoreCase = true)) {
+            chinese.ifBlank { english }
+        } else {
+            english.ifBlank { chinese }
+        }.takeIf(String::isNotBlank)
+    }
+
+    private fun selectLegacy(content: String, language: String): String? {
+        return HORIZONTAL_RULE.findAll(content).firstNotNullOfOrNull { divider ->
+            val chinese = content.substring(0, divider.range.first).trim()
+            val english = content.substring(divider.range.last + 1).trim()
+            if (!LEGACY_ENGLISH_HEADER.containsMatchIn(english)) return@firstNotNullOfOrNull null
+
+            if (language.equals(CHINESE_LANGUAGE, ignoreCase = true)) chinese else english
+        }
+    }
+
+    private fun String.removeChecksumSection(): String {
+        val checksumHeading = CHECKSUM_HEADING.find(this) ?: return this
+        return substring(0, checksumHeading.range.first)
+    }
+
+    private fun String.trimEdgeHorizontalRules(): String {
+        val lines = lines().toMutableList()
+        while (lines.firstOrNull()?.isBlank() == true) lines.removeAt(0)
+        while (lines.lastOrNull()?.isBlank() == true) lines.removeAt(lines.lastIndex)
+        if (lines.firstOrNull()?.matches(HORIZONTAL_RULE_LINE) == true) lines.removeAt(0)
+        if (lines.lastOrNull()?.matches(HORIZONTAL_RULE_LINE) == true) lines.removeAt(lines.lastIndex)
+        return lines.joinToString("\n").trim()
+    }
+
+    private const val CHINESE_LANGUAGE = "zh"
+    private const val CHINESE_MARKER = "<!-- koharia-release-notes:zh -->"
+    private const val ENGLISH_MARKER = "<!-- koharia-release-notes:en -->"
+    private const val END_MARKER = "<!-- koharia-release-notes:end -->"
+    private val HORIZONTAL_RULE_LINE = Regex("""\s*(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})""")
+    private val HORIZONTAL_RULE = Regex("""(?m)^${HORIZONTAL_RULE_LINE.pattern}$""")
+    private val LEGACY_ENGLISH_HEADER = Regex("""(?i)^#\s+Koharia\b""")
+    private val CHECKSUM_HEADING = Regex("""(?im)^\s*(?:#{1,6}\s*)?Checksums?\s*$""")
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -306,6 +306,7 @@ class MainActivity : BaseActivity() {
                             downloadLinks = result.release.downloadLinks,
                             expectedSize = result.release.expectedSize,
                             expectedSha256 = result.release.expectedSha256,
+                            updateAvailable = true,
                         )
                         navigator.push(updateScreen)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -303,7 +303,9 @@ class MainActivity : BaseActivity() {
                         val updateScreen = NewUpdateScreen(
                             versionName = result.release.version,
                             changelogInfo = result.release.info,
-                            downloadLink = result.release.downloadLink,
+                            downloadLinks = result.release.downloadLinks,
+                            expectedSize = result.release.expectedSize,
+                            expectedSha256 = result.release.expectedSha256,
                         )
                         navigator.push(updateScreen)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -14,7 +14,9 @@ import tachiyomi.core.common.DocumentationUrls
 class NewUpdateScreen(
     private val versionName: String,
     private val changelogInfo: String,
-    private val downloadLink: String,
+    private val downloadLinks: List<String>,
+    private val expectedSize: Long?,
+    private val expectedSha256: String?,
 ) : Screen() {
 
     @Composable
@@ -33,8 +35,10 @@ class NewUpdateScreen(
             onAcceptUpdate = {
                 AppUpdateDownloadJob.start(
                     context = context,
-                    url = downloadLink,
+                    urls = downloadLinks,
                     title = versionName,
+                    expectedSize = expectedSize,
+                    expectedSha256 = expectedSha256,
                 )
                 navigator.pop()
             },

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -8,6 +8,7 @@ import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.more.NewUpdateScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
+import eu.kanade.tachiyomi.data.updater.AppUpdateReleaseNotes
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import tachiyomi.core.common.DocumentationUrls
 
@@ -17,19 +18,22 @@ class NewUpdateScreen(
     private val downloadLinks: List<String>,
     private val expectedSize: Long?,
     private val expectedSha256: String?,
+    private val updateAvailable: Boolean,
 ) : Screen() {
 
     @Composable
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
-        val changelogInfoNoChecksum = remember {
-            changelogInfo.replace("""---(\R|.)*Checksums(\R|.)*""".toRegex(), "")
+        val language = context.resources.configuration.locales[0].language
+        val localizedChangelog = remember(changelogInfo, language) {
+            AppUpdateReleaseNotes.select(changelogInfo, language)
         }
 
         NewUpdateScreen(
             versionName = versionName,
-            changelogInfo = changelogInfoNoChecksum,
+            changelogInfo = localizedChangelog,
+            updateAvailable = updateAvailable,
             onOpenInBrowser = { context.openInBrowser(DocumentationUrls.changelog(context, versionName)) },
             onRejectUpdate = navigator::pop,
             onAcceptUpdate = {

--- a/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadPolicyTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadPolicyTest.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.updater
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AppUpdateDownloadPolicyTest {
+
+    @Test
+    fun `temporary HTTP failures are retryable`() {
+        listOf(408, 429, 500, 502, 503, 504).forEach { code ->
+            AppUpdateDownloadPolicy.isRetryableHttpCode(code) shouldBe true
+        }
+    }
+
+    @Test
+    fun `configuration HTTP failures are terminal`() {
+        listOf(400, 403, 404, 413, 421).forEach { code ->
+            AppUpdateDownloadPolicy.isRetryableHttpCode(code) shouldBe false
+        }
+    }
+
+    @Test
+    fun `content range exposes resume offset and total size`() {
+        AppUpdateDownloadPolicy.parseContentRange("bytes 1024-2047/4096") shouldBe
+            AppUpdateDownloadPolicy.ContentRange(
+                start = 1024,
+                endInclusive = 2047,
+                total = 4096,
+            )
+    }
+
+    @Test
+    fun `malformed content range is rejected`() {
+        AppUpdateDownloadPolicy.parseContentRange("bytes 2048-1024/4096") shouldBe null
+        AppUpdateDownloadPolicy.parseContentRange("bytes 0-4096/4096") shouldBe null
+        AppUpdateDownloadPolicy.parseContentRange(null) shouldBe null
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateReleaseNotesTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateReleaseNotesTest.kt
@@ -1,0 +1,85 @@
+package eu.kanade.tachiyomi.data.updater
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AppUpdateReleaseNotesTest {
+
+    @Test
+    fun `marked release selects Chinese and removes the legacy divider`() {
+        val content = """
+            <!-- koharia-release-notes:zh -->
+            # Koharia v1.0.0
+            中文说明
+            ---
+            <!-- koharia-release-notes:en -->
+            # Koharia v1.0.0
+            English notes
+            <!-- koharia-release-notes:end -->
+        """.trimIndent()
+
+        AppUpdateReleaseNotes.select(content, "zh") shouldBe """
+            # Koharia v1.0.0
+            中文说明
+        """.trimIndent()
+    }
+
+    @Test
+    fun `marked release selects English for every non Chinese language`() {
+        val content = """
+            <!-- koharia-release-notes:zh -->
+            中文说明
+            <!-- koharia-release-notes:en -->
+            English notes
+            <!-- koharia-release-notes:end -->
+        """.trimIndent()
+
+        AppUpdateReleaseNotes.select(content, "en") shouldBe "English notes"
+        AppUpdateReleaseNotes.select(content, "ja") shouldBe "English notes"
+    }
+
+    @Test
+    fun `legacy bilingual release remains supported`() {
+        val content = """
+            # Koharia v1.0.0
+            中文说明
+
+            ---
+
+            # Koharia v1.0.0
+            English notes
+        """.trimIndent()
+
+        AppUpdateReleaseNotes.select(content, "zh") shouldBe """
+            # Koharia v1.0.0
+            中文说明
+        """.trimIndent()
+        AppUpdateReleaseNotes.select(content, "fr") shouldBe """
+            # Koharia v1.0.0
+            English notes
+        """.trimIndent()
+    }
+
+    @Test
+    fun `single language release is retained as a safe fallback`() {
+        AppUpdateReleaseNotes.select("# 更新说明\n\n只有中文", "en") shouldBe "# 更新说明\n\n只有中文"
+    }
+
+    @Test
+    fun `checksum content after the end marker is not displayed`() {
+        val content = """
+            <!-- koharia-release-notes:zh -->
+            中文说明
+            <!-- koharia-release-notes:en -->
+            English notes
+            <!-- koharia-release-notes:end -->
+
+            ---
+
+            ## Checksums
+            abc123
+        """.trimIndent()
+
+        AppUpdateReleaseNotes.select(content, "en") shouldBe "English notes"
+    }
+}

--- a/data/src/main/java/tachiyomi/data/release/GithubRelease.kt
+++ b/data/src/main/java/tachiyomi/data/release/GithubRelease.kt
@@ -24,6 +24,8 @@ data class GithubRelease(
 @Serializable
 data class GitHubAsset(
     val name: String,
+    val size: Long,
+    val digest: String? = null,
     @SerialName("browser_download_url")
     val downloadLink: String,
 )

--- a/data/src/main/java/tachiyomi/data/release/KohariaReleaseResponse.kt
+++ b/data/src/main/java/tachiyomi/data/release/KohariaReleaseResponse.kt
@@ -1,0 +1,33 @@
+package tachiyomi.data.release
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class KohariaReleaseResponse(
+    val apiVersion: Int,
+    val repository: String,
+    val release: KohariaRelease,
+)
+
+@Serializable
+data class KohariaRelease(
+    val tagName: String,
+    val name: String,
+    val body: String,
+    val htmlUrl: String,
+    val draft: Boolean,
+    val prerelease: Boolean,
+    val publishedAt: String,
+    val primaryApk: KohariaReleaseAsset? = null,
+    val assets: List<KohariaReleaseAsset> = emptyList(),
+)
+
+@Serializable
+data class KohariaReleaseAsset(
+    val name: String,
+    val size: Long,
+    val digest: String? = null,
+    val sha256: String? = null,
+    val downloadUrl: String,
+    val githubDownloadUrl: String,
+)

--- a/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
+++ b/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
 import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import tachiyomi.domain.release.interactor.GetApplicationRelease
 import tachiyomi.domain.release.model.Release
 import tachiyomi.domain.release.service.ReleaseService
@@ -18,12 +19,26 @@ class ReleaseServiceImpl(
     override suspend fun latest(arguments: GetApplicationRelease.Arguments): Release? {
         val release = with(json) {
             networkService.client
-                .newCall(GET("https://api.github.com/repos/${arguments.repository}/releases/latest"))
+                .newCall(
+                    GET("https://api.github.com/repos/${arguments.repository}/releases/latest")
+                        .newBuilder()
+                        .header("Accept", "application/vnd.github+json")
+                        .header("X-GitHub-Api-Version", "2022-11-28")
+                        .build(),
+                )
                 .awaitSuccess()
                 .parseAs<GithubRelease>()
         }
 
-        val downloadLink = getDownloadLink(release = release, isFoss = arguments.isFoss) ?: return null
+        val downloadAsset = getDownloadAsset(release = release, isFoss = arguments.isFoss) ?: return null
+        val proxyDownloadLink = buildProxyDownloadLink(
+            repository = arguments.repository,
+            tag = release.version,
+            assetName = downloadAsset.name,
+        )
+        val expectedSha256 = downloadAsset.digest
+            ?.substringAfter("sha256:", missingDelimiterValue = "")
+            ?.takeIf { SHA256_REGEX.matches(it) }
 
         return Release(
             version = release.version,
@@ -31,14 +46,21 @@ class ReleaseServiceImpl(
                 "[${mention.value}](https://github.com/${mention.value.substring(1)})"
             },
             releaseLink = release.releaseLink,
-            downloadLink = downloadLink,
+            downloadLink = proxyDownloadLink ?: downloadAsset.downloadLink,
+            fallbackDownloadLinks = listOfNotNull(
+                downloadAsset.downloadLink.takeIf { it != proxyDownloadLink },
+            ),
+            expectedSize = downloadAsset.size.takeIf { it > 0L },
+            expectedSha256 = expectedSha256,
         )
     }
 
-    private fun getDownloadLink(release: GithubRelease, isFoss: Boolean): String? {
-        val map = release.assets.associate { asset ->
-            BUILD_TYPES.find { "-$it" in asset.name } to asset.downloadLink
-        }
+    private fun getDownloadAsset(release: GithubRelease, isFoss: Boolean): GitHubAsset? {
+        val map = release.assets
+            .filter { it.name.startsWith("Koharia") && it.name.endsWith(".apk", ignoreCase = true) }
+            .associate { asset ->
+                BUILD_TYPES.find { "-$it" in asset.name } to asset
+            }
 
         return if (!isFoss) {
             map[Build.SUPPORTED_ABIS[0]] ?: map[null]
@@ -47,9 +69,25 @@ class ReleaseServiceImpl(
         }
     }
 
+    private fun buildProxyDownloadLink(repository: String, tag: String, assetName: String): String? {
+        if (repository != KOHARIA_REPOSITORY) return null
+
+        return DOWNLOAD_BASE_URL.toHttpUrl()
+            .newBuilder()
+            .addPathSegment("releases")
+            .addPathSegment("download")
+            .addPathSegment(tag)
+            .addPathSegment(assetName)
+            .build()
+            .toString()
+    }
+
     companion object {
+        private const val KOHARIA_REPOSITORY = "Mister-album/Koharia"
+        private const val DOWNLOAD_BASE_URL = "https://download.koharia.org"
         private const val FOSS = "foss"
         private val BUILD_TYPES = listOf(FOSS, "arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+        private val SHA256_REGEX = Regex("[0-9a-fA-F]{64}")
 
         /**
          * Regular expression that matches a mention to a valid GitHub username, like it's

--- a/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
+++ b/data/src/main/java/tachiyomi/data/release/ReleaseServiceImpl.kt
@@ -5,8 +5,12 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.network.awaitSuccess
 import eu.kanade.tachiyomi.network.parseAs
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
+import logcat.LogPriority
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.release.interactor.GetApplicationRelease
 import tachiyomi.domain.release.model.Release
 import tachiyomi.domain.release.service.ReleaseService
@@ -17,6 +21,61 @@ class ReleaseServiceImpl(
 ) : ReleaseService {
 
     override suspend fun latest(arguments: GetApplicationRelease.Arguments): Release? {
+        if (arguments.repository == KOHARIA_REPOSITORY) {
+            try {
+                latestFromKoharia(arguments)?.let { return it }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                logcat(LogPriority.WARN, error) {
+                    "Koharia release metadata proxy failed; falling back to GitHub"
+                }
+            }
+        }
+
+        return latestFromGitHub(arguments)
+    }
+
+    private suspend fun latestFromKoharia(arguments: GetApplicationRelease.Arguments): Release? {
+        val response = with(json) {
+            networkService.client
+                .newCall(GET("$DOWNLOAD_BASE_URL/api/releases/latest"))
+                .awaitSuccess()
+                .parseAs<KohariaReleaseResponse>()
+        }
+        if (
+            response.apiVersion != KOHARIA_RELEASE_API_VERSION ||
+            response.repository != arguments.repository ||
+            response.release.draft ||
+            response.release.prerelease
+        ) {
+            return null
+        }
+
+        val release = response.release
+        val version = release.tagName.takeIf(String::isNotBlank) ?: return null
+        val releaseLink = release.htmlUrl.validHttpsUrl() ?: return null
+        val assets = release.assets.ifEmpty { listOfNotNull(release.primaryApk) }
+        val downloadAsset = selectDownloadAsset(assets, arguments.isFoss) { it.name } ?: return null
+        val proxyDownloadLink = downloadAsset.downloadUrl.validHttpsUrl()
+        val githubDownloadLink = downloadAsset.githubDownloadUrl.validHttpsUrl()
+        val primaryDownloadLink = proxyDownloadLink ?: githubDownloadLink ?: return null
+
+        return Release(
+            version = version,
+            info = release.body.withLinkedGitHubMentions(),
+            releaseLink = releaseLink,
+            downloadLink = primaryDownloadLink,
+            fallbackDownloadLinks = listOfNotNull(
+                githubDownloadLink.takeIf { it != primaryDownloadLink },
+            ),
+            expectedSize = downloadAsset.size.takeIf { it > 0L },
+            expectedSha256 = downloadAsset.sha256.validSha256()
+                ?: downloadAsset.digest.sha256FromDigest(),
+        )
+    }
+
+    private suspend fun latestFromGitHub(arguments: GetApplicationRelease.Arguments): Release? {
         val release = with(json) {
             networkService.client
                 .newCall(
@@ -42,9 +101,7 @@ class ReleaseServiceImpl(
 
         return Release(
             version = release.version,
-            info = release.info.substringBeforeLast("<!-->").replace(gitHubUsernameMentionRegex) { mention ->
-                "[${mention.value}](https://github.com/${mention.value.substring(1)})"
-            },
+            info = release.info.withLinkedGitHubMentions(),
             releaseLink = release.releaseLink,
             downloadLink = proxyDownloadLink ?: downloadAsset.downloadLink,
             fallbackDownloadLinks = listOfNotNull(
@@ -56,10 +113,20 @@ class ReleaseServiceImpl(
     }
 
     private fun getDownloadAsset(release: GithubRelease, isFoss: Boolean): GitHubAsset? {
-        val map = release.assets
-            .filter { it.name.startsWith("Koharia") && it.name.endsWith(".apk", ignoreCase = true) }
+        return selectDownloadAsset(release.assets, isFoss) { it.name }
+    }
+
+    private fun <T> selectDownloadAsset(
+        assets: List<T>,
+        isFoss: Boolean,
+        name: (T) -> String,
+    ): T? {
+        val map = assets
+            .filter { asset ->
+                name(asset).startsWith("Koharia") && name(asset).endsWith(".apk", ignoreCase = true)
+            }
             .associate { asset ->
-                BUILD_TYPES.find { "-$it" in asset.name } to asset
+                BUILD_TYPES.find { "-$it" in name(asset) } to asset
             }
 
         return if (!isFoss) {
@@ -67,6 +134,26 @@ class ReleaseServiceImpl(
         } else {
             map[FOSS]
         }
+    }
+
+    private fun String.withLinkedGitHubMentions(): String {
+        return substringBeforeLast("<!-->").replace(gitHubUsernameMentionRegex) { mention ->
+            "[${mention.value}](https://github.com/${mention.value.substring(1)})"
+        }
+    }
+
+    private fun String?.validSha256(): String? = this?.takeIf(SHA256_REGEX::matches)
+
+    private fun String?.sha256FromDigest(): String? {
+        return this
+            ?.substringAfter("sha256:", missingDelimiterValue = "")
+            .validSha256()
+    }
+
+    private fun String.validHttpsUrl(): String? {
+        return toHttpUrlOrNull()
+            ?.takeIf { it.isHttps }
+            ?.toString()
     }
 
     private fun buildProxyDownloadLink(repository: String, tag: String, assetName: String): String? {
@@ -85,6 +172,7 @@ class ReleaseServiceImpl(
     companion object {
         private const val KOHARIA_REPOSITORY = "Mister-album/Koharia"
         private const val DOWNLOAD_BASE_URL = "https://download.koharia.org"
+        private const val KOHARIA_RELEASE_API_VERSION = 1
         private const val FOSS = "foss"
         private val BUILD_TYPES = listOf(FOSS, "arm64-v8a", "armeabi-v7a", "x86_64", "x86")
         private val SHA256_REGEX = Regex("[0-9a-fA-F]{64}")

--- a/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
+++ b/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
@@ -48,28 +48,34 @@ class GetApplicationRelease(
         versionName: String,
         versionTag: String,
     ): Boolean {
-        // Removes prefixes like "r" or "v"
-        val newVersion = versionTag.replace("[^\\d.]".toRegex(), "")
         return if (isPreview) {
             // Preview builds: based on releases in "kohariaapp/koharia-preview" repo
             // tagged as something like "r1234"
-            newVersion.toInt() > commitCount
+            versionTag.filter(Char::isDigit).toIntOrNull()?.let { it > commitCount } == true
         } else {
             // Release builds: based on releases in "kohariaapp/koharia" repo
             // tagged as something like "v0.1.2"
-            val oldVersion = versionName.replace("[^\\d.]".toRegex(), "")
+            val newSemVer = versionTag.toVersionComponents()
+            val oldSemVer = versionName.toVersionComponents()
+            if (newSemVer.isEmpty() || oldSemVer.isEmpty()) return false
 
-            val newSemVer = newVersion.split(".").map { it.toInt() }
-            val oldSemVer = oldVersion.split(".").map { it.toInt() }
-
-            oldSemVer.mapIndexed { index, i ->
-                if (newSemVer[index] > i) {
-                    return true
+            repeat(maxOf(newSemVer.size, oldSemVer.size)) { index ->
+                val newPart = newSemVer.getOrElse(index) { 0 }
+                val oldPart = oldSemVer.getOrElse(index) { 0 }
+                when {
+                    newPart > oldPart -> return true
+                    newPart < oldPart -> return false
                 }
             }
 
             false
         }
+    }
+
+    private fun String.toVersionComponents(): List<Int> {
+        return substringBefore('-')
+            .split('.')
+            .mapNotNull { component -> component.filter(Char::isDigit).toIntOrNull() }
     }
 
     data class Arguments(

--- a/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
+++ b/domain/src/main/java/tachiyomi/domain/release/interactor/GetApplicationRelease.kt
@@ -22,10 +22,10 @@ class GetApplicationRelease(
         // Limit checks to once every 3 days at most
         val nextCheckTime = Instant.ofEpochMilli(lastChecked.get()).plus(3, ChronoUnit.DAYS)
         if (!arguments.forceCheck && now.isBefore(nextCheckTime)) {
-            return Result.NoNewUpdate
+            return Result.NoNewUpdate()
         }
 
-        val release = service.latest(arguments) ?: return Result.NoNewUpdate
+        val release = service.latest(arguments) ?: return Result.NoNewUpdate()
 
         lastChecked.set(now.toEpochMilli())
 
@@ -38,7 +38,7 @@ class GetApplicationRelease(
         )
         return when {
             isNewVersion -> Result.NewUpdate(release)
-            else -> Result.NoNewUpdate
+            else -> Result.NoNewUpdate(release)
         }
     }
 
@@ -89,7 +89,7 @@ class GetApplicationRelease(
 
     sealed interface Result {
         data class NewUpdate(val release: Release) : Result
-        data object NoNewUpdate : Result
+        data class NoNewUpdate(val release: Release? = null) : Result
         data object OsTooOld : Result
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/release/model/Release.kt
+++ b/domain/src/main/java/tachiyomi/domain/release/model/Release.kt
@@ -8,4 +8,10 @@ data class Release(
     val info: String,
     val releaseLink: String,
     val downloadLink: String,
-)
+    val fallbackDownloadLinks: List<String> = emptyList(),
+    val expectedSize: Long? = null,
+    val expectedSha256: String? = null,
+) {
+    val downloadLinks: List<String>
+        get() = (listOf(downloadLink) + fallbackDownloadLinks).distinct()
+}

--- a/domain/src/test/java/tachiyomi/domain/release/interactor/GetApplicationReleaseTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/release/interactor/GetApplicationReleaseTest.kt
@@ -112,7 +112,7 @@ class GetApplicationReleaseTest {
             ),
         )
 
-        result shouldBe GetApplicationRelease.Result.NoNewUpdate
+        result shouldBe GetApplicationRelease.Result.NoNewUpdate(release)
     }
 
     @Test
@@ -146,12 +146,13 @@ class GetApplicationReleaseTest {
         every { preference.get() } returns 0
         every { preference.set(any()) }.answers { }
 
-        coEvery { releaseService.latest(any()) } returns Release(
+        val release = Release(
             "latest",
             "info",
             "http://example.com/release_link",
             "http://example.com/release_link.apk",
         )
+        coEvery { releaseService.latest(any()) } returns release
 
         val result = getApplicationRelease.await(
             GetApplicationRelease.Arguments(
@@ -163,7 +164,7 @@ class GetApplicationReleaseTest {
             ),
         )
 
-        result shouldBe GetApplicationRelease.Result.NoNewUpdate
+        result shouldBe GetApplicationRelease.Result.NoNewUpdate(release)
     }
 
     @Test
@@ -191,6 +192,6 @@ class GetApplicationReleaseTest {
         )
 
         coVerify(exactly = 0) { releaseService.latest(any()) }
-        result shouldBe GetApplicationRelease.Result.NoNewUpdate
+        result shouldBe GetApplicationRelease.Result.NoNewUpdate()
     }
 }

--- a/domain/src/test/java/tachiyomi/domain/release/interactor/GetApplicationReleaseTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/release/interactor/GetApplicationReleaseTest.kt
@@ -116,6 +116,57 @@ class GetApplicationReleaseTest {
     }
 
     @Test
+    fun `When new version has fewer components expect new update`() = runTest {
+        every { preference.get() } returns 0
+        every { preference.set(any()) }.answers { }
+
+        val release = Release(
+            "v1.1",
+            "info",
+            "http://example.com/release_link",
+            "http://example.com/release_link.apk",
+        )
+        coEvery { releaseService.latest(any()) } returns release
+
+        val result = getApplicationRelease.await(
+            GetApplicationRelease.Arguments(
+                isFoss = false,
+                isPreview = false,
+                commitCount = 0,
+                versionName = "1.0.9",
+                repository = "test",
+            ),
+        )
+
+        result shouldBe GetApplicationRelease.Result.NewUpdate(release)
+    }
+
+    @Test
+    fun `When release version is malformed expect no new update`() = runTest {
+        every { preference.get() } returns 0
+        every { preference.set(any()) }.answers { }
+
+        coEvery { releaseService.latest(any()) } returns Release(
+            "latest",
+            "info",
+            "http://example.com/release_link",
+            "http://example.com/release_link.apk",
+        )
+
+        val result = getApplicationRelease.await(
+            GetApplicationRelease.Arguments(
+                isFoss = false,
+                isPreview = false,
+                commitCount = 0,
+                versionName = "1.0.0",
+                repository = "test",
+            ),
+        )
+
+        result shouldBe GetApplicationRelease.Result.NoNewUpdate
+    }
+
+    @Test
     fun `When now is before three days expect no new update`() = runTest {
         every { preference.get() } returns Instant.now().toEpochMilli()
         every { preference.set(any()) }.answers { }

--- a/domain/src/test/java/tachiyomi/domain/release/model/ReleaseTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/release/model/ReleaseTest.kt
@@ -1,0 +1,26 @@
+package tachiyomi.domain.release.model
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ReleaseTest {
+
+    @Test
+    fun `download links keep primary source first and remove duplicates`() {
+        val release = Release(
+            version = "v1.0.0",
+            info = "info",
+            releaseLink = "https://example.com/release",
+            downloadLink = "https://download.example.com/app.apk",
+            fallbackDownloadLinks = listOf(
+                "https://github.com/example/app.apk",
+                "https://download.example.com/app.apk",
+            ),
+        )
+
+        release.downloadLinks shouldBe listOf(
+            "https://download.example.com/app.apk",
+            "https://github.com/example/app.apk",
+        )
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1229,6 +1229,7 @@
 
     <!--UpdateCheck Notifications-->
     <string name="update_check_notification_download_in_progress">Downloading…</string>
+    <string name="update_check_notification_download_retrying">Download interrupted, retrying…</string>
     <string name="update_check_notification_download_complete">Tap to install update</string>
     <string name="update_check_notification_download_error">Download error</string>
     <string name="update_check_notification_update_available">New version available!</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1225,7 +1225,10 @@
     <string name="update_check_open">Open on GitHub</string>
     <!-- reserved for future use -->
     <string name="update_check_eol">This Android version is no longer supported</string>
-    <string name="update_check_no_new_updates">No new updates available</string>
+    <string name="update_check_no_new_updates">No updates available</string>
+    <string name="update_check_current_version">Current version: %s</string>
+    <string name="update_check_release_notes_unavailable">Release notes are unavailable. Open the release page to view the details.</string>
+    <string name="update_check_open_release_page">Open release page</string>
 
     <!--UpdateCheck Notifications-->
     <string name="update_check_notification_download_in_progress">Downloading…</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -339,6 +339,7 @@
     <string name="update_check_confirm">下载</string>
     <string name="update_check_no_new_updates">没有新版本</string>
     <string name="update_check_notification_download_in_progress">正在下载…</string>
+    <string name="update_check_notification_download_retrying">下载中断，正在重试…</string>
     <string name="update_check_notification_download_complete">点击安装更新</string>
     <string name="update_check_notification_download_error">下载失败</string>
     <string name="update_check_notification_update_available">有新版本！</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -337,7 +337,10 @@
     <string name="file_select_cover">选择封面图片</string>
     <string name="file_select_backup">选择备份文件</string>
     <string name="update_check_confirm">下载</string>
-    <string name="update_check_no_new_updates">没有新版本</string>
+    <string name="update_check_no_new_updates">暂无更新</string>
+    <string name="update_check_current_version">当前版本：%s</string>
+    <string name="update_check_release_notes_unavailable">暂时无法获取更新公告，可打开版本页面查看详情。</string>
+    <string name="update_check_open_release_page">打开版本页面</string>
     <string name="update_check_notification_download_in_progress">正在下载…</string>
     <string name="update_check_notification_download_retrying">下载中断，正在重试…</string>
     <string name="update_check_notification_download_complete">点击安装更新</string>


### PR DESCRIPTION
## 中文

### 改动内容

- 保留 GitHub Release API 作为版本元数据来源，将 APK 主下载地址切换为 `download.koharia.org`，并保留 GitHub 资产地址作为备用源。
- 将资产大小与 SHA-256 摘要贯穿更新界面、通知和 WorkManager 下载任务。
- 增加 `.part` 断点续传、Range/Content-Range 校验、多源回退、指数退避重试以及可重试/终止性 HTTP 状态分类。
- 下载完成后校验文件大小、SHA-256、APK 包名和签名，再显示安装入口。
- 修复重复触发下载时旧任务与新任务可能同时写入同一分片文件的问题，下载写入现在可感知取消并在进程内串行执行。
- 增加版本比较、下载策略和下载源顺序测试，以及中英文重试提示。

### 原因与影响

GitHub 直连可能因网络、限流或临时连接问题导致更新失败。新的 Cloudflare 主源和 GitHub 备用源可提高下载可用性，断点续传减少失败后的重复流量，完整性与签名校验则避免损坏或错误 APK 进入安装流程。

### 验证

- `./gradlew.bat spotlessCheck :domain:test :app:testDebugUnitTest :app:compileDebugKotlin --no-daemon`
- `./gradlew.bat spotlessApply :app:testDebugUnitTest :app:installDebug -Penable-updater --no-daemon`
- `./gradlew.bat spotlessCheck :app:compileDebugKotlin :app:installDebug -Penable-updater --no-daemon`
- Android 17 x86_64 模拟器 ADB 验证：代理 `200` 下载、GitHub 备用源切换、断网后 Range `206` 续传、重复触发串行化、大小/SHA 校验和终止性 `403` 行为。

## English

### What changed

- Keep the GitHub Release API for release metadata, use `download.koharia.org` as the primary APK source, and retain the GitHub asset URL as a fallback.
- Carry release asset size and SHA-256 metadata through the update UI, notifications, and WorkManager input.
- Add resumable `.part` downloads, Range validation, source fallback, exponential backoff, and retryable versus terminal HTTP classification.
- Verify size, SHA-256, package name, and signing certificates before prompting installation.
- Prevent replaced workers from writing the same partial file concurrently by making copying cancellation-aware and serializing update downloads in-process.
- Add tests for version comparison, download policy, and source ordering, plus localized retry messaging.

### Why and impact

Direct GitHub downloads can fail because of connectivity, throttling, or transient network issues. The Cloudflare primary source and GitHub fallback improve availability, resumable downloads reduce repeated traffic, and integrity/signature checks prevent corrupted or mismatched APKs from reaching installation.

### Validation

- Gradle formatting, domain/app unit tests, and Debug Kotlin compilation passed.
- Debug build with the updater enabled was installed successfully.
- ADB validation on an Android 17 x86_64 emulator covered proxy downloads, fallback selection, `206` resume, repeated-trigger serialization, metadata validation, and terminal `403` handling.
