### PR TITLE
修复 EPUB 长字符串换行并优化图片命名 / Fix EPUB long-word wrapping and image naming

### DIFF
--- a/app/src/main/java/koharia/epub/EpubImageFileName.kt
+++ b/app/src/main/java/koharia/epub/EpubImageFileName.kt
@@ -1,0 +1,40 @@
+package koharia.epub
+
+import eu.kanade.tachiyomi.util.lang.byteSize
+import eu.kanade.tachiyomi.util.storage.DiskUtil
+
+internal fun buildEpubImageBaseName(
+    seriesTitle: String?,
+    bookTitle: String?,
+    originalFileName: String,
+    extension: String,
+): String {
+    val normalizedExtension = extension.trim().trimStart('.')
+    val extensionBytes = normalizedExtension
+        .takeIf(String::isNotBlank)
+        ?.let { ".$it".byteSize() }
+        ?: 0
+    val maxBaseNameBytes = (DiskUtil.MAX_FILE_NAME_BYTES - extensionBytes).coerceAtLeast(1)
+    var result = originalFileName.validFileNameComponent(maxBaseNameBytes)
+        ?: "image".validFileNameComponent(maxBaseNameBytes)
+        ?: "i"
+
+    listOf(bookTitle, seriesTitle).forEach { component ->
+        val remainingBytes = maxBaseNameBytes - result.byteSize() - EPUB_IMAGE_NAME_SEPARATOR.byteSize()
+        if (remainingBytes <= 0) return@forEach
+        component.validFileNameComponent(remainingBytes)?.let { prefix ->
+            result = "$prefix$EPUB_IMAGE_NAME_SEPARATOR$result"
+        }
+    }
+    return result
+}
+
+private fun String?.validFileNameComponent(maxBytes: Int): String? {
+    val value = this
+        ?.trim()
+        ?.takeIf { it.trim('.', ' ').isNotEmpty() }
+        ?: return null
+    return DiskUtil.buildValidFilename(value, maxBytes).takeIf(String::isNotBlank)
+}
+
+private const val EPUB_IMAGE_NAME_SEPARATOR = " - "

