### PR TITLE
优化书架范围、服务器管理与章节显示 / Improve shelf scope, server management, and chapter display

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/ChapterSettingsDialog.kt
@@ -59,6 +59,10 @@ fun ChapterSettingsDialog(
     onDisplayModeChanged: (Long) -> Unit,
     showChapterReadProgress: Boolean,
     onShowChapterReadProgressChanged: (Boolean) -> Unit,
+    showChapterFileSize: Boolean,
+    onShowChapterFileSizeChanged: (Boolean) -> Unit,
+    hideMissingChapters: Boolean,
+    onHideMissingChaptersChanged: (Boolean) -> Unit,
     onSetAsDefault: (applyToExistingManga: Boolean) -> Unit,
     onResetToDefault: () -> Unit,
 ) {
@@ -129,6 +133,11 @@ fun ChapterSettingsDialog(
                         onDisplayModeSelected = onDisplayModeChanged,
                         showChapterReadProgress = showChapterReadProgress,
                         onShowChapterReadProgressChanged = onShowChapterReadProgressChanged,
+                        showChapterFileSize = showChapterFileSize,
+                        onShowChapterFileSizeChanged = onShowChapterFileSizeChanged,
+                        showChapterFileSizeOption = isKomgaCacheMode,
+                        hideMissingChapters = hideMissingChapters,
+                        onHideMissingChaptersChanged = onHideMissingChaptersChanged,
                     )
                 }
             }
