### PR TITLE
修复 EPUB S Pen 悬空翻页 / Fix S Pen air-action paging in EPUB reader

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -133,7 +133,15 @@
 
         <activity
             android:name="koharia.epub.EpubReaderActivity"
-            android:exported="false" />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
+            </intent-filter>
+
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/s_pen_actions" />
+        </activity>
 
         <activity
             android:name=".ui.security.UnlockActivity"

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -512,22 +512,8 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                                         }
                                     }
                                 },
-                                onPreviousChapter = {
-                                    val previousSection = adjacentTocEntries.first
-                                    if (previousSection != null) {
-                                        epubReaderFragment()?.goTo(previousSection.link)
-                                    } else {
-                                        state.previousBookChapterId?.let(::openAdjacentBook)
-                                    }
-                                },
-                                onNextChapter = {
-                                    val nextSection = adjacentTocEntries.second
-                                    if (nextSection != null) {
-                                        epubReaderFragment()?.goTo(nextSection.link)
-                                    } else {
-                                        state.nextBookChapterId?.let(::openAdjacentBook)
-                                    }
-                                },
+                                onPreviousChapter = { navigateAdjacentChapter(forward = false) },
+                                onNextChapter = { navigateAdjacentChapter(forward = true) },
                                 onOpenContents = {
                                     activePanel = EpubBottomPanel.NONE
                                     scope.launch {
@@ -1093,14 +1079,16 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             event.keyCode == KeyEvent.KEYCODE_VOLUME_UP
         val isSpenPageKey = event.metaState.and(KeyEvent.META_CTRL_ON) > 0 &&
             (event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT)
+        val isSpenChapterKey = event.keyCode == KeyEvent.KEYCODE_N || event.keyCode == KeyEvent.KEYCODE_P
         val state = viewModel.state.value
         val hasBlockingOverlay = state.isSearchActive || viewModel.imageState.value.isVisible ||
             viewModel.footnoteState.value != null
         val canHandleSpenPageKey = isSpenPageKey && !hasBlockingOverlay
+        val canHandleSpenChapterKey = isSpenChapterKey && !hasBlockingOverlay
         val canHandleVolumeKey = isVolumeKey && epubLayoutPreferences.readWithVolumeKeys.get() &&
             !state.menuVisible && !hasBlockingOverlay
-        val isPageNavigationKey = canHandleSpenPageKey || canHandleVolumeKey
-        if (!isPageNavigationKey) {
+        val isReaderNavigationKey = canHandleSpenPageKey || canHandleSpenChapterKey || canHandleVolumeKey
+        if (!isReaderNavigationKey) {
             return super.dispatchKeyEvent(event)
         }
 
@@ -1108,16 +1096,13 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             return true
         }
         if (event.action == KeyEvent.ACTION_UP) {
-            val forward = if (isSpenPageKey) {
-                event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
-            } else {
-                (event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) !=
-                    epubLayoutPreferences.readWithVolumeKeysInverted.get()
-            }
-            if (forward) {
-                epubReaderFragment()?.goForward()
-            } else {
-                epubReaderFragment()?.goBackward()
+            when {
+                isSpenChapterKey -> navigateAdjacentChapter(forward = event.keyCode == KeyEvent.KEYCODE_N)
+                isSpenPageKey -> navigatePage(forward = event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT)
+                else -> navigatePage(
+                    forward = (event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) !=
+                        epubLayoutPreferences.readWithVolumeKeysInverted.get(),
+                )
             }
             return true
         }
@@ -1347,6 +1332,31 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
     private fun epubReaderFragment(): EpubReaderFragment? {
         return readerFragment?.takeIf { it.isAdded && it.view != null }
+    }
+
+    private fun navigatePage(forward: Boolean) {
+        if (forward) {
+            epubReaderFragment()?.goForward()
+        } else {
+            epubReaderFragment()?.goBackward()
+        }
+    }
+
+    private fun navigateAdjacentChapter(forward: Boolean) {
+        val state = viewModel.state.value
+        val adjacentSections = viewModel.adjacentTocEntries(
+            entries = viewModel.tableOfContents(),
+            currentPosition = state.currentPosition,
+            currentHref = state.currentHref,
+        )
+        val section = if (forward) adjacentSections.second else adjacentSections.first
+        if (section != null) {
+            epubReaderFragment()?.goTo(section.link)
+            return
+        }
+
+        val adjacentBookChapterId = if (forward) state.nextBookChapterId else state.previousBookChapterId
+        adjacentBookChapterId?.let(::openAdjacentBook)
     }
 
     private fun openAdjacentBook(chapterId: Long) {

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -1091,11 +1091,16 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val isVolumeKey = event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
             event.keyCode == KeyEvent.KEYCODE_VOLUME_UP
+        val isSpenPageKey = event.metaState.and(KeyEvent.META_CTRL_ON) > 0 &&
+            (event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || event.keyCode == KeyEvent.KEYCODE_DPAD_LEFT)
         val state = viewModel.state.value
-        if (!isVolumeKey || !epubLayoutPreferences.readWithVolumeKeys.get() ||
-            state.menuVisible || state.isSearchActive || viewModel.imageState.value.isVisible ||
+        val hasBlockingOverlay = state.isSearchActive || viewModel.imageState.value.isVisible ||
             viewModel.footnoteState.value != null
-        ) {
+        val canHandleSpenPageKey = isSpenPageKey && !hasBlockingOverlay
+        val canHandleVolumeKey = isVolumeKey && epubLayoutPreferences.readWithVolumeKeys.get() &&
+            !state.menuVisible && !hasBlockingOverlay
+        val isPageNavigationKey = canHandleSpenPageKey || canHandleVolumeKey
+        if (!isPageNavigationKey) {
             return super.dispatchKeyEvent(event)
         }
 
@@ -1103,8 +1108,12 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
             return true
         }
         if (event.action == KeyEvent.ACTION_UP) {
-            val forward = (event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) !=
-                epubLayoutPreferences.readWithVolumeKeysInverted.get()
+            val forward = if (isSpenPageKey) {
+                event.keyCode == KeyEvent.KEYCODE_DPAD_RIGHT
+            } else {
+                (event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN) !=
+                    epubLayoutPreferences.readWithVolumeKeysInverted.get()
+            }
             if (forward) {
                 epubReaderFragment()?.goForward()
             } else {


### PR DESCRIPTION
## 中文

### 问题

Koharia 已向三星系统声明 S Pen 悬空操作，但声明仅绑定到传统漫画阅读器。原生 EPUB 阅读器既未注册 Remote Action，也只处理音量键，因此三星系统注入的 `Ctrl + DPAD_RIGHT/LEFT` 和 `N/P` 事件不会触发翻页或章节导航。

### 改动

- 为 `EpubReaderActivity` 注册三星 S Pen Remote Action 元数据。
- 将 `Ctrl + DPAD_RIGHT` 映射为 EPUB 下一页，将 `Ctrl + DPAD_LEFT` 映射为上一页。
- 将 `N/P` 映射为 EPUB 下一章/上一章：优先跳转同书目录章节，到达边界后切换相邻书籍。
- 工具栏显示时保持 S Pen 翻页可用；搜索、图片预览或脚注弹窗打开时阻止误操作。
- 保持原有音量键翻页设置及反转逻辑不变。

### 用户影响

三星 S Pen 用户现在可以在原生 EPUB 阅读器中使用悬空操作翻页和切换章节，与传统漫画阅读器及 Mihon 的行为保持一致。

### 验证

- `./gradlew.bat spotlessApply`
- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- `git diff --check`

## English

### Problem

Koharia advertises Samsung S Pen air actions, but the declaration was attached only to the legacy comic reader. The native EPUB reader did not register the Remote Action and handled only volume keys, so the system-injected `Ctrl + DPAD_RIGHT/LEFT` and `N/P` events never changed pages or chapters.

### Changes

- Register the Samsung S Pen Remote Action metadata for `EpubReaderActivity`.
- Map `Ctrl + DPAD_RIGHT` to the next EPUB page and `Ctrl + DPAD_LEFT` to the previous page.
- Map `N/P` to next/previous EPUB chapter navigation, preferring adjacent table-of-contents sections before switching to an adjacent book at the boundary.
- Keep S Pen paging available while the reader toolbar is visible, while blocking accidental actions during search, image preview, or footnote overlays.
- Preserve the existing volume-key paging preference and inversion behavior.

### User impact

Samsung S Pen users can now turn pages and navigate chapters with air actions in the native EPUB reader, matching the behavior of the comic reader and Mihon.

### Validation

- `./gradlew.bat spotlessApply`
- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- `git diff --check`

Fixes #65