--- a/app/src/main/java/koharia/epub/EpubImageFileName.kt
+++ b/app/src/main/java/koharia/epub/EpubImageFileName.kt
@@ -15,18 +15,16 @@ internal fun buildEpubImageBaseName(
         ?.let { ".$it".byteSize() }
         ?: 0
     val maxBaseNameBytes = (DiskUtil.MAX_FILE_NAME_BYTES - extensionBytes).coerceAtLeast(1)
-    var result = originalFileName.validFileNameComponent(maxBaseNameBytes)
-        ?: "image".validFileNameComponent(maxBaseNameBytes)
-        ?: "i"
-
-    listOf(bookTitle, seriesTitle).forEach { component ->
-        val remainingBytes = maxBaseNameBytes - result.byteSize() - EPUB_IMAGE_NAME_SEPARATOR.byteSize()
-        if (remainingBytes <= 0) return@forEach
-        component.validFileNameComponent(remainingBytes)?.let { prefix ->
-            result = "$prefix$EPUB_IMAGE_NAME_SEPARATOR$result"
-        }
+    val components = buildList {
+        seriesTitle.validFileNameComponent(maxBaseNameBytes)?.let(::add)
+        bookTitle.validFileNameComponent(maxBaseNameBytes)?.let(::add)
+        add(
+            originalFileName.validFileNameComponent(maxBaseNameBytes)
+                ?: "image".validFileNameComponent(maxBaseNameBytes)
+                ?: "i",
+        )
     }
-    return result
+    return components.fitFileNameComponents(maxBaseNameBytes)
 }
 
 private fun String?.validFileNameComponent(maxBytes: Int): String? {
@@ -35,6 +33,42 @@ private fun String?.validFileNameComponent(maxBytes: Int): String? {
         ?.takeIf { it.trim('.', ' ').isNotEmpty() }
         ?: return null
     return DiskUtil.buildValidFilename(value, maxBytes).takeIf(String::isNotBlank)
+}
+
+private fun List<String>.fitFileNameComponents(maxBytes: Int): String {
+    val fullName = joinToString(EPUB_IMAGE_NAME_SEPARATOR)
+    if (fullName.byteSize() <= maxBytes) return fullName
+
+    val separatorBytes = EPUB_IMAGE_NAME_SEPARATOR.byteSize() * (size - 1)
+    val contentBudget = maxBytes - separatorBytes
+    if (contentBudget < size) {
+        return DiskUtil.truncateToLength(last(), maxBytes).ifBlank { "i" }
+    }
+
+    val componentSizes = map(String::byteSize)
+    val componentBudgets = IntArray(size)
+    val remainingComponents = indices.toMutableList()
+    var remainingBudget = contentBudget
+    while (remainingComponents.isNotEmpty()) {
+        val sharedBudget = remainingBudget / remainingComponents.size
+        val fittingComponents = remainingComponents.filter { componentSizes[it] <= sharedBudget }
+        if (fittingComponents.isEmpty()) {
+            val extraBytes = remainingBudget % remainingComponents.size
+            remainingComponents.forEachIndexed { index, componentIndex ->
+                componentBudgets[componentIndex] = sharedBudget + if (index < extraBytes) 1 else 0
+            }
+            break
+        }
+        fittingComponents.forEach { componentIndex ->
+            componentBudgets[componentIndex] = componentSizes[componentIndex]
+            remainingBudget -= componentSizes[componentIndex]
+        }
+        remainingComponents.removeAll(fittingComponents.toSet())
+    }
+
+    return mapIndexed { index, component ->
+        DiskUtil.truncateToLength(component, componentBudgets[index])
+    }.joinToString(EPUB_IMAGE_NAME_SEPARATOR)
 }
 
 private const val EPUB_IMAGE_NAME_SEPARATOR = " - "

--- a/app/src/main/java/koharia/epub/EpubPaginationModels.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationModels.kt
@@ -137,5 +137,5 @@ private fun String.sha256(): String {
         .joinToString("") { byte -> "%02x".format(byte) }
 }
 
-private const val PAGINATION_ALGORITHM_VERSION = 7
+private const val PAGINATION_ALGORITHM_VERSION = 8
 private const val READIUM_VERSION = "3.3.0"

--- a/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubPaginationScannerFragment.kt
@@ -94,6 +94,10 @@ internal class EpubPaginationScannerFragment : Fragment() {
                             textAlignment = epubLayoutPreferences.textAlignment.get().takeIf { !publisherStyles },
                             tocHrefs = tocHrefs,
                             chapterBreaksEnabled = true,
+                            longWordWrappingEnabled = sessionRepository.getForPagination(chapterId)
+                                ?.publication
+                                ?.metadata
+                                ?.layout != org.readium.r2.shared.publication.Layout.FIXED,
                         )};
                                 return ${fontPreparation.script};
                             })()

--- a/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
+++ b/app/src/main/java/koharia/epub/EpubParagraphIndentOverride.kt
@@ -8,6 +8,12 @@ internal const val EPUB_ORPHANED_INLINE_PADDING_ATTRIBUTE = "data-koharia-orphan
 internal const val EPUB_TEXT_ALIGNMENT_STYLE_ID = "koharia-text-alignment"
 internal const val EPUB_TEXT_ALIGNMENT_TARGET_ATTRIBUTE = "data-koharia-text-alignment-target"
 internal const val EPUB_RIGHT_INDENT_SPACER_ATTRIBUTE = "data-koharia-right-indent-spacer"
+internal const val EPUB_LONG_WORD_WRAP_STYLE_ID = "koharia-long-word-wrap"
+
+internal const val EPUB_LONG_WORD_WRAP_CSS =
+    "html:root:root:root body, html:root:root:root body * { " +
+        "word-wrap: break-word !important; overflow-wrap: anywhere !important; " +
+        "}"
 
 // Readium's paragraph preference targets every <p>. A higher-specificity exception keeps
 // paragraph-shaped headings, signatures and media containers from inheriting body indentation.