@@ -226,12 +235,29 @@ private fun ColumnScope.DisplayPage(
     onDisplayModeSelected: (Long) -> Unit,
     showChapterReadProgress: Boolean,
     onShowChapterReadProgressChanged: (Boolean) -> Unit,
+    showChapterFileSize: Boolean,
+    onShowChapterFileSizeChanged: (Boolean) -> Unit,
+    showChapterFileSizeOption: Boolean,
+    hideMissingChapters: Boolean,
+    onHideMissingChaptersChanged: (Boolean) -> Unit,
 ) {
     SwitchPreferenceWidget(
         title = stringResource(MR.strings.pref_show_chapter_read_progress),
         subtitle = stringResource(MR.strings.pref_show_chapter_read_progress_summary),
         checked = showChapterReadProgress,
         onCheckedChanged = onShowChapterReadProgressChanged,
+    )
+    if (showChapterFileSizeOption) {
+        SwitchPreferenceWidget(
+            title = stringResource(MR.strings.pref_show_chapter_file_size),
+            checked = showChapterFileSize,
+            onCheckedChanged = onShowChapterFileSizeChanged,
+        )
+    }
+    SwitchPreferenceWidget(
+        title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
+        checked = hideMissingChapters,
+        onCheckedChanged = onHideMissingChaptersChanged,
     )
 
     Text(

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -1,5 +1,6 @@
 package eu.kanade.presentation.manga
 
+import android.text.format.Formatter
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Canvas
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,23 +50,18 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.BlurredEdgeTreatment
-import androidx.compose.ui.draw.blur
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
@@ -114,6 +111,7 @@ fun MangaScreen(
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
     showChapterReadProgress: Boolean,
+    showChapterFileSize: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
     onDownloadChapter: ((List<ChapterList.Item>, ChapterDownloadAction) -> Unit)?,
@@ -170,6 +168,7 @@ fun MangaScreen(
             chapterSwipeEndAction = chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
             showChapterReadProgress = showChapterReadProgress,
+            showChapterFileSize = showChapterFileSize,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -207,6 +206,7 @@ fun MangaScreen(
             chapterSwipeEndAction = chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
             showChapterReadProgress = showChapterReadProgress,
+            showChapterFileSize = showChapterFileSize,
             isKomgaCacheMode = isKomgaCacheMode,
             navigateUp = navigateUp,
             onChapterClicked = onChapterClicked,
@@ -247,6 +247,7 @@ private fun MangaScreenSmallImpl(
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
     showChapterReadProgress: Boolean,
+    showChapterFileSize: Boolean,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -449,6 +450,7 @@ private fun MangaScreenSmallImpl(
                         isKomgaSource = state.source.isKomgaSource(),
                         chapters = listItem,
                         showChapterReadProgress = showChapterReadProgress,
+                        showChapterFileSize = showChapterFileSize,
                         isAnyChapterSelected = chapters.fastAny { it.selected },
                         onChapterClicked = onChapterClicked,
                         onChapterSelected = onChapterSelected,
@@ -490,6 +492,7 @@ private fun MangaScreenSmallImpl(
                             manga = state.manga,
                             chapters = listItem,
                             showChapterReadProgress = showChapterReadProgress,
+                            showChapterFileSize = showChapterFileSize,
                             isKomgaCacheMode = isKomgaCacheMode,
                             isAnyChapterSelected = chapters.fastAny { it.selected },
                             chapterSwipeStartAction = chapterSwipeStartAction,
@@ -514,6 +517,7 @@ fun MangaScreenLargeImpl(
     chapterSwipeEndAction: LibraryPreferences.ChapterSwipeAction,
     chapterCoverGridColumns: Int,
     showChapterReadProgress: Boolean,
+    showChapterFileSize: Boolean,
     isKomgaCacheMode: Boolean,
     navigateUp: () -> Unit,
     onChapterClicked: (Chapter) -> Unit,
@@ -727,6 +731,7 @@ fun MangaScreenLargeImpl(
                             chapterHeaderGridItem(
                                 enabled = !isAnySelected,
                                 chapters = chapters,
+                                hideMissingChapters = state.hideMissingChapters,
                                 onClick = onFilterButtonClicked,
                             )
                             sharedChapterGridItems(
@@ -734,6 +739,7 @@ fun MangaScreenLargeImpl(
                                 isKomgaSource = state.source.isKomgaSource(),
                                 chapters = listItem,
                                 showChapterReadProgress = showChapterReadProgress,
+                                showChapterFileSize = showChapterFileSize,
                                 isAnyChapterSelected = chapters.fastAny { it.selected },
                                 onChapterClicked = onChapterClicked,
                                 onChapterSelected = onChapterSelected,
@@ -755,6 +761,7 @@ fun MangaScreenLargeImpl(
                                 chapterHeaderListItem(
                                     enabled = !isAnySelected,
                                     chapters = chapters,
+                                    hideMissingChapters = state.hideMissingChapters,
                                     onClick = onFilterButtonClicked,
                                 )
 
@@ -762,6 +769,7 @@ fun MangaScreenLargeImpl(
                                     manga = state.manga,
                                     chapters = listItem,
                                     showChapterReadProgress = showChapterReadProgress,
+                                    showChapterFileSize = showChapterFileSize,
                                     isKomgaCacheMode = isKomgaCacheMode,
                                     isAnyChapterSelected = chapters.fastAny { it.selected },
                                     chapterSwipeStartAction = chapterSwipeStartAction,
@@ -828,6 +836,7 @@ private fun LazyListScope.sharedChapterItems(
     manga: Manga,
     chapters: List<ChapterList>,
     showChapterReadProgress: Boolean,
+    showChapterFileSize: Boolean,
     isKomgaCacheMode: Boolean,
     isAnyChapterSelected: Boolean,
     chapterSwipeStartAction: LibraryPreferences.ChapterSwipeAction,
@@ -855,14 +864,7 @@ private fun LazyListScope.sharedChapterItems(
             }
             is ChapterList.Item -> {
                 MangaChapterListItem(
-                    title = if (manga.displayMode == Manga.CHAPTER_DISPLAY_NUMBER) {
-                        stringResource(
-                            MR.strings.display_mode_chapter,
-                            formatChapterNumber(item.chapter.chapterNumber),
-                        )
-                    } else {
-                        item.chapter.name
-                    },
+                    title = chapterTitleWithFileSize(manga, item, showChapterFileSize),
                     date = relativeDateText(item.chapter.dateUpload),
                     readProgress = chapterReadProgress(item).takeIf { showChapterReadProgress },
                     scanlator = item.chapter.scanlator.takeIf { !it.isNullOrBlank() },
@@ -965,6 +967,7 @@ private fun LazyListScope.sharedMangaDetailHeaderListItems(
     chapterHeaderListItem(
         enabled = !isAnySelected,
         chapters = chapters,
+        hideMissingChapters = state.hideMissingChapters,
         onClick = onFilterClicked,
     )
 }
@@ -1036,6 +1039,7 @@ private fun LazyGridScope.sharedMangaDetailHeaderGridItems(
     chapterHeaderGridItem(
         enabled = !isAnySelected,
         chapters = chapters,
+        hideMissingChapters = state.hideMissingChapters,
         onClick = onFilterClicked,
     )
 }
@@ -1043,14 +1047,19 @@ private fun LazyGridScope.sharedMangaDetailHeaderGridItems(
 private fun LazyListScope.chapterHeaderListItem(
     enabled: Boolean,
     chapters: List<ChapterList.Item>,
+    hideMissingChapters: Boolean,
     onClick: () -> Unit,
 ) {
     item(
         key = MangaScreenItem.CHAPTER_HEADER,
         contentType = MangaScreenItem.CHAPTER_HEADER,
     ) {
-        val missingChapterCount = remember(chapters) {
-            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+        val missingChapterCount = if (hideMissingChapters) {
+            0
+        } else {
+            remember(chapters) {
+                chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+            }
         }
         ChapterHeader(
             enabled = enabled,
@@ -1064,6 +1073,7 @@ private fun LazyListScope.chapterHeaderListItem(
 private fun LazyGridScope.chapterHeaderGridItem(
     enabled: Boolean,
     chapters: List<ChapterList.Item>,
+    hideMissingChapters: Boolean,
     onClick: () -> Unit,
 ) {
     item(
@@ -1071,8 +1081,12 @@ private fun LazyGridScope.chapterHeaderGridItem(
         span = { GridItemSpan(maxLineSpan) },
         contentType = MangaScreenItem.CHAPTER_HEADER,
     ) {
-        val missingChapterCount = remember(chapters) {
-            chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+        val missingChapterCount = if (hideMissingChapters) {
+            0
+        } else {
+            remember(chapters) {
+                chapters.map { it.chapter.chapterNumber }.missingChaptersCount()
+            }
         }
         ChapterHeader(
             enabled = enabled,
@@ -1088,6 +1102,7 @@ private fun LazyGridScope.sharedChapterGridItems(
     isKomgaSource: Boolean,
     chapters: List<ChapterList>,
     showChapterReadProgress: Boolean,
+    showChapterFileSize: Boolean,
     isAnyChapterSelected: Boolean,
     onChapterClicked: (Chapter) -> Unit,
     onChapterSelected: (ChapterList.Item, Boolean, Boolean) -> Unit,
@@ -1158,7 +1173,7 @@ private fun LazyGridScope.sharedChapterGridItems(
                 if (manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COMFORTABLE) {
                     MangaComfortableGridItem(
                         coverData = coverData,
-                        title = chapterTitle(manga, item),
+                        title = chapterTitleWithFileSize(manga, item, showChapterFileSize),
                         isSelected = item.selected,
                         coverOverlay = coverOverlay,
                         onLongClick = onLongClick,
@@ -1170,7 +1185,7 @@ private fun LazyGridScope.sharedChapterGridItems(
                         title = if (
                             manga.chapterCoverDisplayMode == Manga.CHAPTER_COVER_DISPLAY_COVER_AND_TITLE
                         ) {
-                            chapterTitle(manga, item)
+                            chapterTitleWithFileSize(manga, item, showChapterFileSize)
                         } else {
                             null
                         },
@@ -1190,74 +1205,51 @@ private fun ChapterProgressCorner(
     progress: String,
     modifier: Modifier = Modifier,
 ) {
-    Layout(
-        modifier = modifier,
-        content = {
-            Text(
-                text = progress,
-                color = Color.White,
-                fontWeight = FontWeight.ExtraBold,
-                maxLines = 1,
-                style = MaterialTheme.typography.labelSmall.copy(
-                    shadow = Shadow(
-                        color = Color.Black,
-                        blurRadius = 4f,
-                    ),
-                ),
-            )
-            Canvas(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .blur(
-                        radius = 11.dp,
-                        edgeTreatment = BlurredEdgeTreatment.Unbounded,
-                    ),
-            ) {
-                drawRect(
-                    color = Color.Black.copy(alpha = 0.58f),
-                    topLeft = Offset(size.width / 4f, size.height / 4f),
-                    size = Size(size.width / 2f, size.height / 2f),
-                )
-            }
-        },
-    ) { measurables, constraints ->
-        val textPlaceable = measurables[0].measure(
-            constraints.copy(minWidth = 0, minHeight = 0),
+    val cornerColor = MaterialTheme.colorScheme.primaryContainer
+    val progressColor = MaterialTheme.colorScheme.primary
+    Box(modifier = modifier.size(CHAPTER_STATUS_CORNER_SIZE)) {
+        ChapterStatusCornerBackground(color = cornerColor)
+        Text(
+            text = progress,
+            color = progressColor,
+            fontWeight = FontWeight.Bold,
+            maxLines = 1,
+            softWrap = false,
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontSize = 9.sp,
+                lineHeight = 9.sp,
+            ),
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .offset(x = (-1).dp, y = 5.dp)
+                .rotate(45f),
         )
-        val shadowWidth = (textPlaceable.width * 2)
-            .coerceIn(constraints.minWidth, constraints.maxWidth)
-        val shadowHeight = (textPlaceable.height * 2)
-            .coerceIn(constraints.minHeight, constraints.maxHeight)
-        val shadowPlaceable = measurables[1].measure(
-            Constraints.fixed(shadowWidth, shadowHeight),
-        )
-
-        layout(shadowWidth, shadowHeight) {
-            shadowPlaceable.place(0, 0)
-            textPlaceable.place(
-                x = (shadowWidth - textPlaceable.width) / 2,
-                y = (shadowHeight - textPlaceable.height) / 2,
-            )
-        }
     }
 }
+
+@Composable
+private fun ChapterStatusCornerBackground(color: Color) {
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        drawPath(
+            path = Path().apply {
+                moveTo(0f, 0f)
+                lineTo(size.width, 0f)
+                lineTo(size.width, size.height)
+                close()
+            },
+            color = color,
+        )
+    }
+}
+
+private val CHAPTER_STATUS_CORNER_SIZE = 32.dp
 
 @Composable
 private fun ChapterReadCorner(modifier: Modifier = Modifier) {
     val cornerColor = MaterialTheme.colorScheme.primaryContainer
     val checkColor = MaterialTheme.colorScheme.primary
-    Box(modifier = modifier.size(28.dp)) {
-        Canvas(modifier = Modifier.fillMaxSize()) {
-            drawPath(
-                path = Path().apply {
-                    moveTo(0f, 0f)
-                    lineTo(size.width, 0f)
-                    lineTo(size.width, size.height)
-                    close()
-                },
-                color = cornerColor,
-            )
-        }
+    Box(modifier = modifier.size(CHAPTER_STATUS_CORNER_SIZE)) {
+        ChapterStatusCornerBackground(color = cornerColor)
         Icon(
             imageVector = Icons.Filled.Check,
             contentDescription = null,
@@ -1325,9 +1317,48 @@ private fun chapterTitle(
             formatChapterNumber(item.chapter.chapterNumber),
         )
     } else {
-        item.chapter.name
+        item.chapter.name.withoutEmbeddedFileSize(item.chapter.memo)
     }
 }
+
+@Composable
+private fun chapterTitleWithFileSize(
+    manga: Manga,
+    item: ChapterList.Item,
+    showChapterFileSize: Boolean,
+): String {
+    val title = chapterTitle(manga, item)
+    val fileSize = chapterFileSize(item).takeIf { showChapterFileSize } ?: return title
+    return "$title ($fileSize)"
+}
+
+@Composable
+private fun chapterFileSize(item: ChapterList.Item): String? {
+    val sizeBytes = KomgaChapterMemo.sizeBytes(item.chapter.memo) ?: return null
+    val context = LocalContext.current
+    return remember(sizeBytes, context) {
+        Formatter.formatFileSize(context, sizeBytes)
+    }
+}
+
+private fun String.withoutEmbeddedFileSize(memo: kotlinx.serialization.json.JsonObject): String {
+    if (KomgaChapterMemo.sizeBytes(memo) == null) return this
+    val displaySize = KomgaChapterMemo.displaySize(memo)
+    val withoutRecordedSize = if (displaySize.isNullOrBlank()) {
+        this
+    } else {
+        replace(
+            Regex("\\s*\\(\\s*${Regex.escape(displaySize)}\\s*\\)\\s*$", RegexOption.IGNORE_CASE),
+            "",
+        )
+    }
+    return withoutRecordedSize.replace(TRAILING_FILE_SIZE_REGEX, "").ifBlank { this }
+}
+
+private val TRAILING_FILE_SIZE_REGEX = Regex(
+    pattern = "\\s*\\(\\s*\\d+(?:[.,]\\d+)?\\s*(?:bytes?|[kmgtpe]i?b)\\s*\\)\\s*$",
+    option = RegexOption.IGNORE_CASE,
+)
 
 private fun onChapterItemClick(
     chapterItem: ChapterList.Item,

--- a/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/manga/MangaScreen.kt
@@ -1342,23 +1342,8 @@ private fun chapterFileSize(item: ChapterList.Item): String? {
 }
 
 private fun String.withoutEmbeddedFileSize(memo: kotlinx.serialization.json.JsonObject): String {
-    if (KomgaChapterMemo.sizeBytes(memo) == null) return this
-    val displaySize = KomgaChapterMemo.displaySize(memo)
-    val withoutRecordedSize = if (displaySize.isNullOrBlank()) {
-        this
-    } else {
-        replace(
-            Regex("\\s*\\(\\s*${Regex.escape(displaySize)}\\s*\\)\\s*$", RegexOption.IGNORE_CASE),
-            "",
-        )
-    }
-    return withoutRecordedSize.replace(TRAILING_FILE_SIZE_REGEX, "").ifBlank { this }
+    return KomgaChapterMemo.removeTrailingEmbeddedFileSize(this, memo)
 }
-
-private val TRAILING_FILE_SIZE_REGEX = Regex(
-    pattern = "\\s*\\(\\s*\\d+(?:[.,]\\d+)?\\s*(?:bytes?|[kmgtpe]i?b)\\s*\\)\\s*$",
-    option = RegexOption.IGNORE_CASE,
-)
 
 private fun onChapterItemClick(
     chapterItem: ChapterList.Item,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsLibraryScreen.kt
@@ -279,6 +279,14 @@ object SettingsLibraryScreen : SearchableSettings {
                     title = stringResource(MR.strings.pref_show_chapter_read_progress),
                     subtitle = stringResource(MR.strings.pref_show_chapter_read_progress_summary),
                 ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.showChapterFileSize,
+                    title = stringResource(MR.strings.pref_show_chapter_file_size),
+                ),
+                Preference.PreferenceItem.SwitchPreference(
+                    preference = libraryPreferences.hideMissingChapters,
+                    title = stringResource(MR.strings.pref_hide_missing_chapter_indicators),
+                ),
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreen.kt
@@ -96,6 +96,7 @@ class MangaScreen(
         val state by screenModel.state.collectAsStateWithLifecycle()
         val chapterCoverGridColumns by screenModel.chapterCoverGridColumns
         val showChapterReadProgress = screenModel.showChapterReadProgress
+        val showChapterFileSize = screenModel.showChapterFileSize
 
         if (state is MangaScreenModel.State.Loading) {
             LoadingScreen()
@@ -118,6 +119,7 @@ class MangaScreen(
             chapterSwipeEndAction = screenModel.chapterSwipeEndAction,
             chapterCoverGridColumns = chapterCoverGridColumns,
             showChapterReadProgress = showChapterReadProgress,
+            showChapterFileSize = showChapterFileSize,
             navigateUp = navigator::pop,
             onChapterClicked = { openChapter(context, scope, epubReaderLauncher, it) },
             onDownloadChapter = screenModel::runChapterDownloadActions.takeIf { !successState.source.isLocalOrStub() },
@@ -208,6 +210,10 @@ class MangaScreen(
                 onDisplayModeChanged = screenModel::setDisplayMode,
                 showChapterReadProgress = showChapterReadProgress,
                 onShowChapterReadProgressChanged = screenModel::updateShowChapterReadProgress,
+                showChapterFileSize = showChapterFileSize,
+                onShowChapterFileSizeChanged = screenModel::updateShowChapterFileSize,
+                hideMissingChapters = successState.hideMissingChapters,
+                onHideMissingChaptersChanged = screenModel::updateHideMissingChapters,
                 onSetAsDefault = screenModel::setCurrentSettingsAsDefault,
                 onResetToDefault = screenModel::resetToDefaultSettings,
                 scanlatorFilterActive = successState.scanlatorFilterActive,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -188,6 +188,8 @@ class MangaScreenModel(
     val chapterCoverGridColumns = libraryPreferences.chapterCoverGridColumns.asState(screenModelScope)
     var showChapterReadProgress by mutableStateOf(libraryPreferences.showChapterReadProgress.get())
         private set
+    var showChapterFileSize by mutableStateOf(libraryPreferences.showChapterFileSize.get())
+        private set
     var autoTrackState = trackPreferences.autoUpdateTrackOnMarkRead.get()
 
     private val skipFiltered by readerPreferences.skipFiltered.asState(screenModelScope)
@@ -1140,6 +1142,14 @@ class MangaScreenModel(
         showChapterReadProgress = show
     }
 
+    fun updateShowChapterFileSize(show: Boolean) {
+        showChapterFileSize = show
+    }
+
+    fun updateHideMissingChapters(hide: Boolean) {
+        updateSuccessState { it.copy(hideMissingChapters = hide) }
+    }
+
     /**
      * Sets the sorting method and requests an UI update.
      * @param sort the sorting mode.
@@ -1155,9 +1165,13 @@ class MangaScreenModel(
     fun setCurrentSettingsAsDefault(applyToExisting: Boolean) {
         val manga = successState?.manga ?: return
         val showReadProgress = showChapterReadProgress
+        val showFileSize = showChapterFileSize
+        val hideMissingChapters = successState?.hideMissingChapters ?: return
         screenModelScope.launchNonCancellable {
             libraryPreferences.setChapterSettingsDefault(manga)
             libraryPreferences.showChapterReadProgress.set(showReadProgress)
+            libraryPreferences.showChapterFileSize.set(showFileSize)
+            libraryPreferences.hideMissingChapters.set(hideMissingChapters)
             if (applyToExisting) {
                 setMangaDefaultChapterFlags.awaitAll()
             }
@@ -1168,6 +1182,8 @@ class MangaScreenModel(
     fun resetToDefaultSettings() {
         val manga = successState?.manga ?: return
         showChapterReadProgress = libraryPreferences.showChapterReadProgress.get()
+        showChapterFileSize = libraryPreferences.showChapterFileSize.get()
+        updateHideMissingChapters(libraryPreferences.hideMissingChapters.get())
         screenModelScope.launchNonCancellable {
             setMangaDefaultChapterFlags.await(manga)
         }

--- a/app/src/main/java/koharia/komga/api/dto/Dto.kt
+++ b/app/src/main/java/koharia/komga/api/dto/Dto.kt
@@ -234,7 +234,8 @@ fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     artist = author
 }
 
-fun BookDto.toChapterMemo(baseUrl: String): JsonObject = KomgaChapterMemo.buildMemo(baseUrl, this)
+fun BookDto.toChapterMemo(baseUrl: String, embeddedFileSize: String? = null): JsonObject =
+    KomgaChapterMemo.buildMemo(baseUrl, this, embeddedFileSize)
 
 fun ReadListDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     title = name

--- a/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
+++ b/app/src/main/java/koharia/komga/domain/repository/KomgaRepository.kt
@@ -298,18 +298,48 @@ class KomgaRepository(
         isFromReadList: Boolean,
         chapterNumber: Float,
     ): SChapter {
+        val formattedName = formatChapterName(chapterNameTemplate, isFromReadList)
         return SChapter.create().apply {
             this.chapter_number = chapterNumber
             url = "$baseUrl/api/v1/books/$id"
-            name = formatChapterName(chapterNameTemplate, isFromReadList)
+            name = formattedName
             scanlator = metadata.authors.filter { it.role == "translator" }.joinToString { it.name }
-            memo = toChapterMemo(baseUrl)
+            memo = toChapterMemo(
+                baseUrl,
+                embeddedFileSize = trailingEmbeddedFileSize(
+                    chapterNameTemplate = chapterNameTemplate,
+                    formattedName = formattedName,
+                    isFromReadList = isFromReadList,
+                ),
+            )
             date_upload = when {
                 metadata.releaseDate != null -> parseDate(metadata.releaseDate)
                 created != null -> parseDateTime(created)
                 else -> parseDateTime(fileLastModified)
             }
         }
+    }
+
+    private fun BookDto.trailingEmbeddedFileSize(
+        chapterNameTemplate: String,
+        formattedName: String,
+        isFromReadList: Boolean,
+    ): String? {
+        val markedTemplate = chapterNameTemplate
+            .replace("{size}", FILE_SIZE_MARKER)
+            .replace("{sizeBytes}", FILE_SIZE_MARKER)
+        if (markedTemplate == chapterNameTemplate) return null
+
+        val markedSuffix = TRAILING_PARENTHESIZED_VALUE.find(
+            formatChapterName(markedTemplate, isFromReadList),
+        )?.groupValues?.getOrNull(1)
+        if (markedSuffix?.contains(FILE_SIZE_MARKER) != true) return null
+
+        return TRAILING_PARENTHESIZED_VALUE.find(formattedName)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.trim()
+            ?.takeIf(String::isNotBlank)
     }
 
     data class KomgaFilterOptions(
@@ -322,6 +352,9 @@ class KomgaRepository(
     )
 
     companion object {
+        private const val FILE_SIZE_MARKER = "__KOHARIA_FILE_SIZE__"
+        private val TRAILING_PARENTHESIZED_VALUE = Regex("\\(\\s*([^()]*)\\s*\\)\\s*$")
+
         val formatterDate = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply { timeZone = TimeZone.getTimeZone("UTC") }
         val formatterDateTime = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).apply {
             timeZone =

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -25,6 +25,7 @@ object KomgaChapterMemo {
     const val SERIES_URL = "seriesUrl"
     const val FILE_HASH = "fileHash"
     const val SIZE_BYTES = "sizeBytes"
+    const val DISPLAY_SIZE = "displaySize"
     const val SERIES_TITLE = "seriesTitle"
     const val BOOK_TITLE = "bookTitle"
     const val NUMBER_SORT = "numberSort"
@@ -55,6 +56,7 @@ object KomgaChapterMemo {
         val fingerprint = buildMemo(buildFingerprint(baseUrl, book))
         return buildJsonObject {
             fingerprint.forEach { (key, value) -> put(key, value) }
+            if (book.size.isNotBlank()) put(DISPLAY_SIZE, book.size)
             put(IS_EPUB, book.isEpub)
             put(EPUB_DIVINA_COMPATIBLE, book.media.epubDivinaCompatible)
             if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
@@ -181,6 +183,10 @@ object KomgaChapterMemo {
     fun fileLastModified(memo: JsonObject): String? = memo.string(FILE_LAST_MODIFIED)
 
     fun fileName(memo: JsonObject): String? = memo.string(FILE_NAME)
+
+    fun sizeBytes(memo: JsonObject): Long? = memo.long(SIZE_BYTES)?.takeIf { it > 0L }
+
+    fun displaySize(memo: JsonObject): String? = memo.string(DISPLAY_SIZE)
 
     fun pagesCount(memo: JsonObject): Int? = memo.long(PAGES_COUNT)?.toInt()?.takeIf { it > 0 }
 

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -26,6 +26,7 @@ object KomgaChapterMemo {
     const val FILE_HASH = "fileHash"
     const val SIZE_BYTES = "sizeBytes"
     const val DISPLAY_SIZE = "displaySize"
+    const val EMBEDDED_FILE_SIZE = "embeddedFileSize"
     const val SERIES_TITLE = "seriesTitle"
     const val BOOK_TITLE = "bookTitle"
     const val NUMBER_SORT = "numberSort"
@@ -52,11 +53,16 @@ object KomgaChapterMemo {
         )
     }
 
-    fun buildMemo(baseUrl: String, book: BookDto): JsonObject {
+    fun buildMemo(
+        baseUrl: String,
+        book: BookDto,
+        embeddedFileSize: String? = null,
+    ): JsonObject {
         val fingerprint = buildMemo(buildFingerprint(baseUrl, book))
         return buildJsonObject {
             fingerprint.forEach { (key, value) -> put(key, value) }
             if (book.size.isNotBlank()) put(DISPLAY_SIZE, book.size)
+            embeddedFileSize?.takeIf(String::isNotBlank)?.let { put(EMBEDDED_FILE_SIZE, it) }
             put(IS_EPUB, book.isEpub)
             put(EPUB_DIVINA_COMPATIBLE, book.media.epubDivinaCompatible)
             if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
@@ -187,6 +193,15 @@ object KomgaChapterMemo {
     fun sizeBytes(memo: JsonObject): Long? = memo.long(SIZE_BYTES)?.takeIf { it > 0L }
 
     fun displaySize(memo: JsonObject): String? = memo.string(DISPLAY_SIZE)
+
+    fun removeTrailingEmbeddedFileSize(title: String, memo: JsonObject): String {
+        val embeddedFileSize = memo.string(EMBEDDED_FILE_SIZE) ?: return title
+        val withoutEmbeddedFileSize = title.replace(
+            Regex("\\s*\\(\\s*${Regex.escape(embeddedFileSize)}\\s*\\)\\s*$", RegexOption.IGNORE_CASE),
+            "",
+        )
+        return withoutEmbeddedFileSize.ifBlank { title }
+    }
 
     fun pagesCount(memo: JsonObject): Int? = memo.long(PAGES_COUNT)?.toInt()?.takeIf { it > 0 }
 

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -27,6 +27,7 @@ import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLibraryKind
 import koharia.source.komga.KomgaLibraryScope
 import koharia.source.komga.KomgaSource
+import koharia.source.komga.LibraryFilter
 import koharia.source.komga.TYPE_ALL_INDEX
 import koharia.source.komga.TYPE_BOOKS_INDEX
 import koharia.source.komga.TYPE_READ_LISTS_INDEX
@@ -85,6 +86,7 @@ class KomgaLibraryScreenModel(
     @Volatile
     private var filtersInitialized = false
     private var listingBeforeSearch: Listing? = null
+    private var libraryFilterBeforeQuickSelection: Set<String>? = null
 
     init {
         if (source is CatalogueSource) {
@@ -109,10 +111,16 @@ class KomgaLibraryScreenModel(
         }
 
         if (source is KomgaSource) {
-            komgaSettingsChangeListener = source.registerServerSettingsChangeListener {
+            komgaSettingsChangeListener = source.registerServerSettingsChangeListener { shelfLibrariesChanged ->
                 screenModelScope.launchIO {
                     source.invalidateBrowseCache()
-                    reloadKomgaState(source, showRefreshing = true, resetSelection = true, forceRefresh = true)
+                    reloadKomgaState(
+                        komgaSource = source,
+                        showRefreshing = true,
+                        resetSelection = true,
+                        forceRefresh = true,
+                        forceShelfLibrarySelection = shelfLibrariesChanged,
+                    )
                 }
             }
             screenModelScope.launchIO {
@@ -393,12 +401,20 @@ class KomgaLibraryScreenModel(
 
     fun selectKomgaLibrary(libraryId: String?) {
         val komgaSource = source as? KomgaSource ?: return
+        val currentState = state.value
+        if (currentState.selectedKomgaLibraryId == libraryId) return
+
+        if (currentState.selectedKomgaLibraryId == null && libraryId != null) {
+            libraryFilterBeforeQuickSelection = currentState.filters.selectedLibraryIds()
+        }
+        val restoredLibraryIds = if (libraryId == null) libraryFilterBeforeQuickSelection else null
         val filters = komgaSource.buildFilterListForLibrary(
             libraryId = libraryId,
             allowedLibraryIds = currentAllowedLibraryIds(),
             libraryScope = libraryScope,
-            currentFilters = state.value.filters,
-            resetLibrarySelection = libraryId == null,
+            currentFilters = currentState.filters,
+            librarySelectionOverride = restoredLibraryIds,
+            resetLibrarySelection = libraryId == null && restoredLibraryIds == null,
         )
         mutableState.update {
             it.copy(
@@ -408,6 +424,9 @@ class KomgaLibraryScreenModel(
                 toolbarQuery = null,
                 searchType = TYPE_ALL_INDEX,
             )
+        }
+        if (libraryId == null) {
+            libraryFilterBeforeQuickSelection = null
         }
         komgaSource.saveSessionFilterState(filters, libraryScope)
         komgaSource.refreshBrowseRequests()
@@ -419,7 +438,11 @@ class KomgaLibraryScreenModel(
         showRefreshing: Boolean,
         resetSelection: Boolean,
         forceRefresh: Boolean,
+        forceShelfLibrarySelection: Boolean = false,
     ) {
+        if (resetSelection) {
+            libraryFilterBeforeQuickSelection = null
+        }
         if (showRefreshing) {
             mutableState.update { it.copy(isRefreshing = true) }
         }
@@ -463,6 +486,8 @@ class KomgaLibraryScreenModel(
                 libraryScope = libraryScope,
                 currentFilters = currentFiltersForReload(),
                 preserveSessionFilters = true,
+                resetLibrarySelection = resetSelection,
+                forceConfiguredLibrarySelection = forceShelfLibrarySelection,
             )
 
             mutableState.update {
@@ -479,6 +504,9 @@ class KomgaLibraryScreenModel(
             }
             filtersInitialized = true
             komgaSource.saveSessionFilterState(filters, libraryScope)
+            if (forceShelfLibrarySelection) {
+                komgaSource.savePersistentFilterState(filters, libraryScope)
+            }
             if (forceRefresh) {
                 komgaSource.refreshBrowseRequests()
             }
@@ -522,8 +550,12 @@ class KomgaLibraryScreenModel(
         libraries: List<KomgaClassifiedLibrary>,
     ) {
         if (libraryScope == KomgaLibraryScope.ALL) return
+        val configuredLibraryIds = komgaSource.configuredShelfLibraryIds()
         val visibleLibraries = libraries
-            .filter { it.kind == libraryScope.kind }
+            .filter { library ->
+                library.kind == libraryScope.kind &&
+                    (configuredLibraryIds.isEmpty() || library.id in configuredLibraryIds)
+            }
             .map { LibraryDto(it.id, it.name) }
         if (filtersInitialized && state.value.komgaLibraries == visibleLibraries) return
         val selectedLibraryId = state.value.selectedKomgaLibraryId
@@ -554,15 +586,26 @@ class KomgaLibraryScreenModel(
     }
 
     private fun librariesForScope(libraries: List<LibraryDto>): List<LibraryDto> {
-        if (libraryScope == KomgaLibraryScope.ALL) return libraries
+        val configuredLibraryIds = (source as? KomgaSource)?.configuredShelfLibraryIds().orEmpty()
+        val shelfLibraries = if (configuredLibraryIds.isEmpty()) {
+            libraries
+        } else {
+            libraries.filter { it.id in configuredLibraryIds }
+        }
+        if (libraryScope == KomgaLibraryScope.ALL) return shelfLibraries
         val kindById = libraryClassificationManager.getLibraries(sourceId).associate { it.id to it.kind }
-        return libraries.filter { library ->
+        return shelfLibraries.filter { library ->
             (kindById[library.id] ?: KomgaLibraryKind.COMIC) == libraryScope.kind
         }
     }
 
     private fun List<LibraryDto>.idsForScope(): Set<String>? {
-        return if (libraryScope == KomgaLibraryScope.ALL) null else mapTo(linkedSetOf(), LibraryDto::id)
+        val shelfIsRestricted = (source as? KomgaSource)?.configuredShelfLibraryIds()?.isNotEmpty() == true
+        return if (libraryScope == KomgaLibraryScope.ALL && !shelfIsRestricted) {
+            null
+        } else {
+            mapTo(linkedSetOf(), LibraryDto::id)
+        }
     }
 
     private fun currentAllowedLibraryIds(): Set<String>? {
@@ -572,6 +615,15 @@ class KomgaLibraryScreenModel(
     private fun currentFiltersForReload(): FilterList? {
         if (!filtersInitialized) return null
         return state.value.filters.takeIf { it.isNotEmpty() }
+    }
+
+    private fun FilterList.selectedLibraryIds(): Set<String> {
+        return filterIsInstance<LibraryFilter>()
+            .firstOrNull()
+            ?.state
+            .orEmpty()
+            .filter { it.state }
+            .mapTo(linkedSetOf()) { it.id }
     }
 
     sealed class Listing(open val query: String?, open val filters: FilterList) {

--- a/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaServerProfilesScreen.kt
@@ -1,11 +1,18 @@
 package koharia.source.komga
 
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.absoluteOffset
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
@@ -13,8 +20,10 @@ import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
@@ -25,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -35,8 +45,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -46,10 +61,9 @@ import eu.kanade.presentation.more.settings.widget.PreferenceGroupHeader
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.toImmutableMap
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import me.saket.swipe.SwipeAction
-import me.saket.swipe.SwipeableActionsBox
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
 import tachiyomi.presentation.core.components.material.Scaffold
@@ -57,6 +71,8 @@ import tachiyomi.presentation.core.i18n.stringResource
 import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 class KomgaServerProfilesScreen(
     private val openAddDialog: Boolean = false,
@@ -336,35 +352,105 @@ private fun ServerRow(
     onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
-    val deleteAction = SwipeAction(
-        icon = {
-            Icon(
-                modifier = Modifier.padding(16.dp),
-                imageVector = Icons.Outlined.Delete,
-                contentDescription = stringResource(MR.strings.action_delete),
-            )
-        },
-        background = MaterialTheme.colorScheme.errorContainer,
-        onSwipe = onDelete,
-    )
+    val scope = rememberCoroutineScope()
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val revealDistancePx = with(density) { SERVER_ROW_REVEAL_DISTANCE.toPx() }
+    val revealedOffsetPx = if (layoutDirection == LayoutDirection.Ltr) -revealDistancePx else revealDistancePx
+    var rowOffsetPx by remember(profile.id) { mutableFloatStateOf(0f) }
+    var settleJob by remember(profile.id) { mutableStateOf<Job?>(null) }
 
-    SwipeableActionsBox(
-        modifier = Modifier.clipToBounds(),
-        endActions = listOf(deleteAction),
-        swipeThreshold = serverRowSwipeThreshold,
-        backgroundUntilSwipeThreshold = MaterialTheme.colorScheme.surfaceContainerLowest,
+    fun settleRow(revealed: Boolean) {
+        val targetOffset = if (revealed) revealedOffsetPx else 0f
+        settleJob?.cancel()
+        settleJob = scope.launch {
+            animate(
+                initialValue = rowOffsetPx,
+                targetValue = targetOffset,
+                animationSpec = tween(durationMillis = SERVER_ROW_SETTLE_DURATION_MILLIS),
+            ) { value, _ ->
+                rowOffsetPx = value
+            }
+        }
+    }
+
+    val isDeleteRevealed = abs(rowOffsetPx) > 1f
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clipToBounds(),
     ) {
+        Box(
+            modifier = Modifier.matchParentSize(),
+            contentAlignment = Alignment.CenterEnd,
+        ) {
+            FilledTonalIconButton(
+                onClick = {
+                    settleRow(revealed = false)
+                    onDelete()
+                },
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .size(48.dp),
+                colors = IconButtonDefaults.filledTonalIconButtonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Delete,
+                    contentDescription = stringResource(MR.strings.action_delete),
+                )
+            }
+        }
+
         Row(
             modifier = Modifier
+                .absoluteOffset { IntOffset(rowOffsetPx.roundToInt(), 0) }
+                .background(MaterialTheme.colorScheme.surface)
                 .fillMaxWidth()
-                .clickable(onClick = onSelect)
+                .pointerInput(profile.id, revealedOffsetPx) {
+                    detectHorizontalDragGestures(
+                        onDragStart = {
+                            settleJob?.cancel()
+                        },
+                        onDragCancel = {
+                            settleRow(abs(rowOffsetPx) >= revealDistancePx / 2f)
+                        },
+                        onDragEnd = {
+                            settleRow(abs(rowOffsetPx) >= revealDistancePx / 2f)
+                        },
+                    ) { change, dragAmount ->
+                        val nextOffset = (rowOffsetPx + dragAmount).coerceIn(
+                            minimumValue = minOf(0f, revealedOffsetPx),
+                            maximumValue = maxOf(0f, revealedOffsetPx),
+                        )
+                        if (nextOffset != rowOffsetPx) {
+                            change.consume()
+                            rowOffsetPx = nextOffset
+                        }
+                    }
+                }
+                .clickable {
+                    if (isDeleteRevealed) {
+                        settleRow(revealed = false)
+                    } else {
+                        onSelect()
+                    }
+                }
                 .padding(horizontal = 16.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             RadioButton(
                 selected = isActive,
-                onClick = onSelect,
+                onClick = {
+                    if (isDeleteRevealed) {
+                        settleRow(revealed = false)
+                    } else {
+                        onSelect()
+                    }
+                },
             )
             Text(
                 text = profile.name,
@@ -372,7 +458,15 @@ private fun ServerRow(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-            IconButton(onClick = onEdit) {
+            IconButton(
+                onClick = {
+                    if (isDeleteRevealed) {
+                        settleRow(revealed = false)
+                    } else {
+                        onEdit()
+                    }
+                },
+            ) {
                 Icon(
                     imageVector = Icons.Outlined.Edit,
                     contentDescription = stringResource(MR.strings.action_edit),
@@ -382,7 +476,8 @@ private fun ServerRow(
     }
 }
 
-private val serverRowSwipeThreshold = 72.dp
+private val SERVER_ROW_REVEAL_DISTANCE = 64.dp
+private const val SERVER_ROW_SETTLE_DURATION_MILLIS = 180
 
 @Composable
 private fun EmptyServerState(
@@ -471,7 +566,10 @@ private fun DeleteServerDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             TextButton(onClick = onDelete) {
-                Text(text = stringResource(MR.strings.action_ok))
+                Text(
+                    text = stringResource(MR.strings.action_delete),
+                    color = MaterialTheme.colorScheme.error,
+                )
             }
         },
         dismissButton = {

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -66,7 +66,7 @@ class KomgaSource(
     override val versionId: Int = SOURCE_VERSION
 
     override val baseUrl: String
-        get() = preferences.getString(PREF_ADDRESS, "")!!.removeSuffix("/")
+        get() = preferences.getString(PREF_ADDRESS, "")!!.trim().trimEnd('/')
 
     private val username: String
         get() = preferences.getString(PREF_USERNAME, "")!!
@@ -81,7 +81,7 @@ class KomgaSource(
         get() = preferences.getString(PREF_API_KEY, null)
             ?: preferences.getString(PREF_API_KEY_WRONG_CASE, "")!!
 
-    private val defaultLibraries: Set<String>
+    private val shelfLibraryIds: Set<String>
         get() = preferences.getStringSet(PREF_DEFAULT_LIBRARIES, emptySet()) ?: emptySet()
 
     private val chapterNameTemplate: String
@@ -138,22 +138,22 @@ class KomgaSource(
         .build()
 
     override fun popularMangaRequest(page: Int): Request =
-        repository.popularMangaRequest(page, defaultLibraries, consumeBrowseCachePolicy())
+        repository.popularMangaRequest(page, shelfLibraryIds, consumeBrowseCachePolicy())
 
     override fun popularMangaParse(response: Response) = repository.parseMangasPage(response)
 
     override fun latestUpdatesRequest(page: Int): Request =
-        repository.latestUpdatesRequest(page, defaultLibraries, consumeBrowseCachePolicy())
+        repository.latestUpdatesRequest(page, shelfLibraryIds, consumeBrowseCachePolicy())
 
     override fun latestUpdatesParse(response: Response) = repository.parseMangasPage(response)
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request =
-        repository.searchMangaRequest(page, query, filters, defaultLibraries, consumeBrowseCachePolicy())
+        repository.searchMangaRequest(page, query, filters, shelfLibraryIds, consumeBrowseCachePolicy())
 
     override fun searchMangaParse(response: Response) = repository.parseMangasPage(response)
 
     override suspend fun getSearchManga(page: Int, query: String, filters: FilterList) =
-        repository.getSearchManga(page, query, filters, defaultLibraries, consumeBrowseCachePolicy())
+        repository.getSearchManga(page, query, filters, shelfLibraryIds, consumeBrowseCachePolicy())
 
     override fun getMangaUrl(manga: eu.kanade.tachiyomi.source.model.SManga): String = manga.url.replace("/api/v1", "")
 
@@ -257,7 +257,7 @@ class KomgaSource(
                     collections.forEach { add(CollectionFilterEntry(it.name, it.id)) }
                 },
             ),
-            LibraryFilter(libraries, defaultLibraries),
+            LibraryFilter(libraries, shelfLibraryIds),
             ReadingStateGroup(),
             UriMultiSelectFilter(
                 "Status",
@@ -466,9 +466,11 @@ class KomgaSource(
             title = screen.context.stringResource(MR.strings.komga_pref_address_title),
             default = "",
             summary = baseUrl.ifBlank { screen.context.stringResource(MR.strings.komga_pref_address_summary) },
-            dialogMessage = screen.context.stringResource(MR.strings.komga_pref_address_dialog),
             inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_URI,
-            validate = { it.startsWith("http://") || it.startsWith("https://") },
+            validate = {
+                val address = it.trim()
+                address.startsWith("http://") || address.startsWith("https://")
+            },
             validationMessage = screen.context.stringResource(MR.strings.komga_pref_address_validation),
             key = PREF_ADDRESS,
         )
@@ -534,7 +536,6 @@ class KomgaSource(
         androidx.preference.Preference(screen.context).apply {
             key = PREF_DEFAULT_LIBRARIES
             title = screen.context.stringResource(MR.strings.komga_pref_default_libraries_title)
-            summary = screen.context.stringResource(MR.strings.komga_pref_default_libraries_summary)
             setDefaultValue(emptySet<String>())
 
             var isFetching = false
@@ -544,7 +545,7 @@ class KomgaSource(
                 isFetching = true
 
                 val dataStore = pref.preferenceManager.preferenceDataStore
-                val currentAddress = (dataStore?.getString(PREF_ADDRESS, "") ?: "").removeSuffix("/")
+                val currentAddress = (dataStore?.getString(PREF_ADDRESS, "") ?: "").trim().trimEnd('/')
                 val currentAuthMode =
                     dataStore?.getString(PREF_AUTH_MODE, null) ?: defaultAuthMode()
                 val currentUsername = dataStore?.getString(PREF_USERNAME, "") ?: ""
@@ -584,15 +585,33 @@ class KomgaSource(
                         return@launch
                     }
 
-                    val names = fetchedLibraries.map { it.name }.toTypedArray<CharSequence>()
-                    val checkedItems = fetchedLibraries.map { it.id in currentSelection }.toBooleanArray()
-                    val newSelection = currentSelection.toMutableSet()
+                    val availableIds = fetchedLibraries.mapTo(linkedSetOf(), LibraryDto::id)
+                    val newSelection = currentSelection.intersect(availableIds).toMutableSet()
+                    val names = listOf(screen.context.stringResource(MR.strings.all))
+                        .plus(fetchedLibraries.map { it.name })
+                        .toTypedArray<CharSequence>()
+                    val checkedItems = BooleanArray(names.size) { index ->
+                        if (index == 0) newSelection.isEmpty() else fetchedLibraries[index - 1].id in newSelection
+                    }
 
                     com.google.android.material.dialog.MaterialAlertDialogBuilder(screen.context)
                         .setTitle(screen.context.stringResource(MR.strings.komga_pref_default_libraries_title))
-                        .setMultiChoiceItems(names, checkedItems) { _, which, isChecked ->
-                            val id = fetchedLibraries[which].id
-                            if (isChecked) newSelection.add(id) else newSelection.remove(id)
+                        .setMultiChoiceItems(names, checkedItems) { dialog, which, isChecked ->
+                            val alertDialog = dialog as? androidx.appcompat.app.AlertDialog
+                            if (which == 0) {
+                                if (isChecked) {
+                                    newSelection.clear()
+                                    fetchedLibraries.indices.forEach { index ->
+                                        alertDialog?.listView?.setItemChecked(index + 1, false)
+                                    }
+                                } else if (newSelection.isEmpty()) {
+                                    alertDialog?.listView?.setItemChecked(0, true)
+                                }
+                            } else {
+                                val id = fetchedLibraries[which - 1].id
+                                if (isChecked) newSelection.add(id) else newSelection.remove(id)
+                                alertDialog?.listView?.setItemChecked(0, newSelection.isEmpty())
+                            }
                         }
                         .setPositiveButton(android.R.string.ok) { _, _ ->
                             if (newSelection != currentSelection) {
@@ -657,14 +676,16 @@ class KomgaSource(
         forceBrowseRequestsUntil.set(System.currentTimeMillis() + BROWSE_REFRESH_WINDOW_MILLIS)
     }
 
+    fun configuredShelfLibraryIds(): Set<String> = shelfLibraryIds.toSet()
+
     fun registerServerSettingsChangeListener(
-        onChanged: () -> Unit,
+        onChanged: (shelfLibrariesChanged: Boolean) -> Unit,
     ): SharedPreferences.OnSharedPreferenceChangeListener {
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
             if (key in SERVER_SETTING_KEYS) {
                 searchCapabilities.clear()
                 invalidateBrowseCache()
-                onChanged()
+                onChanged(key == PREF_DEFAULT_LIBRARIES)
             }
         }
         preferences.registerOnSharedPreferenceChangeListener(listener)
@@ -683,7 +704,9 @@ class KomgaSource(
         currentFilters: FilterList? = null,
         preserveSessionFilters: Boolean = false,
         fallbackLibraries: List<LibraryDto>? = null,
+        librarySelectionOverride: Set<String>? = null,
         resetLibrarySelection: Boolean = false,
+        forceConfiguredLibrarySelection: Boolean = false,
     ): FilterList {
         val filters = getFilterList().withFallbackLibraries(fallbackLibraries)
         val currentState = currentFilters
@@ -717,9 +740,24 @@ class KomgaSource(
         }
         scopedFilters.filterIsInstance<LibraryFilter>().firstOrNull()?.state?.let { options ->
             when {
+                librarySelectionOverride != null -> {
+                    val availableSelection = librarySelectionOverride.intersect(options.mapTo(linkedSetOf()) { it.id })
+                    val selection = if (availableSelection.isEmpty() && allowedLibraryIds != null) {
+                        options.mapTo(linkedSetOf()) { it.id }
+                    } else {
+                        availableSelection
+                    }
+                    options.forEach { option -> option.state = option.id in selection }
+                }
                 libraryId != null -> options.forEach { option -> option.state = option.id == libraryId }
-                resetLibrarySelection -> options.forEach { option ->
-                    option.state = allowedLibraryIds != null || option.id in defaultLibraries
+                forceConfiguredLibrarySelection || (resetLibrarySelection && !hasPreservedState) -> {
+                    val availableDefaults = shelfLibraryIds.intersect(options.mapTo(linkedSetOf()) { it.id })
+                    val selection = if (availableDefaults.isEmpty() && allowedLibraryIds != null) {
+                        options.mapTo(linkedSetOf()) { it.id }
+                    } else {
+                        availableDefaults
+                    }
+                    options.forEach { option -> option.state = option.id in selection }
                 }
                 allowedLibraryIds != null && options.none { it.state } -> options.forEach { it.state = true }
             }

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -110,4 +110,35 @@ class KomgaChapterMemoTest {
         assertEquals(imageUrl, KomgaChapterMemo.networkPageImageUrl(first))
         assertEquals(first, KomgaChapterMemo.versionedPageImageUrl(first, firstMemo))
     }
+
+    @Test
+    fun `only structured embedded file size is removed from chapter title`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.SIZE_BYTES, 64L * 1024 * 1024)
+            put(KomgaChapterMemo.DISPLAY_SIZE, "64 MB")
+            put(KomgaChapterMemo.EMBEDDED_FILE_SIZE, "64 MB")
+        }
+
+        assertEquals(
+            "Chapter 1",
+            KomgaChapterMemo.removeTrailingEmbeddedFileSize("Chapter 1 (64 MB)", memo),
+        )
+        assertEquals(
+            "Chapter 1 (32 MB)",
+            KomgaChapterMemo.removeTrailingEmbeddedFileSize("Chapter 1 (32 MB)", memo),
+        )
+    }
+
+    @Test
+    fun `title suffix resembling file size is preserved without embedded marker`() {
+        val memo = buildJsonObject {
+            put(KomgaChapterMemo.SIZE_BYTES, 64L * 1024 * 1024)
+            put(KomgaChapterMemo.DISPLAY_SIZE, "64 MB")
+        }
+
+        assertEquals(
+            "A Story (64 MB)",
+            KomgaChapterMemo.removeTrailingEmbeddedFileSize("A Story (64 MB)", memo),
+        )
+    }
 }

--- a/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/service/LibraryPreferences.kt
@@ -181,6 +181,11 @@ class LibraryPreferences(
         true,
     )
 
+    val showChapterFileSize: Preference<Boolean> = preferenceStore.getBoolean(
+        "show_chapter_file_size",
+        true,
+    )
+
     val sortChapterByAscendingOrDescending: Preference<Long> = preferenceStore.getLong(
         "default_chapter_sort_by_ascending_or_descending",
         Manga.CHAPTER_SORT_DESC,

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -250,7 +250,6 @@
     <string name="komga_scoped_settings_disabled_summary">Add or select a server to change server-scoped settings.</string>
     <string name="komga_pref_address_title">Server address</string>
     <string name="komga_pref_address_summary">The server address</string>
-    <string name="komga_pref_address_dialog">The address must not end with a forward slash.</string>
     <string name="komga_pref_address_validation">The URL must start with http:// or https://</string>
     <string name="komga_pref_api_key_title">API key</string>
     <string name="komga_pref_api_key_summary">Optional: Use an API key for authentication</string>
@@ -258,9 +257,8 @@
     <string name="komga_pref_username_summary">The Komga username or email</string>
     <string name="komga_pref_password_title">Password</string>
     <string name="komga_pref_password_summary">The Komga account password</string>
-    <string name="komga_pref_default_libraries_title">Default libraries</string>
-    <string name="komga_pref_default_libraries_summary">Show content from selected libraries by default.</string>
-    <string name="komga_pref_default_libraries_reload_hint">Exit and re-enter the settings page to load options.</string>
+    <string name="komga_pref_default_libraries_title">Show libraries</string>
+    <string name="komga_pref_default_libraries_reload_hint">Exit and re-enter the settings page to load library options.</string>
     <string name="komga_pref_chapter_name_template_title">Chapter title format</string>
     <string name="komga_pref_chapter_name_template_summary">Customize how chapter names appear. Read list books are prefixed by the series title.</string>
     <string name="komga_pref_chapter_name_template_dialog">Supported placeholders:\n- {title}\n- {seriesTitle}\n- {number}\n- {createdDate}\n- {releaseDate}\n- {size}\n- {sizeBytes}</string>
@@ -960,8 +958,8 @@
     <string name="pref_category_epub_reader">Reader</string>
     <string name="pref_prefer_local_epub_file">Prefer local downloaded file</string>
     <string name="pref_prefer_local_epub_file_summary">Use the downloaded file when both local and remote copies are available</string>
-    <string name="pref_sync_epub_progression_komga">Sync reading progress to Komga</string>
-    <string name="pref_sync_epub_progression_komga_summary">Sync locator-based reading progress with Komga</string>
+    <string name="pref_sync_epub_progression_komga">Sync reading progress to server</string>
+    <string name="pref_sync_epub_progression_komga_summary">Sync locator-based reading progress with the server</string>
     <string name="pref_correct_komga_server_timestamps">Correct server timestamps</string>
     <string name="pref_correct_komga_server_timestamps_summary">Use the HTTP server time and recent progress updates to detect and correct abnormal whole-hour offsets. Enable only for affected Komga servers.</string>
     <string name="pref_epub_layout_mode">Layout mode</string>
@@ -1115,6 +1113,7 @@
     <string name="epub_chapter_progress_short">%1$d%%</string>
     <string name="pref_show_chapter_read_progress">Show reading progress and read status</string>
     <string name="pref_show_chapter_read_progress_summary">Show progress, unread markers, and read checkmarks in chapter lists and grids</string>
+    <string name="pref_show_chapter_file_size">Show file size</string>
     <string name="no_next_chapter">Next chapter not found</string>
     <string name="decode_image_error">The image couldn\'t be loaded</string>
     <string name="confirm_set_image_as_cover">Use this image as cover art?</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -82,7 +82,6 @@
     <string name="komga_server_delete_failed">无法删除服务器，服务器设置已保留，请重试。</string>
     <string name="komga_pref_address_title">服务器地址</string>
     <string name="komga_pref_address_summary">服务器地址</string>
-    <string name="komga_pref_address_dialog">地址末尾不能带斜杠。</string>
     <string name="komga_pref_address_validation">URL 必须以 http:// 或 https:// 开头</string>
     <string name="komga_pref_api_key_title">API Key</string>
     <string name="komga_pref_api_key_summary">可选：使用 API Key 进行认证</string>
@@ -90,9 +89,8 @@
     <string name="komga_pref_username_summary">Komga 用户名或邮箱</string>
     <string name="komga_pref_password_title">密码</string>
     <string name="komga_pref_password_summary">Komga 账户密码</string>
-    <string name="komga_pref_default_libraries_title">默认分类</string>
-    <string name="komga_pref_default_libraries_summary">默认只显示所选 Komga 分类下的内容。</string>
-    <string name="komga_pref_default_libraries_reload_hint">退出并重新进入设置页后可加载分类选项。</string>
+    <string name="komga_pref_default_libraries_title">显示书库</string>
+    <string name="komga_pref_default_libraries_reload_hint">退出并重新进入设置页后可加载书库选项。</string>
     <string name="komga_pref_chapter_name_template_title">章节标题格式</string>
     <string name="komga_pref_chapter_name_template_summary">自定义章节名称显示方式。阅读列表中的图书会自动加上作品标题前缀。</string>
     <string name="komga_pref_chapter_name_template_dialog">支持的占位符：\n- {title}\n- {seriesTitle}\n- {number}\n- {createdDate}\n- {releaseDate}\n- {size}\n- {sizeBytes}</string>
@@ -316,6 +314,7 @@
     <string name="epub_chapter_progress_short">%1$d%%</string>
     <string name="pref_show_chapter_read_progress">显示阅读进度与已读状态</string>
     <string name="pref_show_chapter_read_progress_summary">在章节列表和网格中显示进度、未读标记及已读勾选</string>
+    <string name="pref_show_chapter_file_size">显示文件大小</string>
     <string name="no_next_chapter">后面没有啦</string>
     <string name="decode_image_error">加载图片失败</string>
     <string name="confirm_set_image_as_cover">要将此页设为封面吗？</string>
@@ -607,8 +606,8 @@
     <string name="pref_category_epub_reader">阅读</string>
     <string name="pref_prefer_local_epub_file">优先使用本地已下载文件</string>
     <string name="pref_prefer_local_epub_file_summary">当本地和远程副本同时存在时，优先打开已下载文件</string>
-    <string name="pref_sync_epub_progression_komga">将阅读进度同步到 Komga</string>
-    <string name="pref_sync_epub_progression_komga_summary">将基于 Locator 的阅读位置与 Komga 保持同步</string>
+    <string name="pref_sync_epub_progression_komga">将阅读进度同步到服务器</string>
+    <string name="pref_sync_epub_progression_komga_summary">将基于 Locator 的阅读位置与服务器保持同步</string>
     <string name="pref_correct_komga_server_timestamps">修正服务器时间戳</string>
     <string name="pref_correct_komga_server_timestamps_summary">使用 HTTP 服务器时间和最近的进度更新，识别并修正异常的整小时偏移。请仅对受影响的 Komga 服务器开启。</string>
     <string name="pref_epub_layout_mode">布局模式</string>


### PR DESCRIPTION
## 中文

### 变更内容

- 修复书架筛选在切换书库后丢失的问题，并让服务器“显示书库”范围真正限制书架可见内容；默认仍显示全部书库。
- 优化服务器删除交互：左滑显示更紧凑的删除按钮，点击后再次确认。
- 为作品详情页和全局书架设置增加“隐藏缺失章节提示符”和“显示文件大小”开关。
- 恢复章节名称后以括号跟随文件大小的展示方式，并为各网格模式优化阅读进度角标。
- 精简服务器、同步进度和章节文件大小相关设置文案。
- 兼容服务器地址末尾斜杠及首尾空格，避免 URL 拼接异常。

### 影响

书架范围、筛选状态和作品详情显示设置更符合实际语义，服务器管理操作更安全且紧凑，章节信息在列表及网格模式下更易辨识。

## English

### Changes

- Preserve shelf filters when switching libraries, and make the server-level “Show libraries” scope actually restrict shelf contents while keeping all libraries as the default.
- Improve server deletion with a compact swipe action followed by confirmation.
- Add “Hide missing chapter indicators” and “Show file size” controls to series details and global library settings.
- Restore file sizes next to chapter titles in parentheses and refine reading-progress badges across grid layouts.
- Simplify server, reading-progress sync, and chapter file-size setting copy.
- Normalize surrounding whitespace and trailing slashes in server addresses to prevent malformed URL composition.

### Impact

Shelf scope, filters, and series display settings now match their intended behavior. Server deletion is safer and more compact, while chapter information remains readable across list and grid modes.

## 验证 / Validation

- .\gradlew.bat spotlessApply
- .\gradlew.bat spotlessCheck
- .\gradlew.bat :app:compileDebugKotlin