@@ -78,6 +84,30 @@ internal const val REMOVE_EPUB_PARAGRAPH_INDENT_SCRIPT =
         });
         return true;
     })()"""
+
+internal fun buildEpubLongWordWrapScript(enabled: Boolean): String {
+    val updateStyle = if (enabled) {
+        """
+            if (!style) {
+                style = document.createElementNS('http://www.w3.org/1999/xhtml', 'style');
+                style.id = '$EPUB_LONG_WORD_WRAP_STYLE_ID';
+                style.setAttribute('type', 'text/css');
+                (document.head || document.documentElement).appendChild(style);
+            }
+            style.textContent = '$EPUB_LONG_WORD_WRAP_CSS';
+        """.trimIndent()
+    } else {
+        "if (style) style.remove();"
+    }
+    return """
+        (function() {
+            if (!document.documentElement || document.documentElement.localName.toLowerCase() !== 'html') return false;
+            var style = document.getElementById('$EPUB_LONG_WORD_WRAP_STYLE_ID');
+            $updateStyle
+            return true;
+        })()
+    """.trimIndent()
+}
 
 internal fun buildEpubTextAlignmentOverrideScript(
     textAlignment: EpubLayoutPreferences.TextAlignment?,
@@ -187,6 +217,7 @@ internal fun buildEpubTextAlignmentOverrideScript(
 internal fun buildEpubTypographyPreparationScript(
     paragraphIndentOverrideEnabled: Boolean,
     textAlignment: EpubLayoutPreferences.TextAlignment?,
+    longWordWrappingEnabled: Boolean = true,
 ): String {
     val paragraphIndentScript = if (paragraphIndentOverrideEnabled) {
         APPLY_EPUB_PARAGRAPH_INDENT_SCRIPT
@@ -197,6 +228,7 @@ internal fun buildEpubTypographyPreparationScript(
         (function() {
             $paragraphIndentScript;
             ${buildEpubTextAlignmentOverrideScript(textAlignment)};
+            ${buildEpubLongWordWrapScript(longWordWrappingEnabled)};
             return true;
         })()
     """.trimIndent()
@@ -207,10 +239,15 @@ internal fun buildEpubLayoutPreparationScript(
     textAlignment: EpubLayoutPreferences.TextAlignment?,
     tocHrefs: List<String>,
     chapterBreaksEnabled: Boolean,
+    longWordWrappingEnabled: Boolean = true,
 ): String =
     """
         (function() {
-            ${buildEpubTypographyPreparationScript(paragraphIndentOverrideEnabled, textAlignment)};
+            ${buildEpubTypographyPreparationScript(
+        paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
+        textAlignment = textAlignment,
+        longWordWrappingEnabled = longWordWrappingEnabled,
+    )};
             ${buildEpubChapterBreakOverrideScript(tocHrefs, chapterBreaksEnabled)};
             return true;
         })()
@@ -224,12 +261,14 @@ internal fun buildEpubDocumentPreparationScript(
     preserveImageColors: Boolean,
     parentColorsInverted: Boolean,
     readerFontScale: Float,
+    longWordWrappingEnabled: Boolean = true,
 ): String {
     val layoutPreparationScript = buildEpubLayoutPreparationScript(
         paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
         textAlignment = textAlignment,
         tocHrefs = tocHrefs,
         chapterBreaksEnabled = chapterBreaksEnabled,
+        longWordWrappingEnabled = longWordWrappingEnabled,
     )
     return """
         (function() {

--- a/app/src/main/java/koharia/epub/EpubReaderFragment.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderFragment.kt
@@ -138,6 +138,7 @@ class EpubReaderFragment : Fragment() {
         preserveImageColors = preserveImageColors,
         parentColorsInverted = parentColorsInverted,
         readerFontScale = readerFontScale,
+        longWordWrappingEnabled = true,
     )
     private var fontPreparation = buildEpubFontPreparationScript(
         fontManager = fontManager,
@@ -695,6 +696,7 @@ class EpubReaderFragment : Fragment() {
             preserveImageColors = preserveImageColors,
             parentColorsInverted = parentColorsInverted,
             readerFontScale = readerFontScale,
+            longWordWrappingEnabled = !fontOverridesDisabled(),
         )
         imageColorPolicyScript = """
             (function() {
@@ -1068,6 +1070,7 @@ class EpubReaderFragment : Fragment() {
                                 ${buildEpubTypographyPreparationScript(
                             paragraphIndentOverrideEnabled = paragraphIndentOverrideEnabled,
                             textAlignment = textAlignmentOverride,
+                            longWordWrappingEnabled = !fontOverridesDisabled(),
                         )};
                                 ${buildEpubFootnoteCompatibilityScript(
                             applyReaderStyles = paragraphIndentOverrideEnabled,

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -887,15 +887,14 @@ class EpubReaderViewModel @JvmOverloads constructor(
     }
 
     private fun EpubImageContent.toImage(location: Location): Image.Page {
-        val baseName = DiskUtil.buildValidFilename(
-            listOfNotNull(
-                state.value.mangaTitle?.takeIf(String::isNotBlank),
-                originalFileName.takeIf(String::isNotBlank),
-            ).joinToString(" - ").ifBlank { "image" },
-        )
         return Image.Page(
             inputStream = { bytes.toByteArray().inputStream() },
-            name = baseName,
+            name = buildEpubImageBaseName(
+                seriesTitle = state.value.mangaTitle,
+                bookTitle = state.value.chapterTitle,
+                originalFileName = originalFileName,
+                extension = extension,
+            ),
             location = location,
             encodedFormat = EncodedFormat(mimeType, extension).takeIf { isSvg },
         )

--- a/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
+++ b/app/src/test/java/koharia/epub/EpubDocumentPreparationTest.kt
@@ -22,6 +22,8 @@ class EpubDocumentPreparationTest {
         assertTrue(script.contains(EPUB_PARAGRAPH_NO_INDENT_ATTRIBUTE))
         assertTrue(script.contains("text-align: justify !important"))
         assertTrue(script.contains("hyphens: auto !important"))
+        assertTrue(script.contains("overflow-wrap: anywhere !important"))
+        assertTrue(script.contains("word-wrap: break-word !important"))
         assertTrue(script.contains("break-before: column !important"))
         assertTrue(script.contains("'duokan-footnote'"))
         assertTrue(script.contains("setAttributeNS(epubNamespace, 'epub:type', updated)"))
@@ -131,5 +133,27 @@ class EpubDocumentPreparationTest {
                 "document.documentElement.localName.toLowerCase() !== 'html'",
             ),
         )
+        assertTrue(
+            buildEpubLongWordWrapScript(enabled = true).contains(
+                "document.documentElement.localName.toLowerCase() !== 'html'",
+            ),
+        )
+    }
+
+    @Test
+    fun `fixed layout removes long word wrapping policy`() {
+        val script = buildEpubDocumentPreparationScript(
+            paragraphIndentOverrideEnabled = false,
+            textAlignment = null,
+            tocHrefs = emptyList(),
+            chapterBreaksEnabled = false,
+            preserveImageColors = true,
+            parentColorsInverted = false,
+            readerFontScale = 1f,
+            longWordWrappingEnabled = false,
+        )
+
+        assertTrue(script.contains("if (style) style.remove();"))
+        assertFalse(script.contains("overflow-wrap: anywhere !important"))
     }
 }

--- a/app/src/test/java/koharia/epub/EpubImageFileNameTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageFileNameTest.kt
@@ -1,0 +1,70 @@
+package koharia.epub
+
+import eu.kanade.tachiyomi.util.storage.DiskUtil
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubImageFileNameTest {
+
+    @Test
+    fun `image name includes series book and original resource name`() {
+        val firstBook = buildEpubImageBaseName(
+            seriesTitle = "Series",
+            bookTitle = "Book One",
+            originalFileName = "CoverDesign",
+            extension = "jpg",
+        )
+        val secondBook = buildEpubImageBaseName(
+            seriesTitle = "Series",
+            bookTitle = "Book Two",
+            originalFileName = "CoverDesign",
+            extension = "jpg",
+        )
+
+        assertEquals("Series - Book One - CoverDesign", firstBook)
+        assertEquals("Series - Book Two - CoverDesign", secondBook)
+        assertNotEquals(firstBook, secondBook)
+    }
+
+    @Test
+    fun `long titles preserve original resource name and extension budget`() {
+        val baseName = buildEpubImageBaseName(
+            seriesTitle = "系列".repeat(100),
+            bookTitle = "书名".repeat(100),
+            originalFileName = "CoverDesign",
+            extension = "webp",
+        )
+
+        assertTrue(baseName.contains("书名"))
+        assertTrue(baseName.endsWith(" - CoverDesign"))
+        assertTrue("$baseName.webp".toByteArray().size <= DiskUtil.MAX_FILE_NAME_BYTES)
+    }
+
+    @Test
+    fun `blank components fall back to a stable image name`() {
+        assertEquals(
+            "Series - image",
+            buildEpubImageBaseName(
+                seriesTitle = "Series",
+                bookTitle = " ",
+                originalFileName = "...",
+                extension = ".png",
+            ),
+        )
+    }
+
+    @Test
+    fun `invalid filename characters are sanitized per component`() {
+        assertEquals(
+            "Series_One - Book_ Two - cover_",
+            buildEpubImageBaseName(
+                seriesTitle = "Series/One",
+                bookTitle = "Book: Two",
+                originalFileName = "cover?",
+                extension = "jpg",
+            ),
+        )
+    }
+}

--- a/app/src/test/java/koharia/epub/EpubImageFileNameTest.kt
+++ b/app/src/test/java/koharia/epub/EpubImageFileNameTest.kt
@@ -43,6 +43,29 @@ class EpubImageFileNameTest {
     }
 
     @Test
+    fun `long original resource names reserve space for distinct book titles`() {
+        val originalFileName = "very-long-resource-name-".repeat(20)
+        val firstBook = buildEpubImageBaseName(
+            seriesTitle = "Series",
+            bookTitle = "Book One",
+            originalFileName = originalFileName,
+            extension = "jpg",
+        )
+        val secondBook = buildEpubImageBaseName(
+            seriesTitle = "Series",
+            bookTitle = "Book Two",
+            originalFileName = originalFileName,
+            extension = "jpg",
+        )
+
+        assertTrue(firstBook.startsWith("Series - Book One - very-long-resource-name-"))
+        assertTrue(secondBook.startsWith("Series - Book Two - very-long-resource-name-"))
+        assertNotEquals(firstBook, secondBook)
+        assertTrue("$firstBook.jpg".toByteArray().size <= DiskUtil.MAX_FILE_NAME_BYTES)
+        assertTrue("$secondBook.jpg".toByteArray().size <= DiskUtil.MAX_FILE_NAME_BYTES)
+    }
+
+    @Test
     fun `blank components fall back to a stable image name`() {
         assertEquals(
             "Series - image",

--- a/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
+++ b/app/src/test/java/koharia/epub/EpubPaginationModelsTest.kt
@@ -2,6 +2,7 @@ package koharia.epub
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class EpubPaginationModelsTest {
@@ -13,6 +14,7 @@ class EpubPaginationModelsTest {
 
         assertEquals(first.json, second.json)
         assertEquals(first.key, second.key)
+        assertTrue(first.json.contains("\"algorithmVersion\":8"))
     }
 
     @Test


### PR DESCRIPTION
## 中文

- 为可重排 EPUB 注入超长字符串安全换行规则，覆盖分页阅读、连续滚动与后台页数扫描。
- 固定版式 EPUB 不应用该规则，并提升分页算法版本以使旧页数缓存失效。
- EPUB 图片保存与分享名称改为“系列标题 - 书名 - 原图名”。
- 文件名按 UTF-8 字节预算生成，优先保留书名、原图名与扩展名，降低覆盖碰撞风险。
- 补充固定版式、长标题、非法字符、长度限制和书籍间同名图片等回归测试。

## English

- Add safe wrapping for unbreakable strings in reflowable EPUBs across paginated reading, continuous scroll, and background pagination scans.
- Keep fixed-layout EPUBs unchanged and bump the pagination algorithm version to invalidate stale page-count caches.
- Name saved and shared EPUB images as “Series Title - Book Title - Original Image Name”.
- Enforce the UTF-8 filename byte budget while prioritizing the book title, original image name, and extension to reduce overwrite collisions.
- Add regression coverage for fixed layouts, long titles, invalid characters, byte limits, and same-named images across books.

## 验证 / Verification

- spotlessCheck
- app:testDebugUnitTest（17 项相关测试 / 17 focused tests）
- app:compileDebugKotlin

Fixes #68
Closes #69
