### PR TITLE
修复仅显示缓存的离线书架 / Fix cached-only offline shelves

### DIFF
--- a/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
+++ b/app/src/main/java/eu/kanade/domain/manga/interactor/UpdateManga.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
+import koharia.komga.api.dto.mergeKomgaOfflineMemo
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import tachiyomi.domain.library.service.LibraryPreferences
@@ -87,7 +88,7 @@ class UpdateManga(
                 updateStrategy = remoteManga.update_strategy,
                 initialized = true,
                 viewerFlags = viewerFlags,
-                memo = remoteManga.memo.takeIf { it.isNotEmpty() },
+                memo = mergeKomgaOfflineMemo(localManga.memo, remoteManga.memo),
             ),
         )
         if (success && title != null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -68,6 +68,9 @@ class DownloadManager(
     val queueState
         get() = downloader.queueState
 
+    val cacheChanges
+        get() = cache.changes
+
     // For use by DownloadService only
     fun downloaderStart() = downloader.start()
     fun downloaderStop(reason: String? = null) = downloader.stop(reason)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -49,6 +49,7 @@ import koharia.domain.epub.model.EpubProgress
 import koharia.domain.epub.model.EpubRemoteProgressCache
 import koharia.epub.cache.EpubCacheManager
 import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
+import koharia.komga.api.dto.offlineFilterMetadata
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -314,7 +315,8 @@ class MangaScreenModel(
 
             val shouldRefreshKomga = source.isKomgaSource() &&
                 (
-                    !manga.initialized ||
+                    manga.memo.offlineFilterMetadata() == null ||
+                        !manga.initialized ||
                         manga.lastUpdate <= 0L ||
                         System.currentTimeMillis() - manga.lastUpdate >= KOMGA_DETAILS_REFRESH_INTERVAL_MS
                     )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -20,8 +20,6 @@ import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.interactor.GetExcludedScanlators
 import eu.kanade.domain.manga.interactor.SetExcludedScanlators
 import eu.kanade.domain.manga.interactor.UpdateManga
-import eu.kanade.domain.manga.model.chaptersFiltered
-import eu.kanade.domain.manga.model.downloadedFilter
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.domain.track.interactor.AddTracks
 import eu.kanade.domain.track.interactor.RefreshTracks
@@ -49,7 +47,9 @@ import koharia.domain.epub.interactor.GetEpubProgress
 import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
 import koharia.domain.epub.model.EpubProgress
 import koharia.domain.epub.model.EpubRemoteProgressCache
+import koharia.epub.cache.EpubCacheManager
 import koharia.epub.progress.KomgaEpubRemoteProgressCoordinator
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.async
@@ -60,6 +60,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -159,6 +160,8 @@ class MangaScreenModel(
     private val getEpubProgress: GetEpubProgress = Injekt.get(),
     private val getEpubRemoteProgressCache: GetEpubRemoteProgressCache = Injekt.get(),
     private val epubRemoteProgressCoordinator: KomgaEpubRemoteProgressCoordinator = Injekt.get(),
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
+    private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
     val snackbarHostState: SnackbarHostState = SnackbarHostState(),
 ) : StateScreenModel<MangaScreenModel.State>(State.Loading) {
 
@@ -226,6 +229,7 @@ class MangaScreenModel(
                 return@launchIO
             }
             val resolvedMangaId = manga.id
+            val cachedOnlyPreference = scopedPreferenceStoreFactory.basePreferences(manga.source).downloadedOnly
 
             val chaptersDeferred = async {
                 getMangaAndChapters.awaitChapters(resolvedMangaId, applyScanlatorFilter = true)
@@ -256,7 +260,7 @@ class MangaScreenModel(
             val source = Injekt.get<SourceManager>().getOrStub(manga.source)
 
             launch {
-                combine(
+                val chapterUpdates = combine(
                     getMangaAndChapters.subscribe(resolvedMangaId, applyScanlatorFilter = true).distinctUntilChanged(),
                     getEpubProgress.subscribeByMangaId(resolvedMangaId),
                     getEpubRemoteProgressCache.subscribeByMangaId(resolvedMangaId),
@@ -265,7 +269,15 @@ class MangaScreenModel(
                 ) { mangaAndChapters, localProgresses, remoteProgresses, _, _ ->
                     Triple(mangaAndChapters, localProgresses, remoteProgresses)
                 }
-                    .collectLatest { (mangaAndChapters, localProgresses, remoteProgresses) ->
+                combine(
+                    chapterUpdates,
+                    epubCacheManager.changes,
+                    cachedOnlyPreference.changes().onStart { emit(cachedOnlyPreference.get()) },
+                ) { chapterUpdate, _, cachedOnly ->
+                    chapterUpdate to cachedOnly
+                }
+                    .collectLatest { (chapterUpdate, cachedOnly) ->
+                        val (mangaAndChapters, localProgresses, remoteProgresses) = chapterUpdate
                         val (updatedManga, chapters) = mangaAndChapters
                         updateSuccessState {
                             it.copy(
@@ -274,6 +286,7 @@ class MangaScreenModel(
                                     updatedManga,
                                     mergeEpubProgressions(localProgresses, remoteProgresses),
                                 ),
+                                cachedOnly = cachedOnly,
                             )
                         }
                     }
@@ -320,6 +333,7 @@ class MangaScreenModel(
                     isRefreshingData = needRefreshInfo || needRefreshChapter,
                     dialog = null,
                     hideMissingChapters = libraryPreferences.hideMissingChapters.get(),
+                    cachedOnly = cachedOnlyPreference.get(),
                 )
             }
 
@@ -333,6 +347,7 @@ class MangaScreenModel(
                                 item.copy(
                                     downloadState = resolved.downloadState,
                                     downloadProgress = resolved.downloadProgress,
+                                    isCompleteEpubCached = resolved.isCompleteEpubCached,
                                 )
                             } ?: item
                         },
@@ -754,6 +769,7 @@ class MangaScreenModel(
                 chapter = chapter,
                 downloadState = downloadState,
                 downloadProgress = activeDownload?.progress ?: 0,
+                isCompleteEpubCached = epubCacheManager.hasCompleteBook(manga.source, chapter),
                 epubProgressPercent = epubProgresses[chapter.id]
                     ?.let { progression ->
                         (progression.coerceIn(0.0, 1.0) * 100)
@@ -1374,6 +1390,7 @@ class MangaScreenModel(
             val dialog: Dialog? = null,
             val hasPromptedToAddBefore: Boolean = false,
             val hideMissingChapters: Boolean = false,
+            val cachedOnly: Boolean = false,
         ) : State {
             val processedChapters by lazy {
                 chapters.applyFilters(manga).toList()
@@ -1418,7 +1435,11 @@ class MangaScreenModel(
                 get() = excludedScanlators.intersect(availableScanlators).isNotEmpty()
 
             val filterActive: Boolean
-                get() = scanlatorFilterActive || manga.chaptersFiltered()
+                get() = scanlatorFilterActive ||
+                    cachedOnly ||
+                    manga.unreadFilter != TriState.DISABLED ||
+                    manga.downloadedFilterRaw != Manga.SHOW_ALL ||
+                    manga.bookmarkedFilter != TriState.DISABLED
 
             /**
              * Applies the view filters to the list of chapters obtained from the database.
@@ -1426,12 +1447,22 @@ class MangaScreenModel(
              */
             private fun List<ChapterList.Item>.applyFilters(manga: Manga): Sequence<ChapterList.Item> {
                 val unreadFilter = manga.unreadFilter
-                val downloadedFilter = manga.downloadedFilter
+                val downloadedFilter = when (manga.downloadedFilterRaw) {
+                    Manga.CHAPTER_SHOW_DOWNLOADED -> TriState.ENABLED_IS
+                    Manga.CHAPTER_SHOW_NOT_DOWNLOADED -> TriState.ENABLED_NOT
+                    else -> TriState.DISABLED
+                }
                 val bookmarkedFilter = manga.bookmarkedFilter
                 return asSequence()
                     .filter { (chapter) -> applyFilter(unreadFilter) { !chapter.read } }
                     .filter { (chapter) -> applyFilter(bookmarkedFilter) { chapter.bookmark } }
-                    .filter { applyFilter(downloadedFilter) { it.isDownloaded } }
+                    .filter {
+                        if (cachedOnly) {
+                            it.isAvailableOffline
+                        } else {
+                            applyFilter(downloadedFilter) { it.isDownloaded }
+                        }
+                    }
                     .sortedWith { (chapter1), (chapter2) -> getChapterSort(manga).invoke(chapter1, chapter2) }
             }
         }
@@ -1451,10 +1482,12 @@ sealed class ChapterList {
         val chapter: Chapter,
         val downloadState: Download.State,
         val downloadProgress: Int,
+        val isCompleteEpubCached: Boolean = false,
         val epubProgressPercent: Int? = null,
         val selected: Boolean = false,
     ) : ChapterList() {
         val id = chapter.id
         val isDownloaded = downloadState == Download.State.DOWNLOADED
+        val isAvailableOffline = isDownloaded || isCompleteEpubCached
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -34,13 +34,13 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderOrientation
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.Viewer
-import eu.kanade.tachiyomi.util.chapter.filterDownloaded
 import eu.kanade.tachiyomi.util.chapter.removeDuplicates
 import eu.kanade.tachiyomi.util.editCover
 import eu.kanade.tachiyomi.util.lang.byteSize
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.epub.cache.EpubCacheManager
 import koharia.epub.progress.EpubPageProgress
 import koharia.epub.progress.KomgaEpubProgressSyncService
 import koharia.komga.download.KomgaChapterMemo
@@ -110,6 +110,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private val komgaProgressSyncService: KomgaProgressSyncService = Injekt.get(),
     private val komgaEpubProgressSyncService: KomgaEpubProgressSyncService = Injekt.get(),
     private val getEpubProgress: GetEpubProgress = Injekt.get(),
+    private val epubCacheManager: EpubCacheManager = Injekt.get(),
     private val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get(),
 ) : ViewModel() {
 
@@ -248,7 +249,16 @@ class ReaderViewModel @JvmOverloads constructor(
             }
             .run {
                 if (basePreferences.downloadedOnly.get()) {
-                    filterDownloaded(manga)
+                    filter { chapter ->
+                        downloadManager.isChapterDownloaded(
+                            chapter.name,
+                            chapter.scanlator,
+                            chapter.url,
+                            manga.title,
+                            manga.source,
+                            allowSharedLookup = false,
+                        ) || epubCacheManager.hasCompleteBook(manga.source, chapter)
+                    }
                 } else {
                     this
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -256,7 +256,6 @@ class ReaderViewModel @JvmOverloads constructor(
                             chapter.url,
                             manga.title,
                             manga.source,
-                            allowSharedLookup = false,
                         ) || epubCacheManager.hasCompleteBook(manga.source, chapter)
                     }
                 } else {

--- a/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
+++ b/app/src/main/java/koharia/epub/cache/EpubCacheManager.kt
@@ -2,13 +2,19 @@ package koharia.epub.cache
 
 import android.app.Application
 import android.text.format.Formatter
+import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
@@ -22,6 +28,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Response
 import tachiyomi.core.common.storage.LocalTempCacheDirectoryProvider
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.model.Chapter
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -59,11 +66,38 @@ class EpubCacheManager(
     private val activePartialFiles = ConcurrentHashMap.newKeySet<String>()
     private val clearGeneration = AtomicLong(0L)
     private var scheduledTrimJob: Job? = null
+    private val _changes = Channel<Unit>(Channel.UNLIMITED)
+    val changes = _changes.receiveAsFlow()
+        .onStart { emit(Unit) }
+        .shareIn(cleanupScope, SharingStarted.Lazily, replay = 1)
 
     fun completeBookFile(sourceId: Long, publicationKey: String): File? {
         val file = completeBookTarget(sourceId, publicationKey)
         return file.takeIf { it.isFile && it.length() > 0L }
             ?.also(::touch)
+    }
+
+    fun hasCompleteBook(sourceId: Long, publicationKey: String): Boolean {
+        val file = completeBookTarget(sourceId, publicationKey)
+        return file.isFile && file.length() > 0L
+    }
+
+    fun hasCompleteBook(sourceId: Long, chapter: Chapter): Boolean {
+        val fingerprint = KomgaChapterMemo.readFingerprint(chapter.memo)
+        val publicationKey = EpubCachePolicy.publicationKey(
+            fileHash = fingerprint?.fileHash,
+            fileLastModified = KomgaChapterMemo.fileLastModified(chapter.memo),
+            sizeBytes = fingerprint?.sizeBytes ?: 0L,
+            fallback = "book:${chapter.id}:${chapter.url}",
+        )
+        return hasCompleteBook(sourceId, publicationKey)
+    }
+
+    fun hasAnyCompleteBook(sourceId: Long): Boolean {
+        return File(booksDir, sourceId.toString())
+            .listFiles()
+            .orEmpty()
+            .any { it.isFile && it.extension.equals("epub", ignoreCase = true) && it.length() > 0L }
     }
 
     fun acquire(file: File) {
@@ -76,7 +110,11 @@ class EpubCacheManager(
         touch(file)
         if (pendingDeleteFiles.remove(file.absolutePath)) {
             cleanupScope.launch {
-                ioMutex.withLock { file.delete() }
+                ioMutex.withLock {
+                    if (file.delete() && file.extension.equals("epub", ignoreCase = true)) {
+                        notifyChanges()
+                    }
+                }
             }
         }
         scheduleTrim()
@@ -151,6 +189,7 @@ class EpubCacheManager(
                             if (acquireLease) acquire(target)
                             trimToSizeLocked()
                         }
+                        notifyChanges()
                         target
                     }
                 } catch (error: CancellationException) {
@@ -232,10 +271,12 @@ class EpubCacheManager(
             clearGeneration.incrementAndGet()
             leasedFiles.forEach(pendingDeleteFiles::add)
             leasedPublicationDirs.forEach(pendingDeleteDirs::add)
-            cacheFiles()
+            val deleted = cacheFiles()
                 .filterNot(::isProtected)
                 .count { it.delete() }
                 .also { deleteEmptyDirectories() }
+            if (deleted > 0) notifyChanges()
+            deleted
         }
     }
 
@@ -248,10 +289,12 @@ class EpubCacheManager(
                 .forEach(pendingDeleteFiles::add)
             leasedPublicationDirs.filter { path -> File(path).startsWith(sourceResourceDir) }
                 .forEach(pendingDeleteDirs::add)
-            (sourceBookDir.walkTopDown() + sourceResourceDir.walkTopDown())
+            val deleted = (sourceBookDir.walkTopDown() + sourceResourceDir.walkTopDown())
                 .filter { it.isFile && !isProtected(it) }
                 .count { it.delete() }
                 .also { deleteEmptyDirectories() }
+            if (deleted > 0) notifyChanges()
+            deleted
         }
     }
 
@@ -285,15 +328,22 @@ class EpubCacheManager(
             .map { file -> CacheCandidate(listOf(file), file.lastModified()) }
             .sortedBy(CacheCandidate::lastModified)
             .toList()
+        var completeBooksChanged = false
         for (candidate in resources + books) {
             if (size <= limit) break
             val deletedSize = candidate.files.sumOf { file ->
                 val length = file.length()
-                if (file.delete()) length else 0L
+                if (file.delete()) {
+                    if (file.extension.equals("epub", ignoreCase = true)) completeBooksChanged = true
+                    length
+                } else {
+                    0L
+                }
             }
             size -= deletedSize
         }
         deleteEmptyDirectories()
+        if (completeBooksChanged) notifyChanges()
     }
 
     @Synchronized
@@ -380,6 +430,10 @@ class EpubCacheManager(
 
     private fun touch(file: File) {
         if (file.exists()) file.setLastModified(System.currentTimeMillis())
+    }
+
+    private fun notifyChanges() {
+        _changes.trySend(Unit)
     }
 
     private fun String.sha256(): String = MessageDigest.getInstance("SHA-256")

--- a/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
+++ b/app/src/main/java/koharia/epub/service/KomgaReadiumHttpClient.kt
@@ -14,6 +14,7 @@ import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.http.DefaultHttpClient
 import org.readium.r2.shared.util.http.HttpClient
+import org.readium.r2.shared.util.http.HttpError
 import org.readium.r2.shared.util.http.HttpRequest
 import org.readium.r2.shared.util.http.HttpResponse
 import org.readium.r2.shared.util.http.HttpStatus
@@ -24,6 +25,7 @@ import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.ByteArrayInputStream
+import java.io.IOException
 import java.net.URI
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
@@ -48,6 +50,7 @@ class KomgaReadiumHttpClient(
         publicationKey: String = "source:$sourceId",
         persistCache: Boolean = true,
     ): HttpClient {
+        val cachedOnlyPreference = scopedPreferenceStoreFactory.basePreferences(sourceId).downloadedOnly
         val client = DefaultHttpClient()
         client.callback = object : DefaultHttpClient.Callback {
             override suspend fun onStartRequest(request: HttpRequest) = Try.success(
@@ -77,6 +80,7 @@ class KomgaReadiumHttpClient(
             sourceId = sourceId,
             publicationKey = publicationKey,
             persistCache = persistCache,
+            cachedOnlyProvider = cachedOnlyPreference::get,
         )
         return ParagraphIndentNormalizingHttpClient(cachedClient) {
             !(
@@ -87,33 +91,42 @@ class KomgaReadiumHttpClient(
     }
 }
 
+internal fun shouldUseKomgaReadiumNetwork(cachedOnly: Boolean): Boolean = !cachedOnly
+
 private class EpubResourceCacheHttpClient(
     private val delegate: HttpClient,
     private val cacheManager: EpubCacheManager,
     private val sourceId: Long,
     private val publicationKey: String,
     private val persistCache: Boolean,
+    private val cachedOnlyProvider: () -> Boolean,
 ) : HttpClient {
 
     private val prefetchScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override suspend fun stream(request: HttpRequest): org.readium.r2.shared.util.http.HttpTry<HttpStreamResponse> {
-        if (!isCacheable(request)) return delegate.stream(request)
-
-        cacheManager.getResource(sourceId, publicationKey, request.url.toString())?.let { cached ->
-            return Try.success(
-                HttpStreamResponse(
-                    response = HttpResponse(
-                        request = request,
-                        url = request.url,
-                        statusCode = HttpStatus(200),
-                        headers = emptyMap(),
-                        mediaType = cached.mediaType?.let { value -> MediaType(value) },
+        if (isCacheable(request)) {
+            cacheManager.getResource(sourceId, publicationKey, request.url.toString())?.let { cached ->
+                return Try.success(
+                    HttpStreamResponse(
+                        response = HttpResponse(
+                            request = request,
+                            url = request.url,
+                            statusCode = HttpStatus(200),
+                            headers = emptyMap(),
+                            mediaType = cached.mediaType?.let { value -> MediaType(value) },
+                        ),
+                        body = ByteArrayInputStream(cached.bytes),
                     ),
-                    body = ByteArrayInputStream(cached.bytes),
-                ),
-            )
+                )
+            }
         }
+
+        if (!shouldUseKomgaReadiumNetwork(cachedOnlyProvider())) {
+            return Try.failure(HttpError.IO(IOException("Komga network access disabled in cached-only mode")))
+        }
+
+        if (!isCacheable(request)) return delegate.stream(request)
 
         return delegate.stream(request).map { response ->
             if (response.response.statusCode != HttpStatus(200) ||
@@ -146,7 +159,7 @@ private class EpubResourceCacheHttpClient(
     }
 
     private fun isCacheable(request: HttpRequest): Boolean {
-        if (!persistCache || request.method != HttpRequest.Method.GET) return false
+        if (request.method != HttpRequest.Method.GET) return false
         if (request.headers.keys.any { it.equals("Range", ignoreCase = true) }) return false
         val url = request.url.toString().substringBefore('?')
         return url.contains("/manifest/epub") ||

--- a/app/src/main/java/koharia/komga/api/KomgaActiveServerSseManager.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaActiveServerSseManager.kt
@@ -3,6 +3,7 @@ package koharia.komga.api
 import android.app.Application
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
 import eu.kanade.tachiyomi.network.NetworkHelper
 import koharia.source.komga.KomgaServerPreferences
@@ -12,6 +13,8 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import okhttp3.Headers
 import tachiyomi.domain.source.service.SourceManager
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class KomgaActiveServerSseManager(
     application: Application,
@@ -19,6 +22,7 @@ class KomgaActiveServerSseManager(
     private val sourceManager: SourceManager,
     private val komgaServerPreferences: KomgaServerPreferences,
     komgaProgressSyncService: Lazy<KomgaProgressSyncService>,
+    private val basePreferences: BasePreferences = Injekt.get(),
 ) {
 
     private val lifecycleScope = ProcessLifecycleOwner.get().lifecycleScope
@@ -28,12 +32,18 @@ class KomgaActiveServerSseManager(
         komgaProgressSyncService = komgaProgressSyncService,
         baseUrlProvider = { currentSource()?.baseUrl.orEmpty() },
         headersProvider = { currentSource()?.currentHeaders() ?: Headers.Builder().build() },
+        cachedOnlyProvider = { basePreferences.downloadedOnly.get() },
     )
 
     init {
         sseClient.start(lifecycleScope)
         lifecycleScope.launch {
             komgaServerPreferences.activeServerId.changes().drop(1).collectLatest {
+                sseClient.reconnect()
+            }
+        }
+        lifecycleScope.launch {
+            basePreferences.downloadedOnly.changes().collectLatest {
                 sseClient.reconnect()
             }
         }

--- a/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
@@ -28,6 +28,7 @@ class KomgaSseClient(
     private val komgaProgressSyncService: Lazy<KomgaProgressSyncService>,
     private val baseUrlProvider: () -> String,
     private val headersProvider: () -> Headers,
+    private val cachedOnlyProvider: () -> Boolean,
 ) : DefaultLifecycleObserver {
 
     private var appScope: CoroutineScope? = null
@@ -68,7 +69,8 @@ class KomgaSseClient(
     }
 
     private fun checkAndReconnect() {
-        if (isForeground && isWifi) {
+        val cachedOnly = cachedOnlyProvider()
+        if (isForeground && isWifi && !cachedOnly) {
             lastSkippedReason = null
             connect()
         } else {
@@ -76,6 +78,7 @@ class KomgaSseClient(
             val reason = when {
                 !isForeground -> "app not in foreground"
                 !isWifi -> "network is not validated Wi-Fi"
+                cachedOnly -> "cached-only mode enabled"
                 else -> "connection requirements not met"
             }
             if (lastSkippedReason != reason) {

--- a/app/src/main/java/koharia/komga/api/dto/Dto.kt
+++ b/app/src/main/java/koharia/komga/api/dto/Dto.kt
@@ -222,6 +222,7 @@ fun SeriesDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
         artist = authors["penciller"]?.distinct()?.joinToString()
     }
     memo = buildMemo(metadata, booksMetadata, booksCount, libraryId)
+        .withOfflineFilterMetadata(offlineFilterMetadata())
 }
 
 fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
@@ -237,7 +238,7 @@ fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
         if (libraryId.isNotBlank()) {
             put(KOMGA_LIBRARY_ID_MEMO_KEY, libraryId)
         }
-    }
+    }.withOfflineFilterMetadata(offlineFilterMetadata())
 }
 
 fun BookDto.toChapterMemo(baseUrl: String, embeddedFileSize: String? = null): JsonObject =
@@ -249,6 +250,7 @@ fun ReadListDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     url = "$baseUrl/api/v1/readlists/$id"
     thumbnail_url = "$url/thumbnail"
     status = SManga.UNKNOWN
+    memo = JsonObject(emptyMap()).withOfflineFilterMetadata(offlineFilterMetadata())
 }
 
 fun BookDto.formatChapterName(template: String, isFromReadList: Boolean): String {
@@ -308,3 +310,4 @@ private fun buildMemo(
 }
 
 const val KOMGA_LIBRARY_ID_MEMO_KEY = "komgaLibraryId"
+const val KOMGA_LIBRARY_IDS_MEMO_KEY = "komgaLibraryIds"

--- a/app/src/main/java/koharia/komga/api/dto/Dto.kt
+++ b/app/src/main/java/koharia/komga/api/dto/Dto.kt
@@ -161,6 +161,7 @@ data class BookDto(
     val id: String,
     val seriesId: String = "",
     val seriesTitle: String = "",
+    val libraryId: String = "",
     val name: String,
     val number: Float = 0F,
     val created: String? = null,
@@ -220,7 +221,7 @@ fun SeriesDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
         author = authors["writer"]?.distinct()?.joinToString()
         artist = authors["penciller"]?.distinct()?.joinToString()
     }
-    memo = buildMemo(metadata, booksMetadata, booksCount)
+    memo = buildMemo(metadata, booksMetadata, booksCount, libraryId)
 }
 
 fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
@@ -232,6 +233,11 @@ fun BookDto.toSManga(baseUrl: String): SManga = SManga.create().apply {
     description = metadata.summary
     author = metadata.authors.joinToString { it.name }
     artist = author
+    memo = buildJsonObject {
+        if (libraryId.isNotBlank()) {
+            put(KOMGA_LIBRARY_ID_MEMO_KEY, libraryId)
+        }
+    }
 }
 
 fun BookDto.toChapterMemo(baseUrl: String, embeddedFileSize: String? = null): JsonObject =
@@ -273,7 +279,11 @@ private fun buildMemo(
     metadata: SeriesMetadataDto,
     booksMetadata: BookMetadataAggregationDto = BookMetadataAggregationDto(),
     booksCount: Int = 0,
+    libraryId: String = "",
 ): JsonObject = buildJsonObject {
+    if (libraryId.isNotBlank()) {
+        put(KOMGA_LIBRARY_ID_MEMO_KEY, libraryId)
+    }
     if (metadata.readingDirection.isNotBlank()) {
         put("readingDirection", metadata.readingDirection)
     }
@@ -296,3 +306,5 @@ private fun buildMemo(
         put("releaseDate", booksMetadata.releaseDate)
     }
 }
+
+const val KOMGA_LIBRARY_ID_MEMO_KEY = "komgaLibraryId"

--- a/app/src/main/java/koharia/komga/api/dto/KomgaOfflineFilterMetadata.kt
+++ b/app/src/main/java/koharia/komga/api/dto/KomgaOfflineFilterMetadata.kt
@@ -1,0 +1,156 @@
+package koharia.komga.api.dto
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+internal data class KomgaOfflineAuthor(
+    val name: String,
+    val role: String,
+)
+
+internal data class KomgaOfflineFilterMetadata(
+    val status: String? = null,
+    val genres: Set<String> = emptySet(),
+    val tags: Set<String> = emptySet(),
+    val publisher: String? = null,
+    val authors: Set<KomgaOfflineAuthor> = emptySet(),
+    val titleSort: String? = null,
+    val createdDate: String? = null,
+    val lastModifiedDate: String? = null,
+    val oneShot: Boolean? = null,
+)
+
+internal fun SeriesDto.offlineFilterMetadata() = KomgaOfflineFilterMetadata(
+    status = metadata.status.takeIf(String::isNotBlank),
+    genres = metadata.genres,
+    tags = metadata.tags + booksMetadata.tags,
+    publisher = metadata.publisher.takeIf(String::isNotBlank),
+    authors = booksMetadata.authors.toOfflineAuthors(),
+    titleSort = metadata.titleSort.takeIf(String::isNotBlank),
+    createdDate = created ?: metadata.created,
+    lastModifiedDate = lastModified ?: metadata.lastModified,
+    oneShot = booksCount == 1,
+)
+
+internal fun BookDto.offlineFilterMetadata() = KomgaOfflineFilterMetadata(
+    tags = metadata.tags,
+    authors = metadata.authors.toOfflineAuthors(),
+    titleSort = metadata.title.takeIf(String::isNotBlank),
+    createdDate = created,
+    lastModifiedDate = lastModified,
+)
+
+internal fun ReadListDto.offlineFilterMetadata() = KomgaOfflineFilterMetadata(
+    titleSort = name.takeIf(String::isNotBlank),
+    createdDate = createdDate,
+    lastModifiedDate = lastModifiedDate,
+)
+
+internal fun JsonObject.withOfflineFilterMetadata(metadata: KomgaOfflineFilterMetadata): JsonObject {
+    val offlineMetadata = JsonObject(
+        buildMap {
+            put(VERSION_FIELD, JsonPrimitive(CURRENT_VERSION))
+            metadata.status?.let { put(STATUS_FIELD, JsonPrimitive(it)) }
+            metadata.genres.takeIf(Set<String>::isNotEmpty)?.let { put(GENRES_FIELD, it.toJsonArray()) }
+            metadata.tags.takeIf(Set<String>::isNotEmpty)?.let { put(TAGS_FIELD, it.toJsonArray()) }
+            metadata.publisher?.let { put(PUBLISHER_FIELD, JsonPrimitive(it)) }
+            metadata.authors.takeIf(Set<KomgaOfflineAuthor>::isNotEmpty)?.let { authors ->
+                put(
+                    AUTHORS_FIELD,
+                    JsonArray(
+                        authors.sortedWith(
+                            compareBy(KomgaOfflineAuthor::role, KomgaOfflineAuthor::name),
+                        ).map { author ->
+                            JsonObject(
+                                mapOf(
+                                    AUTHOR_NAME_FIELD to JsonPrimitive(author.name),
+                                    AUTHOR_ROLE_FIELD to JsonPrimitive(author.role),
+                                ),
+                            )
+                        },
+                    ),
+                )
+            }
+            metadata.titleSort?.let { put(TITLE_SORT_FIELD, JsonPrimitive(it)) }
+            metadata.createdDate?.let { put(CREATED_DATE_FIELD, JsonPrimitive(it)) }
+            metadata.lastModifiedDate?.let { put(LAST_MODIFIED_DATE_FIELD, JsonPrimitive(it)) }
+            metadata.oneShot?.let { put(ONE_SHOT_FIELD, JsonPrimitive(it)) }
+        },
+    )
+    return JsonObject(this + (KOMGA_OFFLINE_FILTERS_MEMO_KEY to offlineMetadata))
+}
+
+internal fun JsonObject.offlineFilterMetadata(): KomgaOfflineFilterMetadata? {
+    val metadata = this[KOMGA_OFFLINE_FILTERS_MEMO_KEY] as? JsonObject ?: return null
+    if (metadata[VERSION_FIELD]?.jsonPrimitive?.intOrNull != CURRENT_VERSION) return null
+
+    return KomgaOfflineFilterMetadata(
+        status = metadata.string(STATUS_FIELD),
+        genres = metadata.stringSet(GENRES_FIELD),
+        tags = metadata.stringSet(TAGS_FIELD),
+        publisher = metadata.string(PUBLISHER_FIELD),
+        authors = (metadata[AUTHORS_FIELD] as? JsonArray)
+            .orEmpty()
+            .mapNotNullTo(linkedSetOf()) { element ->
+                runCatching {
+                    val author = element.jsonObject
+                    val name = author.string(AUTHOR_NAME_FIELD) ?: return@runCatching null
+                    val role = author.string(AUTHOR_ROLE_FIELD) ?: return@runCatching null
+                    KomgaOfflineAuthor(name, role)
+                }.getOrNull()
+            },
+        titleSort = metadata.string(TITLE_SORT_FIELD),
+        createdDate = metadata.string(CREATED_DATE_FIELD),
+        lastModifiedDate = metadata.string(LAST_MODIFIED_DATE_FIELD),
+        oneShot = metadata[ONE_SHOT_FIELD]?.jsonPrimitive?.booleanOrNull,
+    )
+}
+
+internal fun mergeKomgaOfflineMemo(localMemo: JsonObject, remoteMemo: JsonObject): JsonObject? {
+    if (remoteMemo.isEmpty()) return null
+    return if (KOMGA_OFFLINE_FILTERS_MEMO_KEY in remoteMemo) {
+        JsonObject(localMemo + remoteMemo)
+    } else {
+        remoteMemo
+    }
+}
+
+private fun List<AuthorDto>.toOfflineAuthors(): Set<KomgaOfflineAuthor> =
+    mapNotNullTo(linkedSetOf()) { author ->
+        val name = author.name.takeIf(String::isNotBlank) ?: return@mapNotNullTo null
+        val role = author.role.takeIf(String::isNotBlank) ?: return@mapNotNullTo null
+        KomgaOfflineAuthor(name, role)
+    }
+
+private fun Set<String>.toJsonArray(): JsonArray =
+    JsonArray(filter(String::isNotBlank).sorted().map(::JsonPrimitive))
+
+private fun JsonObject.string(key: String): String? =
+    this[key]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)
+
+private fun JsonObject.stringSet(key: String): Set<String> =
+    (this[key] as? JsonArray)
+        .orEmpty()
+        .mapNotNullTo(linkedSetOf()) { it.jsonPrimitive.contentOrNull?.takeIf(String::isNotBlank) }
+
+const val KOMGA_OFFLINE_FILTERS_MEMO_KEY = "komgaOfflineFilters"
+
+private const val CURRENT_VERSION = 1
+private const val VERSION_FIELD = "version"
+private const val STATUS_FIELD = "status"
+private const val GENRES_FIELD = "genres"
+private const val TAGS_FIELD = "tags"
+private const val PUBLISHER_FIELD = "publisher"
+private const val AUTHORS_FIELD = "authors"
+private const val AUTHOR_NAME_FIELD = "name"
+private const val AUTHOR_ROLE_FIELD = "role"
+private const val TITLE_SORT_FIELD = "titleSort"
+private const val CREATED_DATE_FIELD = "createdDate"
+private const val LAST_MODIFIED_DATE_FIELD = "lastModifiedDate"
+private const val ONE_SHOT_FIELD = "oneShot"

--- a/app/src/main/java/koharia/komga/api/dto/KomgaOfflineFilterMetadata.kt
+++ b/app/src/main/java/koharia/komga/api/dto/KomgaOfflineFilterMetadata.kt
@@ -115,7 +115,18 @@ internal fun JsonObject.offlineFilterMetadata(): KomgaOfflineFilterMetadata? {
 internal fun mergeKomgaOfflineMemo(localMemo: JsonObject, remoteMemo: JsonObject): JsonObject? {
     if (remoteMemo.isEmpty()) return null
     return if (KOMGA_OFFLINE_FILTERS_MEMO_KEY in remoteMemo) {
-        JsonObject(localMemo + remoteMemo)
+        val mergedMemo = localMemo + remoteMemo
+        val remoteLibraryId = remoteMemo[KOMGA_LIBRARY_ID_MEMO_KEY]
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.takeIf(String::isNotBlank)
+        JsonObject(
+            if (remoteLibraryId != null) {
+                mergedMemo + (KOMGA_LIBRARY_IDS_MEMO_KEY to JsonArray(listOf(JsonPrimitive(remoteLibraryId))))
+            } else {
+                mergedMemo
+            },
+        )
     } else {
         remoteMemo
     }

--- a/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
+++ b/app/src/main/java/koharia/komga/download/KomgaChapterMemo.kt
@@ -37,6 +37,7 @@ object KomgaChapterMemo {
     const val FILE_LAST_MODIFIED = "fileLastModified"
     const val FILE_NAME = "fileName"
     const val PAGES_COUNT = "pagesCount"
+    const val LIBRARY_ID = "libraryId"
 
     private const val PAGE_CACHE_VERSION_FRAGMENT = "#koharia-publication="
 
@@ -68,6 +69,7 @@ object KomgaChapterMemo {
             if (book.fileLastModified.isNotBlank()) put(FILE_LAST_MODIFIED, book.fileLastModified)
             if (book.name.isNotBlank()) put(FILE_NAME, book.name)
             if (book.media.pagesCount > 0) put(PAGES_COUNT, book.media.pagesCount)
+            if (book.libraryId.isNotBlank()) put(LIBRARY_ID, book.libraryId)
         }
     }
 
@@ -204,6 +206,8 @@ object KomgaChapterMemo {
     }
 
     fun pagesCount(memo: JsonObject): Int? = memo.long(PAGES_COUNT)?.toInt()?.takeIf { it > 0 }
+
+    fun libraryId(memo: JsonObject): String? = memo.string(LIBRARY_ID)
 
     fun publicationVersion(memo: JsonObject): String? {
         val fileHash = memo.string(FILE_HASH)

--- a/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaFilterDialog.kt
@@ -25,6 +25,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import koharia.source.komga.AuthorGroup
 import koharia.source.komga.CollectionSelect
 import koharia.source.komga.LibraryFilter
+import koharia.source.komga.OneshotFilter
 import koharia.source.komga.ReadingStateGroup
 import koharia.source.komga.SeriesSort
 import koharia.source.komga.TYPE_ALL_INDEX
@@ -49,6 +50,7 @@ import tachiyomi.presentation.core.i18n.stringResource
 fun KomgaFilterDialog(
     onDismissRequest: () -> Unit,
     filters: FilterList,
+    cachedOnly: Boolean,
     persistentFilteringEnabled: Boolean,
     onReset: () -> Unit,
     onFilter: () -> Unit,
@@ -60,7 +62,7 @@ fun KomgaFilterDialog(
         filterRevision += 1
         onUpdate(filters)
     }
-    val visibleFilters = remember(filters, filterRevision) { filters.visibleFilters() }
+    val visibleFilters = remember(filters, filterRevision, cachedOnly) { filters.visibleFilters(cachedOnly) }
 
     AdaptiveSheet(onDismissRequest = onDismissRequest) {
         LazyColumn {
@@ -248,15 +250,29 @@ private fun komgaFilterLabel(label: String): String {
     }
 }
 
-private fun FilterList.visibleFilters(): List<Filter<*>> {
+private fun FilterList.visibleFilters(cachedOnly: Boolean): List<Filter<*>> {
     val type = selectedContentType()
     val hasCollection = (filterIsInstance<CollectionSelect>().firstOrNull()?.state ?: 0) != 0
-    return filter { filter ->
+    val availableFilters = if (cachedOnly && getOrNull(0) is Filter.Header && getOrNull(1) is Filter.Separator) {
+        drop(2)
+    } else {
+        this
+    }
+    return availableFilters.filter { filter ->
+        if (cachedOnly && filter is CollectionSelect) return@filter false
         when (type) {
             TYPE_READ_LISTS_INDEX -> filter.isReadListFilter()
             TYPE_BOOKS_INDEX -> filter.isBookFilter()
             TYPE_ALL_INDEX -> filter.isAllFilter()
             else -> filter !is SeriesSort || !hasCollection
+        }
+    }.map { filter ->
+        if (cachedOnly && type != TYPE_SERIES_INDEX && filter is ReadingStateGroup) {
+            ReadingStateGroup().apply {
+                state = filter.state.filterNot { it is OneshotFilter }
+            }
+        } else {
+            filter
         }
     }
 }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -355,6 +355,7 @@ data class KomgaLibraryScreen(
                 KomgaFilterDialog(
                     onDismissRequest = onDismissRequest,
                     filters = state.filters,
+                    cachedOnly = screenModel.cachedOnly,
                     persistentFilteringEnabled = state.persistentFilteringEnabled,
                     onReset = screenModel::resetFilters,
                     onFilter = { screenModel.search(filters = state.filters) },

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -44,7 +44,6 @@ import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
-import eu.kanade.domain.base.BasePreferences
 import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.service.SourcePreferences
@@ -58,10 +57,12 @@ import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.manga.MangaScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
+import koharia.epub.cache.EpubCacheManager
 import koharia.komga.ui.library.components.KomgaLibraryToolbar
 import koharia.komga.ui.library.components.KomgaServerSetupPrompt
 import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLibraryScope
+import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaServerSettingsScreen
 import kotlinx.collections.immutable.persistentListOf
@@ -69,6 +70,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import tachiyomi.core.common.DocumentationUrls
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.source.interactor.GetRemoteManga
@@ -122,13 +124,16 @@ data class KomgaLibraryScreen(
 
         val sourceManager: SourceManager = Injekt.get()
         val sourcePreferences: SourcePreferences = Injekt.get()
-        val basePreferences: BasePreferences = Injekt.get()
+        val scopedPreferenceStoreFactory: KomgaScopedPreferenceStoreFactory = Injekt.get()
+        val basePreferences = remember(sourceId) { scopedPreferenceStoreFactory.basePreferences(sourceId) }
         val libraryPreferences: LibraryPreferences = Injekt.get()
         val komgaServerPreferences: KomgaServerPreferences = Injekt.get()
         val downloadManager: DownloadManager = Injekt.get()
         val getRemoteManga: GetRemoteManga = Injekt.get()
         val getManga: GetManga = Injekt.get()
         val updateManga: UpdateManga = Injekt.get()
+        val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get()
+        val epubCacheManager: EpubCacheManager = Injekt.get()
         val getIncognitoState: GetIncognitoState = Injekt.get()
         val libraryClassificationManager: KomgaLibraryClassificationManager = Injekt.get()
 
@@ -144,6 +149,8 @@ data class KomgaLibraryScreen(
                 getRemoteManga = getRemoteManga,
                 getManga = getManga,
                 updateManga = updateManga,
+                getChaptersByMangaId = getChaptersByMangaId,
+                epubCacheManager = epubCacheManager,
                 getIncognitoState = getIncognitoState,
                 libraryScope = libraryScope,
                 libraryClassificationManager = libraryClassificationManager,

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreen.kt
@@ -45,6 +45,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifSourcesLoaded
 import eu.kanade.domain.base.BasePreferences
+import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.browse.BrowseSourceContent
@@ -127,6 +128,7 @@ data class KomgaLibraryScreen(
         val downloadManager: DownloadManager = Injekt.get()
         val getRemoteManga: GetRemoteManga = Injekt.get()
         val getManga: GetManga = Injekt.get()
+        val updateManga: UpdateManga = Injekt.get()
         val getIncognitoState: GetIncognitoState = Injekt.get()
         val libraryClassificationManager: KomgaLibraryClassificationManager = Injekt.get()
 
@@ -141,6 +143,7 @@ data class KomgaLibraryScreen(
                 downloadManager = downloadManager,
                 getRemoteManga = getRemoteManga,
                 getManga = getManga,
+                updateManga = updateManga,
                 getIncognitoState = getIncognitoState,
                 libraryScope = libraryScope,
                 libraryClassificationManager = libraryClassificationManager,

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -23,6 +23,7 @@ import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import koharia.epub.cache.EpubCacheManager
 import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
 import koharia.komga.api.dto.LibraryDto
 import koharia.source.komga.KomgaClassifiedLibrary
@@ -57,6 +58,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
@@ -76,6 +78,8 @@ class KomgaLibraryScreenModel(
     private val getRemoteManga: GetRemoteManga,
     private val getManga: GetManga,
     private val updateManga: UpdateManga,
+    private val getChaptersByMangaId: GetChaptersByMangaId,
+    private val epubCacheManager: EpubCacheManager,
     private val getIncognitoState: GetIncognitoState,
     private val libraryScope: KomgaLibraryScope,
     private val libraryClassificationManager: KomgaLibraryClassificationManager,
@@ -148,11 +152,10 @@ class KomgaLibraryScreenModel(
                     }
                 }
             }
-            if (libraryScope != KomgaLibraryScope.ALL) {
-                screenModelScope.launchIO {
-                    libraryClassificationManager.classificationsChanges(sourceId).collect { libraries ->
-                        applyClassifiedLibraries(source, libraries)
-                    }
+            applyClassifiedLibraries(source, libraryClassificationManager.getLibraries(sourceId))
+            screenModelScope.launchIO {
+                libraryClassificationManager.classificationsChanges(sourceId).collect { libraries ->
+                    applyClassifiedLibraries(source, libraries)
                 }
             }
         }
@@ -176,16 +179,21 @@ class KomgaLibraryScreenModel(
         } else if (request.cachedOnly) {
             combine(
                 getManga.subscribeBySourceId(sourceId),
-                downloadManager.queueState,
-            ) { localManga, _ ->
+                downloadManager.cacheChanges,
+                epubCacheManager.changes,
+            ) { localManga, _, _ ->
                 val query = (request.listing as? Listing.Search)?.query
                 val selectedLibraryIds = request.listing.filters.selectedLibraryIds()
-                val downloadedManga = localManga.asSequence()
-                    .filter { downloadManager.getDownloadCount(it) > 0 }
-                    .toList()
-                val cachedManga = downloadedManga.withCachedLibraryIds()
+                val selectedContentType = request.listing.filters.selectedContentType()
+                val hasCompleteEpubCache = epubCacheManager.hasAnyCompleteBook(sourceId)
+                val locallyAvailableManga = localManga.filter { manga ->
+                    downloadManager.getDownloadCount(manga) > 0 ||
+                        (hasCompleteEpubCache && manga.hasCompleteEpubCache())
+                }
+                val cachedManga = locallyAvailableManga.withCachedLibraryIds()
                 val cachedItems = cachedManga.asSequence()
                     .filter { it.matchesCachedLibraryFilter(selectedLibraryIds) }
+                    .filter { it.matchesCachedContentType(selectedContentType) }
                     .filter { it.matchesCachedOnlyQuery(query) }
                     .map { MutableStateFlow(it) as StateFlow<Manga> }
                     .toList()
@@ -227,6 +235,12 @@ class KomgaLibraryScreenModel(
             updateManga.awaitAll(updates)
         }
         return enriched
+    }
+
+    private suspend fun Manga.hasCompleteEpubCache(): Boolean {
+        return getChaptersByMangaId.await(id).any { chapter ->
+            epubCacheManager.hasCompleteBook(sourceId, chapter)
+        }
     }
 
     fun resetFilters() {
@@ -611,11 +625,10 @@ class KomgaLibraryScreenModel(
         komgaSource: KomgaSource,
         libraries: List<KomgaClassifiedLibrary>,
     ) {
-        if (libraryScope == KomgaLibraryScope.ALL) return
         val configuredLibraryIds = komgaSource.configuredShelfLibraryIds()
         val visibleLibraries = libraries
             .filter { library ->
-                library.kind == libraryScope.kind &&
+                (libraryScope == KomgaLibraryScope.ALL || library.kind == libraryScope.kind) &&
                     (configuredLibraryIds.isEmpty() || library.id in configuredLibraryIds)
             }
             .map { LibraryDto(it.id, it.name) }
@@ -625,7 +638,7 @@ class KomgaLibraryScreenModel(
         val filters = komgaSource.buildFilterListForLibrary(
             libraryId = selectedLibraryId,
             preservePersistentFilters = selectedLibraryId == null,
-            allowedLibraryIds = visibleLibraries.mapTo(linkedSetOf(), LibraryDto::id),
+            allowedLibraryIds = visibleLibraries.idsForScope(),
             libraryScope = libraryScope,
             currentFilters = currentFiltersForReload(),
             preserveSessionFilters = true,
@@ -639,7 +652,7 @@ class KomgaLibraryScreenModel(
                 searchType = TYPE_ALL_INDEX,
                 komgaLibraries = visibleLibraries.toImmutableList(),
                 selectedKomgaLibraryId = selectedLibraryId,
-                isLibraryScopeEmpty = visibleLibraries.isEmpty(),
+                isLibraryScopeEmpty = libraryScope != KomgaLibraryScope.ALL && visibleLibraries.isEmpty(),
             )
         }
         filtersInitialized = true
@@ -686,6 +699,13 @@ class KomgaLibraryScreenModel(
             .orEmpty()
             .filter { it.state }
             .mapTo(linkedSetOf()) { it.id }
+    }
+
+    private fun FilterList.selectedContentType(): Int {
+        return filterIsInstance<koharia.source.komga.TypeSelect>()
+            .firstOrNull()
+            ?.state
+            ?: TYPE_ALL_INDEX
     }
 
     sealed class Listing(open val query: String?, open val filters: FilterList) {
@@ -788,6 +808,16 @@ internal fun Manga.matchesCachedOnlyQuery(query: String?): Boolean {
 internal fun Manga.matchesCachedLibraryFilter(selectedLibraryIds: Set<String>): Boolean {
     if (selectedLibraryIds.isEmpty()) return true
     return cachedLibraryId in selectedLibraryIds
+}
+
+internal fun Manga.matchesCachedContentType(contentType: Int): Boolean {
+    val path = url.substringBefore('?').trimEnd('/')
+    return when (contentType) {
+        TYPE_SERIES_INDEX -> path.contains("/api/v1/series/")
+        TYPE_READ_LISTS_INDEX -> path.contains("/api/v1/readlists/")
+        TYPE_BOOKS_INDEX -> path.contains("/api/v1/books/")
+        else -> true
+    }
 }
 
 private val Manga.cachedLibraryId: String?

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -5,22 +5,25 @@ import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.paging.LoadState
+import androidx.paging.LoadStates
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import androidx.paging.filter
 import androidx.paging.map
 import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.core.preference.asState
 import eu.kanade.domain.base.BasePreferences
+import eu.kanade.domain.manga.interactor.UpdateManga
 import eu.kanade.domain.source.interactor.GetIncognitoState
 import eu.kanade.domain.source.service.SourcePreferences
 import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
 import koharia.komga.api.dto.LibraryDto
 import koharia.source.komga.KomgaClassifiedLibrary
 import koharia.source.komga.KomgaLibraryClassificationManager
@@ -47,12 +50,17 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.model.MangaUpdate
 import tachiyomi.domain.source.interactor.GetRemoteManga
 import tachiyomi.domain.source.service.SourceManager
 import eu.kanade.tachiyomi.source.model.Filter as SourceModelFilter
@@ -67,6 +75,7 @@ class KomgaLibraryScreenModel(
     private val downloadManager: DownloadManager,
     private val getRemoteManga: GetRemoteManga,
     private val getManga: GetManga,
+    private val updateManga: UpdateManga,
     private val getIncognitoState: GetIncognitoState,
     private val libraryScope: KomgaLibraryScope,
     private val libraryClassificationManager: KomgaLibraryClassificationManager,
@@ -114,17 +123,30 @@ class KomgaLibraryScreenModel(
             komgaSettingsChangeListener = source.registerServerSettingsChangeListener { shelfLibrariesChanged ->
                 screenModelScope.launchIO {
                     source.invalidateBrowseCache()
-                    reloadKomgaState(
-                        komgaSource = source,
-                        showRefreshing = true,
-                        resetSelection = true,
-                        forceRefresh = true,
-                        forceShelfLibrarySelection = shelfLibrariesChanged,
-                    )
+                    if (basePreferences.downloadedOnly.get()) {
+                        refreshSignal.value += 1
+                    } else {
+                        reloadKomgaState(
+                            komgaSource = source,
+                            showRefreshing = true,
+                            resetSelection = true,
+                            forceRefresh = true,
+                            forceShelfLibrarySelection = shelfLibrariesChanged,
+                        )
+                    }
+                }
+            }
+            if (!basePreferences.downloadedOnly.get()) {
+                screenModelScope.launchIO {
+                    reloadKomgaState(source, showRefreshing = false, resetSelection = true, forceRefresh = true)
                 }
             }
             screenModelScope.launchIO {
-                reloadKomgaState(source, showRefreshing = false, resetSelection = true, forceRefresh = true)
+                basePreferences.downloadedOnly.changes().collect { cachedOnly ->
+                    if (!cachedOnly) {
+                        reloadKomgaState(source, showRefreshing = true, resetSelection = true, forceRefresh = true)
+                    }
+                }
             }
             if (libraryScope != KomgaLibraryScope.ALL) {
                 screenModelScope.launchIO {
@@ -151,6 +173,27 @@ class KomgaLibraryScreenModel(
     }.flatMapLatest { request ->
         if (request.scopeEmpty || !request.serverConfigured) {
             flowOf(PagingData.empty())
+        } else if (request.cachedOnly) {
+            combine(
+                getManga.subscribeBySourceId(sourceId),
+                downloadManager.queueState,
+            ) { localManga, _ ->
+                val query = (request.listing as? Listing.Search)?.query
+                val selectedLibraryIds = request.listing.filters.selectedLibraryIds()
+                val downloadedManga = localManga.asSequence()
+                    .filter { downloadManager.getDownloadCount(it) > 0 }
+                    .toList()
+                val cachedManga = downloadedManga.withCachedLibraryIds()
+                val cachedItems = cachedManga.asSequence()
+                    .filter { it.matchesCachedLibraryFilter(selectedLibraryIds) }
+                    .filter { it.matchesCachedOnlyQuery(query) }
+                    .map { MutableStateFlow(it) as StateFlow<Manga> }
+                    .toList()
+                PagingData.from(
+                    data = cachedItems,
+                    sourceLoadStates = CACHED_ONLY_LOAD_STATES,
+                )
+            }
         } else {
             Pager(PagingConfig(pageSize = 25)) {
                 getRemoteManga(sourceId, request.listing.query ?: "", request.listing.filters)
@@ -164,14 +207,27 @@ class KomgaLibraryScreenModel(
                             initialValue = remoteManga,
                         )
                 }
-                    .filter { mangaStateFlow ->
-                        !request.cachedOnly ||
-                            downloadManager.getDownloadCount(mangaStateFlow.value) > 0
-                    }
             }
         }
     }
         .cachedIn(ioCoroutineScope)
+
+    private suspend fun List<Manga>.withCachedLibraryIds(): List<Manga> {
+        val komgaSource = source as? KomgaSource ?: return this
+        val updates = mutableListOf<MangaUpdate>()
+        val enriched = map { manga ->
+            if (manga.cachedLibraryId != null) return@map manga
+
+            val libraryId = komgaSource.findCachedLibraryId(manga.url) ?: return@map manga
+            val updatedMemo = JsonObject(manga.memo + (KOMGA_LIBRARY_ID_MEMO_KEY to JsonPrimitive(libraryId)))
+            updates += MangaUpdate(id = manga.id, memo = updatedMemo)
+            manga.copy(memo = updatedMemo)
+        }
+        if (updates.isNotEmpty()) {
+            updateManga.awaitAll(updates)
+        }
+        return enriched
+    }
 
     fun resetFilters() {
         if (source !is CatalogueSource) return
@@ -383,6 +439,10 @@ class KomgaLibraryScreenModel(
     }
 
     fun refresh() {
+        if (basePreferences.downloadedOnly.get()) {
+            refreshSignal.value += 1
+            return
+        }
         val komgaSource = source as? KomgaSource
         if (komgaSource != null) {
             screenModelScope.launchIO {
@@ -429,7 +489,9 @@ class KomgaLibraryScreenModel(
             libraryFilterBeforeQuickSelection = null
         }
         komgaSource.saveSessionFilterState(filters, libraryScope)
-        komgaSource.refreshBrowseRequests()
+        if (!basePreferences.downloadedOnly.get()) {
+            komgaSource.refreshBrowseRequests()
+        }
         refreshSignal.value += 1
     }
 
@@ -712,3 +774,30 @@ private fun mergeRemoteWithLocal(remote: Manga, local: Manga?): Manga {
         notes = local.notes,
     )
 }
+
+internal fun Manga.matchesCachedOnlyQuery(query: String?): Boolean {
+    val normalizedQuery = query?.trim().orEmpty()
+    if (normalizedQuery.isEmpty()) return true
+
+    return title.contains(normalizedQuery, ignoreCase = true) ||
+        author?.contains(normalizedQuery, ignoreCase = true) == true ||
+        artist?.contains(normalizedQuery, ignoreCase = true) == true ||
+        genre.orEmpty().any { it.contains(normalizedQuery, ignoreCase = true) }
+}
+
+internal fun Manga.matchesCachedLibraryFilter(selectedLibraryIds: Set<String>): Boolean {
+    if (selectedLibraryIds.isEmpty()) return true
+    return cachedLibraryId in selectedLibraryIds
+}
+
+private val Manga.cachedLibraryId: String?
+    get() = memo[KOMGA_LIBRARY_ID_MEMO_KEY]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.takeIf { it.isNotBlank() }
+
+internal val CACHED_ONLY_LOAD_STATES = LoadStates(
+    refresh = LoadState.NotLoading(endOfPaginationReached = true),
+    prepend = LoadState.NotLoading(endOfPaginationReached = true),
+    append = LoadState.NotLoading(endOfPaginationReached = true),
+)

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -153,7 +153,15 @@ class KomgaLibraryScreenModel(
                 screenModelScope.launchIO {
                     source.invalidateBrowseCache()
                     if (basePreferences.downloadedOnly.get()) {
-                        refreshSignal.value += 1
+                        if (shelfLibrariesChanged) {
+                            applyClassifiedLibraries(
+                                source,
+                                libraryClassificationManager.getLibraries(sourceId),
+                                forceShelfLibrarySelection = true,
+                            )
+                        } else {
+                            refreshSignal.value += 1
+                        }
                     } else {
                         reloadKomgaState(
                             komgaSource = source,
@@ -719,6 +727,7 @@ class KomgaLibraryScreenModel(
     private fun applyClassifiedLibraries(
         komgaSource: KomgaSource,
         libraries: List<KomgaClassifiedLibrary>,
+        forceShelfLibrarySelection: Boolean = false,
     ) {
         val configuredLibraryIds = komgaSource.configuredShelfLibraryIds()
         val visibleLibraries = libraries
@@ -727,7 +736,7 @@ class KomgaLibraryScreenModel(
                     (configuredLibraryIds.isEmpty() || library.id in configuredLibraryIds)
             }
             .map { LibraryDto(it.id, it.name) }
-        if (filtersInitialized && state.value.komgaLibraries == visibleLibraries) return
+        if (!forceShelfLibrarySelection && filtersInitialized && state.value.komgaLibraries == visibleLibraries) return
         val selectedLibraryId = state.value.selectedKomgaLibraryId
             ?.takeIf { selectedId -> visibleLibraries.any { it.id == selectedId } }
         val filters = komgaSource.buildFilterListForLibrary(
@@ -738,6 +747,7 @@ class KomgaLibraryScreenModel(
             currentFilters = currentFiltersForReload(),
             preserveSessionFilters = true,
             fallbackLibraries = visibleLibraries,
+            forceConfiguredLibrarySelection = forceShelfLibrarySelection,
         ).let { filters ->
             if (basePreferences.downloadedOnly.get()) filters.withoutUnsupportedCachedSelections() else filters
         }
@@ -754,6 +764,9 @@ class KomgaLibraryScreenModel(
         }
         filtersInitialized = true
         komgaSource.saveSessionFilterState(filters, libraryScope)
+        if (forceShelfLibrarySelection) {
+            komgaSource.savePersistentFilterState(filters, libraryScope)
+        }
         refreshSignal.value += 1
     }
 

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -23,19 +23,39 @@ import eu.kanade.presentation.util.ioCoroutineScope
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.SManga
 import koharia.epub.cache.EpubCacheManager
+import koharia.komga.api.dto.KOMGA_LIBRARY_IDS_MEMO_KEY
 import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
+import koharia.komga.api.dto.KomgaOfflineAuthor
+import koharia.komga.api.dto.KomgaOfflineFilterMetadata
 import koharia.komga.api.dto.LibraryDto
+import koharia.komga.api.dto.mergeKomgaOfflineMemo
+import koharia.komga.api.dto.offlineFilterMetadata
+import koharia.komga.domain.repository.KomgaRepository
+import koharia.komga.download.KomgaChapterMemo
+import koharia.source.komga.AuthorFilter
+import koharia.source.komga.AuthorGroup
+import koharia.source.komga.CollectionSelect
+import koharia.source.komga.InProgressFilter
 import koharia.source.komga.KomgaClassifiedLibrary
 import koharia.source.komga.KomgaLibraryClassificationManager
 import koharia.source.komga.KomgaLibraryKind
 import koharia.source.komga.KomgaLibraryScope
 import koharia.source.komga.KomgaSource
 import koharia.source.komga.LibraryFilter
+import koharia.source.komga.OneshotFilter
+import koharia.source.komga.ReadFilter
+import koharia.source.komga.ReadingStateGroup
+import koharia.source.komga.SeriesSort
 import koharia.source.komga.TYPE_ALL_INDEX
 import koharia.source.komga.TYPE_BOOKS_INDEX
 import koharia.source.komga.TYPE_READ_LISTS_INDEX
 import koharia.source.komga.TYPE_SERIES_INDEX
+import koharia.source.komga.TypeSelect
+import koharia.source.komga.UnreadFilter
+import koharia.source.komga.UriMultiSelectFilter
+import koharia.source.komga.UriMultiSelectOption
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -51,6 +71,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
@@ -59,6 +80,7 @@ import logcat.LogPriority
 import tachiyomi.core.common.util.lang.launchIO
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
+import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.library.service.LibraryPreferences
 import tachiyomi.domain.manga.interactor.GetManga
 import tachiyomi.domain.manga.model.Manga
@@ -100,6 +122,9 @@ class KomgaLibraryScreenModel(
     private var filtersInitialized = false
     private var listingBeforeSearch: Listing? = null
     private var libraryFilterBeforeQuickSelection: Set<String>? = null
+
+    @Volatile
+    private var latestCachedManga = emptyList<Manga>()
 
     init {
         if (source is CatalogueSource) {
@@ -147,7 +172,15 @@ class KomgaLibraryScreenModel(
             }
             screenModelScope.launchIO {
                 basePreferences.downloadedOnly.changes().collect { cachedOnly ->
-                    if (!cachedOnly) {
+                    if (cachedOnly) {
+                        val filters = state.value.filters.withoutUnsupportedCachedSelections()
+                        mutableState.update { current ->
+                            current.copy(
+                                filters = filters,
+                                listing = Listing.Search(current.listing.query, filters),
+                            )
+                        }
+                    } else {
                         reloadKomgaState(source, showRefreshing = true, resetSelection = true, forceRefresh = true)
                     }
                 }
@@ -182,19 +215,46 @@ class KomgaLibraryScreenModel(
                 downloadManager.cacheChanges,
                 epubCacheManager.changes,
             ) { localManga, _, _ ->
+                val chaptersByMangaId = mutableMapOf<Long, List<Chapter>>()
+                suspend fun chaptersFor(manga: Manga): List<Chapter> {
+                    chaptersByMangaId[manga.id]?.let { return it }
+                    return getChaptersByMangaId.await(manga.id).also { chaptersByMangaId[manga.id] = it }
+                }
+
                 val query = (request.listing as? Listing.Search)?.query
                 val selectedLibraryIds = request.listing.filters.selectedLibraryIds()
                 val selectedContentType = request.listing.filters.selectedContentType()
+                val selectedAdvancedFilters = request.listing.filters.cachedAdvancedFilterSelection()
                 val hasCompleteEpubCache = epubCacheManager.hasAnyCompleteBook(sourceId)
-                val locallyAvailableManga = localManga.filter { manga ->
-                    downloadManager.getDownloadCount(manga) > 0 ||
-                        (hasCompleteEpubCache && manga.hasCompleteEpubCache())
+                val locallyAvailableManga = buildList {
+                    for (manga in localManga) {
+                        val isAvailable = downloadManager.getDownloadCount(manga) > 0 ||
+                            (
+                                hasCompleteEpubCache &&
+                                    chaptersFor(manga).any { epubCacheManager.hasCompleteBook(sourceId, it) }
+                                )
+                        if (isAvailable) add(manga)
+                    }
                 }
-                val cachedManga = locallyAvailableManga.withCachedLibraryIds()
-                val cachedItems = cachedManga.asSequence()
-                    .filter { it.matchesCachedLibraryFilter(selectedLibraryIds) }
-                    .filter { it.matchesCachedContentType(selectedContentType) }
-                    .filter { it.matchesCachedOnlyQuery(query) }
+                val cachedManga = locallyAvailableManga.withCachedLibraryIds(::chaptersFor)
+                latestCachedManga = cachedManga
+                val filteredManga = buildList {
+                    for (manga in cachedManga) {
+                        if (!manga.matchesCachedLibraryFilter(selectedLibraryIds)) continue
+                        if (!manga.matchesCachedContentType(selectedContentType)) continue
+                        if (!manga.matchesCachedOnlyQuery(query)) continue
+                        val chapters = if (selectedAdvancedFilters.requiresReadingStatus) {
+                            chaptersFor(manga)
+                        } else {
+                            emptyList()
+                        }
+                        if (!manga.matchesCachedAdvancedFilters(selectedAdvancedFilters, chapters)) continue
+                        add(manga)
+                    }
+                }
+                val cachedItems = filteredManga
+                    .sortedForCachedFilters(selectedAdvancedFilters, request.refreshSignal)
+                    .asSequence()
                     .map { MutableStateFlow(it) as StateFlow<Manga> }
                     .toList()
                 PagingData.from(
@@ -220,14 +280,25 @@ class KomgaLibraryScreenModel(
     }
         .cachedIn(ioCoroutineScope)
 
-    private suspend fun List<Manga>.withCachedLibraryIds(): List<Manga> {
+    private suspend fun List<Manga>.withCachedLibraryIds(
+        chaptersFor: suspend (Manga) -> List<Chapter>,
+    ): List<Manga> {
         val komgaSource = source as? KomgaSource ?: return this
         val updates = mutableListOf<MangaUpdate>()
         val enriched = map { manga ->
-            if (manga.cachedLibraryId != null) return@map manga
+            if (manga.cachedLibraryIds.isNotEmpty()) return@map manga
 
-            val libraryId = komgaSource.findCachedLibraryId(manga.url) ?: return@map manga
-            val updatedMemo = JsonObject(manga.memo + (KOMGA_LIBRARY_ID_MEMO_KEY to JsonPrimitive(libraryId)))
+            val libraryIds = manga.resolveCachedLibraryIds(komgaSource, chaptersFor)
+            if (libraryIds.isEmpty()) return@map manga
+            val updatedMemo = JsonObject(
+                manga.memo +
+                    (KOMGA_LIBRARY_IDS_MEMO_KEY to JsonArray(libraryIds.map(::JsonPrimitive))) +
+                    if (libraryIds.size == 1) {
+                        mapOf(KOMGA_LIBRARY_ID_MEMO_KEY to JsonPrimitive(libraryIds.single()))
+                    } else {
+                        emptyMap()
+                    },
+            )
             updates += MangaUpdate(id = manga.id, memo = updatedMemo)
             manga.copy(memo = updatedMemo)
         }
@@ -237,9 +308,16 @@ class KomgaLibraryScreenModel(
         return enriched
     }
 
-    private suspend fun Manga.hasCompleteEpubCache(): Boolean {
-        return getChaptersByMangaId.await(id).any { chapter ->
-            epubCacheManager.hasCompleteBook(sourceId, chapter)
+    private suspend fun Manga.resolveCachedLibraryIds(
+        komgaSource: KomgaSource,
+        chaptersFor: suspend (Manga) -> List<Chapter>,
+    ): Set<String> {
+        val cachedIds = komgaSource.findCachedLibraryIds(url)
+        if (cachedIds.isNotEmpty()) return cachedIds
+
+        return chaptersFor(this).mapNotNullTo(linkedSetOf()) { chapter ->
+            KomgaChapterMemo.libraryId(chapter.memo)
+                ?: KomgaChapterMemo.readFingerprint(chapter.memo)?.bookUrl?.let(komgaSource::findCachedLibraryId)
         }
     }
 
@@ -250,11 +328,19 @@ class KomgaLibraryScreenModel(
             resetPersistentFilters(libraryScope)
             resetSessionFilterState(libraryScope)
         }
-        val filters = (source as? KomgaSource)?.buildFilterListForLibrary(
-            libraryId = state.value.selectedKomgaLibraryId,
-            allowedLibraryIds = currentAllowedLibraryIds(),
-            libraryScope = libraryScope,
-        ) ?: source.getFilterList()
+        val filters = (
+            (source as? KomgaSource)?.buildFilterListForLibrary(
+                libraryId = state.value.selectedKomgaLibraryId,
+                allowedLibraryIds = currentAllowedLibraryIds(),
+                libraryScope = libraryScope,
+            ) ?: source.getFilterList()
+            ).let { filters ->
+            if (basePreferences.downloadedOnly.get()) {
+                filters.withCachedMetadataOptions(latestCachedManga).withoutUnsupportedCachedSelections()
+            } else {
+                filters
+            }
+        }
         mutableState.update { it.copy(filters = filters) }
     }
 
@@ -401,6 +487,15 @@ class KomgaLibraryScreenModel(
     }
 
     fun openFilterSheet() {
+        if (basePreferences.downloadedOnly.get()) {
+            val filters = state.value.filters.withCachedMetadataOptions(latestCachedManga)
+            mutableState.update { current ->
+                current.copy(
+                    filters = filters,
+                    listing = Listing.Search(current.listing.query, filters),
+                )
+            }
+        }
         setDialog(Dialog.Filter)
     }
 
@@ -643,7 +738,9 @@ class KomgaLibraryScreenModel(
             currentFilters = currentFiltersForReload(),
             preserveSessionFilters = true,
             fallbackLibraries = visibleLibraries,
-        )
+        ).let { filters ->
+            if (basePreferences.downloadedOnly.get()) filters.withoutUnsupportedCachedSelections() else filters
+        }
         mutableState.update {
             it.copy(
                 listing = Listing.Search(query = null, filters = filters),
@@ -770,7 +867,7 @@ private data class BrowseRequest(
     val scopeEmpty: Boolean,
     val serverConfigured: Boolean,
     val cachedOnly: Boolean,
-    @Suppress("unused") val refreshSignal: Int,
+    val refreshSignal: Int,
 )
 
 private fun mergeRemoteWithLocal(remote: Manga, local: Manga?): Manga {
@@ -792,6 +889,7 @@ private fun mergeRemoteWithLocal(remote: Manga, local: Manga?): Manga {
         favoriteModifiedAt = local.favoriteModifiedAt,
         version = local.version,
         notes = local.notes,
+        memo = mergeKomgaOfflineMemo(local.memo, remote.memo) ?: local.memo,
     )
 }
 
@@ -807,7 +905,7 @@ internal fun Manga.matchesCachedOnlyQuery(query: String?): Boolean {
 
 internal fun Manga.matchesCachedLibraryFilter(selectedLibraryIds: Set<String>): Boolean {
     if (selectedLibraryIds.isEmpty()) return true
-    return cachedLibraryId in selectedLibraryIds
+    return cachedLibraryIds.any { it in selectedLibraryIds }
 }
 
 internal fun Manga.matchesCachedContentType(contentType: Int): Boolean {
@@ -820,11 +918,220 @@ internal fun Manga.matchesCachedContentType(contentType: Int): Boolean {
     }
 }
 
+internal data class CachedAdvancedFilterSelection(
+    val readingStatuses: Set<String> = emptySet(),
+    val statuses: Set<String> = emptySet(),
+    val genres: Set<String> = emptySet(),
+    val tags: Set<String> = emptySet(),
+    val publishers: Set<String> = emptySet(),
+    val authors: Set<KomgaOfflineAuthor> = emptySet(),
+    val oneShot: Boolean = false,
+    val sortIndex: Int = 0,
+    val sortAscending: Boolean = true,
+) {
+    val requiresReadingStatus: Boolean get() = readingStatuses.isNotEmpty()
+}
+
+internal fun FilterList.cachedAdvancedFilterSelection(): CachedAdvancedFilterSelection {
+    val readingFilters = filterIsInstance<ReadingStateGroup>().firstOrNull()?.state.orEmpty()
+    val contentType = filterIsInstance<TypeSelect>().firstOrNull()?.state ?: TYPE_ALL_INDEX
+    val readingStatuses = buildSet {
+        if (readingFilters.filterIsInstance<UnreadFilter>().firstOrNull()?.state == true) {
+            add("UNREAD")
+            add("IN_PROGRESS")
+        }
+        if (readingFilters.filterIsInstance<InProgressFilter>().firstOrNull()?.state == true) {
+            add("IN_PROGRESS")
+        }
+        if (readingFilters.filterIsInstance<ReadFilter>().firstOrNull()?.state == true) {
+            add("READ")
+        }
+    }
+    val sort = filterIsInstance<SeriesSort>().firstOrNull()?.state
+    return CachedAdvancedFilterSelection(
+        readingStatuses = readingStatuses,
+        statuses = selectedCachedOptions("Status"),
+        genres = selectedCachedOptions("Genres"),
+        tags = selectedCachedOptions("Tags"),
+        publishers = selectedCachedOptions("Publishers"),
+        authors = filterIsInstance<AuthorGroup>()
+            .flatMap { group ->
+                group.state.filter { it.state }.map { KomgaOfflineAuthor(it.author.name, it.author.role) }
+            }
+            .toSet(),
+        oneShot = contentType == TYPE_SERIES_INDEX &&
+            readingFilters.filterIsInstance<OneshotFilter>().firstOrNull()?.state == true,
+        sortIndex = sort?.index ?: 0,
+        sortAscending = sort?.ascending ?: true,
+    )
+}
+
+internal fun Manga.matchesCachedAdvancedFilters(
+    filters: CachedAdvancedFilterSelection,
+    chapters: List<Chapter> = emptyList(),
+): Boolean {
+    val metadata = memo.offlineFilterMetadata()
+    if (filters.statuses.isNotEmpty() && !(cachedSeriesStatus(metadata) inIgnoreCase filters.statuses)) return false
+    if (filters.genres.isNotEmpty() && metadata?.genres.orEmpty() hasNoValueIn filters.genres) return false
+    if (filters.tags.isNotEmpty() && metadata?.tags.orEmpty() hasNoValueIn filters.tags) return false
+    if (filters.publishers.isNotEmpty() && setOfNotNull(cachedPublisher(metadata)) hasNoValueIn filters.publishers) {
+        return false
+    }
+    if (filters.authors.isNotEmpty() && metadata?.authors.orEmpty().none { cachedAuthor ->
+            filters.authors.any { selected ->
+                cachedAuthor.name.equals(selected.name, ignoreCase = true) &&
+                    cachedAuthor.role.equals(selected.role, ignoreCase = true)
+            }
+        }
+    ) {
+        return false
+    }
+    if (filters.oneShot && metadata?.oneShot != true) return false
+    if (filters.readingStatuses.isNotEmpty() && chapters.cachedReadingStatus() !in filters.readingStatuses) return false
+    return true
+}
+
+internal fun List<Manga>.sortedForCachedFilters(
+    filters: CachedAdvancedFilterSelection,
+    randomSeed: Int,
+): List<Manga> {
+    val sorted = when (filters.sortIndex) {
+        1 -> sortedWith(compareBy<Manga> { it.cachedTitleSort().lowercase() }.thenBy { it.id })
+        2 -> sortedWith(compareBy<Manga> { it.cachedCreatedTimestamp() }.thenBy { it.id })
+        3 -> sortedWith(compareBy<Manga> { it.cachedModifiedTimestamp() }.thenBy { it.id })
+        4 -> sortedWith(compareBy<Manga> { cachedRandomKey(it.id, randomSeed) }.thenBy { it.id })
+        else -> this
+    }
+    return if (filters.sortAscending) sorted else sorted.asReversed()
+}
+
+internal fun FilterList.withCachedMetadataOptions(mangas: List<Manga>): FilterList {
+    val metadata = mangas.mapNotNull { manga -> manga.memo.offlineFilterMetadata()?.let { manga to it } }
+    val cachedValues = mapOf(
+        "Status" to mangas.mapNotNullTo(linkedSetOf()) { it.cachedSeriesStatus(it.memo.offlineFilterMetadata()) },
+        "Genres" to metadata.flatMapTo(linkedSetOf()) { it.second.genres },
+        "Tags" to metadata.flatMapTo(linkedSetOf()) { it.second.tags },
+        "Publishers" to mangas.mapNotNullTo(linkedSetOf()) { it.cachedPublisher(it.memo.offlineFilterMetadata()) },
+    )
+    val updated = map { filter ->
+        if (filter is UriMultiSelectFilter && filter !is LibraryFilter) {
+            val selected = filter.state.filter { it.state }.mapTo(linkedSetOf()) { it.id }
+            val labels = filter.state.associate { it.id to it.name }
+            val values = cachedValues[filter.name].orEmpty() + selected
+            UriMultiSelectFilter(
+                filter.name,
+                values.sortedWith(String.CASE_INSENSITIVE_ORDER).map { id ->
+                    UriMultiSelectOption(labels[id] ?: id, id).apply { state = id in selected }
+                },
+            )
+        } else {
+            filter
+        }
+    }.toMutableList()
+
+    val selectedAuthors = filterIsInstance<AuthorGroup>()
+        .flatMap { group -> group.state.filter { it.state }.map { it.author } }
+        .associateBy { it.name to it.role }
+    val cachedAuthors = metadata.flatMapTo(linkedSetOf()) { it.second.authors }
+    val authors = (cachedAuthors + selectedAuthors.values.map { KomgaOfflineAuthor(it.name, it.role) })
+        .groupBy(KomgaOfflineAuthor::role)
+    val firstAuthorIndex = updated.indexOfFirst { it is AuthorGroup }
+    updated.removeAll { it is AuthorGroup }
+    val insertionIndex = firstAuthorIndex.takeIf { it >= 0 }
+        ?: updated.indexOfFirst { it is SeriesSort }.takeIf { it >= 0 }
+        ?: updated.size
+    updated.addAll(
+        insertionIndex,
+        authors.toSortedMap(String.CASE_INSENSITIVE_ORDER).map { (role, roleAuthors) ->
+            AuthorGroup(
+                role,
+                roleAuthors.sortedBy { it.name.lowercase() }.map { author ->
+                    AuthorFilter(koharia.komga.api.dto.AuthorDto(author.name, author.role)).apply {
+                        state = (author.name to author.role) in selectedAuthors
+                    }
+                },
+            )
+        },
+    )
+    return FilterList(updated)
+}
+
+private fun FilterList.withoutUnsupportedCachedSelections(): FilterList = FilterList(
+    map { filter ->
+        if (filter is CollectionSelect && filter.state != 0) {
+            CollectionSelect(filter.collections).apply { state = 0 }
+        } else {
+            filter
+        }
+    },
+)
+
+private fun FilterList.selectedCachedOptions(name: String): Set<String> =
+    filterIsInstance<UriMultiSelectFilter>()
+        .firstOrNull { it.name == name }
+        ?.state
+        .orEmpty()
+        .filter { it.state }
+        .mapTo(linkedSetOf()) { it.id }
+
+private fun Manga.cachedSeriesStatus(metadata: KomgaOfflineFilterMetadata?): String? =
+    metadata?.status ?: when (status.toInt()) {
+        SManga.ONGOING -> "ONGOING"
+        SManga.COMPLETED, SManga.PUBLISHING_FINISHED -> "ENDED"
+        SManga.CANCELLED -> "ABANDONED"
+        SManga.ON_HIATUS -> "HIATUS"
+        else -> null
+    }
+
+private fun Manga.cachedPublisher(metadata: KomgaOfflineFilterMetadata?): String? =
+    metadata?.publisher ?: memo["publisher"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)
+
+private fun Manga.cachedTitleSort(): String =
+    memo.offlineFilterMetadata()?.titleSort ?: title
+
+private fun Manga.cachedCreatedTimestamp(): Long =
+    memo.offlineFilterMetadata()?.createdDate?.let { KomgaRepository.parseDateTime(it) }?.takeIf { it > 0L }
+        ?: dateAdded
+
+private fun Manga.cachedModifiedTimestamp(): Long =
+    memo.offlineFilterMetadata()?.lastModifiedDate?.let { KomgaRepository.parseDateTime(it) }?.takeIf { it > 0L }
+        ?: lastModifiedAt
+
+private fun List<Chapter>.cachedReadingStatus(): String? = when {
+    isEmpty() -> null
+    all(Chapter::read) -> "READ"
+    any { it.read || it.lastPageRead > 0L } -> "IN_PROGRESS"
+    else -> "UNREAD"
+}
+
+private infix fun String?.inIgnoreCase(values: Set<String>): Boolean =
+    this != null && values.any { equals(it, ignoreCase = true) }
+
+private infix fun Set<String>.hasNoValueIn(values: Set<String>): Boolean =
+    none { cached -> values.any { cached.equals(it, ignoreCase = true) } }
+
+private fun cachedRandomKey(mangaId: Long, seed: Int): Long {
+    var value = mangaId xor (seed.toLong() shl 32)
+    value = (value xor (value ushr 33)) * -49064778989728563L
+    value = (value xor (value ushr 33)) * -4265267296055464877L
+    return value xor (value ushr 33)
+}
+
 private val Manga.cachedLibraryId: String?
     get() = memo[KOMGA_LIBRARY_ID_MEMO_KEY]
         ?.jsonPrimitive
         ?.contentOrNull
         ?.takeIf { it.isNotBlank() }
+
+private val Manga.cachedLibraryIds: Set<String>
+    get() = buildSet {
+        cachedLibraryId?.let(::add)
+        (memo[KOMGA_LIBRARY_IDS_MEMO_KEY] as? JsonArray)
+            .orEmpty()
+            .mapNotNullTo(this) { element ->
+                element.jsonPrimitive.contentOrNull?.takeIf(String::isNotBlank)
+            }
+    }
 
 internal val CACHED_ONLY_LOAD_STATES = LoadStates(
     refresh = LoadState.NotLoading(endOfPaginationReached = true),

--- a/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
@@ -2,6 +2,8 @@ package koharia.source.komga
 
 import android.content.Context
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -67,11 +69,26 @@ internal class KomgaMetadataCacheStore(
 
     fun findLibraryId(contentUrl: String): String? {
         val content = readJsonObject(contentUrl) ?: return null
-        content[LIBRARY_ID_FIELD]?.jsonPrimitive?.contentOrNull
+        return content.findLibraryId(contentUrl)
+    }
+
+    fun findLibraryIds(contentUrl: String): Set<String> {
+        findLibraryId(contentUrl)?.let { return setOf(it) }
+        if (!contentUrl.substringBefore('?').trimEnd('/').contains("$API_PATH/readlists/")) return emptySet()
+
+        val booksUrl = contentUrl.trimEnd('/') + READ_LIST_BOOKS_QUERY
+        val books = readJsonObject(booksUrl)?.get(CONTENT_FIELD) as? JsonArray ?: return emptySet()
+        return books.mapNotNullTo(linkedSetOf()) { element ->
+            runCatching { element.jsonObject.findLibraryId(contentUrl) }.getOrNull()
+        }
+    }
+
+    private fun JsonObject.findLibraryId(contentUrl: String): String? {
+        this[LIBRARY_ID_FIELD]?.jsonPrimitive?.contentOrNull
             ?.takeIf { it.isNotBlank() }
             ?.let { return it }
 
-        val seriesId = content[SERIES_ID_FIELD]?.jsonPrimitive?.contentOrNull
+        val seriesId = this[SERIES_ID_FIELD]?.jsonPrimitive?.contentOrNull
             ?.takeIf { it.isNotBlank() }
             ?: return null
         val baseUrl = contentUrl.substringBefore(API_PATH, missingDelimiterValue = "")
@@ -171,8 +188,10 @@ internal class KomgaMetadataCacheStore(
         private val PAGE_IMAGE_REGEX = Regex("/pages/\\d+(?:\\?.*)?$")
         private val SEARCH_LIST_PATHS = setOf("/api/v1/books/list", "/api/v1/series/list")
         private const val API_PATH = "/api/v1"
+        private const val CONTENT_FIELD = "content"
         private const val LIBRARY_ID_FIELD = "libraryId"
         private const val SERIES_ID_FIELD = "seriesId"
+        private const val READ_LIST_BOOKS_QUERY = "/books?unpaged=true&media_status=READY&deleted=false"
     }
 }
 

--- a/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaMetadataCacheStore.kt
@@ -1,6 +1,10 @@
 package koharia.source.komga
 
 import android.content.Context
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
@@ -60,6 +64,28 @@ internal class KomgaMetadataCacheStore(
             .body(bodyBytes.toResponseBody(contentType))
             .build()
     }
+
+    fun findLibraryId(contentUrl: String): String? {
+        val content = readJsonObject(contentUrl) ?: return null
+        content[LIBRARY_ID_FIELD]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
+
+        val seriesId = content[SERIES_ID_FIELD]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+            ?: return null
+        val baseUrl = contentUrl.substringBefore(API_PATH, missingDelimiterValue = "")
+        if (baseUrl.isBlank()) return null
+
+        return readJsonObject("$baseUrl$API_PATH/series/$seriesId")
+            ?.get(LIBRARY_ID_FIELD)
+            ?.jsonPrimitive
+            ?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun readJsonObject(url: String) = readEntry(url)
+        ?.let { entry -> runCatching { Json.parseToJsonElement(entry.body.decodeToString()).jsonObject }.getOrNull() }
 
     private fun readEntry(identity: String): CacheEntry? {
         val bodyFile = bodyFile(identity)
@@ -144,6 +170,9 @@ internal class KomgaMetadataCacheStore(
 
         private val PAGE_IMAGE_REGEX = Regex("/pages/\\d+(?:\\?.*)?$")
         private val SEARCH_LIST_PATHS = setOf("/api/v1/books/list", "/api/v1/series/list")
+        private const val API_PATH = "/api/v1"
+        private const val LIBRARY_ID_FIELD = "libraryId"
+        private const val SERIES_ID_FIELD = "seriesId"
     }
 }
 

--- a/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
@@ -1,7 +1,6 @@
 package koharia.source.komga
 
 import android.content.Context
-import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.util.system.isOnline
 import logcat.LogPriority
 import okhttp3.CacheControl
@@ -10,14 +9,12 @@ import okhttp3.Response
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 class KomgaOfflineInterceptor(
     private val context: Context,
-    private val cachedOnlyProvider: () -> Boolean = { Injekt.get<BasePreferences>().downloadedOnly.get() },
+    private val cachedOnlyProvider: () -> Boolean,
 ) : Interceptor {
     private val metadataCacheStore = KomgaMetadataCacheStore(context.applicationContext)
 

--- a/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaOfflineInterceptor.kt
@@ -1,6 +1,7 @@
 package koharia.source.komga
 
 import android.content.Context
+import eu.kanade.domain.base.BasePreferences
 import eu.kanade.tachiyomi.util.system.isOnline
 import logcat.LogPriority
 import okhttp3.CacheControl
@@ -9,19 +10,28 @@ import okhttp3.Response
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.IOException
 import java.util.concurrent.TimeUnit
 
-class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
+class KomgaOfflineInterceptor(
+    private val context: Context,
+    private val cachedOnlyProvider: () -> Boolean = { Injekt.get<BasePreferences>().downloadedOnly.get() },
+) : Interceptor {
     private val metadataCacheStore = KomgaMetadataCacheStore(context.applicationContext)
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()
-        val isOnline = context.isOnline()
-        val request = if (isOnline) {
+        val cachedOnly = cachedOnlyProvider()
+        val canUseNetwork = shouldUseKomgaNetwork(cachedOnly, context.isOnline())
+        val request = if (canUseNetwork) {
             originalRequest
         } else {
-            logcat(LogPriority.INFO) { "No network, forcing Komga cache read: ${originalRequest.url}" }
+            logcat(LogPriority.INFO) {
+                val reason = if (cachedOnly) "cached-only mode" else "no network"
+                "Forcing Komga cache read ($reason): ${originalRequest.url}"
+            }
             originalRequest.newBuilder()
                 .cacheControl(
                     CacheControl.Builder()
@@ -40,19 +50,19 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
         while (retryCount < maxRetries) {
             try {
                 response = chain.proceed(request)
-                if (!isOnline && response.code == 504) {
+                if (!canUseNetwork && response.code == 504) {
                     val fallbackResponse = metadataCacheStore.load(originalRequest)
                     if (fallbackResponse != null) {
                         response.close()
                         response = fallbackResponse
                     }
                 }
-                if (!isOnline && response.code == 504) {
+                if (!canUseNetwork && response.code == 504) {
                     response.close()
                     response = null
                     throw IOException(context.stringResource(MR.strings.exception_offline))
                 }
-                if (response.isSuccessful || !isOnline) {
+                if (response.isSuccessful || !canUseNetwork) {
                     break
                 }
                 if (response.code >= 500) {
@@ -69,7 +79,7 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
                 break
             } catch (e: IOException) {
                 exception = e
-                if (!isOnline) {
+                if (!canUseNetwork) {
                     break
                 }
                 retryCount++
@@ -102,7 +112,7 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
         }
 
         if (response == null) {
-            if (!isOnline) {
+            if (!canUseNetwork) {
                 throw IOException(context.stringResource(MR.strings.exception_offline))
             }
             throw exception ?: IOException("Request failed after $maxRetries retries")
@@ -111,3 +121,5 @@ class KomgaOfflineInterceptor(private val context: Context) : Interceptor {
         return response
     }
 }
+
+internal fun shouldUseKomgaNetwork(cachedOnly: Boolean, isOnline: Boolean): Boolean = !cachedOnly && isOnline

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -94,6 +94,9 @@ class KomgaSource(
     private val repository: KomgaRepository
         get() = KomgaRepository(baseUrl, apiClient)
     private val metadataCacheStore by lazy { KomgaMetadataCacheStore(application.applicationContext) }
+    private val scopedBasePreferences by lazy {
+        Injekt.get<KomgaScopedPreferenceStoreFactory>().basePreferences(id)
+    }
     private val forceBrowseRequestsUntil = AtomicLong(0L)
 
     fun currentHeaders(): Headers = headersBuilder().build()
@@ -122,7 +125,7 @@ class KomgaSource(
         }
 
     override val client = super.client.newBuilder()
-        .addInterceptor(KomgaOfflineInterceptor(application))
+        .addInterceptor(KomgaOfflineInterceptor(application) { scopedBasePreferences.downloadedOnly.get() })
         .addNetworkInterceptor(KomgaCacheControlInterceptor(application))
         .addInterceptor { chain ->
             val original = chain.request()

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -93,6 +93,7 @@ class KomgaSource(
 
     private val repository: KomgaRepository
         get() = KomgaRepository(baseUrl, apiClient)
+    private val metadataCacheStore by lazy { KomgaMetadataCacheStore(application.applicationContext) }
     private val forceBrowseRequestsUntil = AtomicLong(0L)
 
     fun currentHeaders(): Headers = headersBuilder().build()
@@ -677,6 +678,8 @@ class KomgaSource(
     }
 
     fun configuredShelfLibraryIds(): Set<String> = shelfLibraryIds.toSet()
+
+    fun findCachedLibraryId(contentUrl: String): String? = metadataCacheStore.findLibraryId(contentUrl)
 
     fun registerServerSettingsChangeListener(
         onChanged: (shelfLibrariesChanged: Boolean) -> Unit,

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -684,6 +684,8 @@ class KomgaSource(
 
     fun findCachedLibraryId(contentUrl: String): String? = metadataCacheStore.findLibraryId(contentUrl)
 
+    fun findCachedLibraryIds(contentUrl: String): Set<String> = metadataCacheStore.findLibraryIds(contentUrl)
+
     fun registerServerSettingsChangeListener(
         onChanged: (shelfLibrariesChanged: Boolean) -> Unit,
     ): SharedPreferences.OnSharedPreferenceChangeListener {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/manga/MangaCachedOnlyChapterFilterTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/manga/MangaCachedOnlyChapterFilterTest.kt
@@ -1,0 +1,80 @@
+package eu.kanade.tachiyomi.ui.manga
+
+import eu.kanade.tachiyomi.data.download.model.Download
+import eu.kanade.tachiyomi.source.Source
+import kotlinx.serialization.json.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.manga.model.Manga
+
+class MangaCachedOnlyChapterFilterTest {
+
+    @Test
+    fun `cached only keeps downloads and complete epub caches`() {
+        val state = successState(
+            manga = Manga.create(),
+            cachedOnly = true,
+        )
+
+        assertEquals(setOf(1L, 2L), state.processedChapters.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `download filter does not treat complete epub cache as manual download`() {
+        val state = successState(
+            manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_DOWNLOADED),
+            cachedOnly = false,
+        )
+
+        assertEquals(setOf(1L), state.processedChapters.map { it.id }.toSet())
+    }
+
+    @Test
+    fun `not downloaded filter retains cached epub chapter`() {
+        val state = successState(
+            manga = Manga.create().copy(chapterFlags = Manga.CHAPTER_SHOW_NOT_DOWNLOADED),
+            cachedOnly = false,
+        )
+
+        assertEquals(setOf(2L, 3L), state.processedChapters.map { it.id }.toSet())
+    }
+
+    private fun successState(
+        manga: Manga,
+        cachedOnly: Boolean,
+    ) = MangaScreenModel.State.Success(
+        manga = manga,
+        source = TestSource,
+        isFromSource = false,
+        chapters = listOf(
+            chapterItem(id = 1L, downloadState = Download.State.DOWNLOADED),
+            chapterItem(id = 2L, isCompleteEpubCached = true),
+            chapterItem(id = 3L),
+        ),
+        availableScanlators = emptySet(),
+        excludedScanlators = emptySet(),
+        cachedOnly = cachedOnly,
+    )
+
+    private fun chapterItem(
+        id: Long,
+        downloadState: Download.State = Download.State.NOT_DOWNLOADED,
+        isCompleteEpubCached: Boolean = false,
+    ) = ChapterList.Item(
+        chapter = Chapter.create().copy(
+            id = id,
+            chapterNumber = id.toDouble(),
+            sourceOrder = id,
+            memo = JsonObject(emptyMap()),
+        ),
+        downloadState = downloadState,
+        downloadProgress = 0,
+        isCompleteEpubCached = isCompleteEpubCached,
+    )
+
+    private data object TestSource : Source {
+        override val id = 1L
+        override val name = "Test"
+    }
+}

--- a/app/src/test/java/koharia/komga/api/dto/KomgaOfflineFilterMetadataTest.kt
+++ b/app/src/test/java/koharia/komga/api/dto/KomgaOfflineFilterMetadataTest.kt
@@ -1,0 +1,96 @@
+package koharia.komga.api.dto
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaOfflineFilterMetadataTest {
+
+    @Test
+    fun `series details keep fields needed by cached filters`() {
+        val series = SeriesDto(
+            id = "series-id",
+            libraryId = "library-id",
+            name = "Series",
+            created = "2026-01-01T00:00:00Z",
+            lastModified = "2026-02-01T00:00:00Z",
+            fileLastModified = "2026-02-01T00:00:00Z",
+            booksCount = 1,
+            metadata = SeriesMetadataDto(
+                status = "ENDED",
+                title = "Displayed title",
+                titleSort = "Sortable title",
+                publisher = "Publisher",
+                genres = setOf("Fantasy"),
+                tags = setOf("Award winner"),
+            ),
+            booksMetadata = BookMetadataAggregationDto(
+                authors = listOf(AuthorDto("Writer", "writer"), AuthorDto("Artist", "penciller")),
+                tags = setOf("Book tag"),
+            ),
+        )
+
+        val metadata = requireNotNull(series.toSManga("https://komga.test").memo.offlineFilterMetadata())
+
+        assertEquals("ENDED", metadata.status)
+        assertEquals(setOf("Fantasy"), metadata.genres)
+        assertEquals(setOf("Award winner", "Book tag"), metadata.tags)
+        assertEquals("Publisher", metadata.publisher)
+        assertEquals(
+            setOf(KomgaOfflineAuthor("Writer", "writer"), KomgaOfflineAuthor("Artist", "penciller")),
+            metadata.authors,
+        )
+        assertEquals("Sortable title", metadata.titleSort)
+        assertEquals("2026-01-01T00:00:00Z", metadata.createdDate)
+        assertEquals("2026-02-01T00:00:00Z", metadata.lastModifiedDate)
+        assertTrue(metadata.oneShot == true)
+    }
+
+    @Test
+    fun `book and read list details keep their supported cached sort metadata`() {
+        val book = BookDto(
+            id = "book-id",
+            name = "book.epub",
+            created = "2026-03-01T00:00:00Z",
+            lastModified = "2026-04-01T00:00:00Z",
+            fileLastModified = "2026-04-01T00:00:00Z",
+            metadata = BookMetadataDto(
+                title = "Book title",
+                tags = setOf("Novel"),
+                authors = listOf(AuthorDto("Author", "writer")),
+            ),
+        ).toSManga("https://komga.test").memo.offlineFilterMetadata()
+        val readList = ReadListDto(
+            id = "list-id",
+            name = "Reading order",
+            createdDate = "2026-05-01T00:00:00Z",
+            lastModifiedDate = "2026-06-01T00:00:00Z",
+        ).toSManga("https://komga.test").memo.offlineFilterMetadata()
+
+        assertEquals(setOf("Novel"), book?.tags)
+        assertEquals(setOf(KomgaOfflineAuthor("Author", "writer")), book?.authors)
+        assertEquals("Book title", book?.titleSort)
+        assertEquals("Reading order", readList?.titleSort)
+        assertEquals("2026-05-01T00:00:00Z", readList?.createdDate)
+    }
+
+    @Test
+    fun `offline detail metadata merges without dropping durable library membership`() {
+        val localMemo = buildJsonObject {
+            put(KOMGA_LIBRARY_IDS_MEMO_KEY, JsonArray(listOf(JsonPrimitive("library-a"), JsonPrimitive("library-b"))))
+        }
+        val remoteMemo = buildJsonObject {}
+            .withOfflineFilterMetadata(KomgaOfflineFilterMetadata(titleSort = "Title"))
+
+        val merged = requireNotNull(mergeKomgaOfflineMemo(localMemo, remoteMemo))
+
+        assertTrue(KOMGA_LIBRARY_IDS_MEMO_KEY in merged)
+        assertEquals("Title", merged.offlineFilterMetadata()?.titleSort)
+        assertFalse(merged.isEmpty())
+    }
+}

--- a/app/src/test/java/koharia/komga/api/dto/KomgaOfflineFilterMetadataTest.kt
+++ b/app/src/test/java/koharia/komga/api/dto/KomgaOfflineFilterMetadataTest.kt
@@ -3,6 +3,7 @@ package koharia.komga.api.dto
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -92,5 +93,39 @@ class KomgaOfflineFilterMetadataTest {
         assertTrue(KOMGA_LIBRARY_IDS_MEMO_KEY in merged)
         assertEquals("Title", merged.offlineFilterMetadata()?.titleSort)
         assertFalse(merged.isEmpty())
+    }
+
+    @Test
+    fun `series details replace stale plural library membership`() {
+        val localMemo = buildJsonObject {
+            put(KOMGA_LIBRARY_ID_MEMO_KEY, "library-a")
+            put(KOMGA_LIBRARY_IDS_MEMO_KEY, JsonArray(listOf(JsonPrimitive("library-a"))))
+        }
+        val remoteMemo = buildJsonObject {
+            put(KOMGA_LIBRARY_ID_MEMO_KEY, "library-b")
+        }.withOfflineFilterMetadata(KomgaOfflineFilterMetadata(titleSort = "Moved series"))
+
+        val merged = requireNotNull(mergeKomgaOfflineMemo(localMemo, remoteMemo))
+
+        assertEquals("library-b", merged[KOMGA_LIBRARY_ID_MEMO_KEY]?.jsonPrimitive?.content)
+        assertEquals(
+            JsonArray(listOf(JsonPrimitive("library-b"))),
+            merged[KOMGA_LIBRARY_IDS_MEMO_KEY],
+        )
+    }
+
+    @Test
+    fun `read list details preserve plural library membership`() {
+        val libraryIds = JsonArray(listOf(JsonPrimitive("library-a"), JsonPrimitive("library-b")))
+        val localMemo = buildJsonObject {
+            put(KOMGA_LIBRARY_IDS_MEMO_KEY, libraryIds)
+        }
+        val remoteMemo = buildJsonObject {}
+            .withOfflineFilterMetadata(KomgaOfflineFilterMetadata(titleSort = "Reading order"))
+
+        val merged = requireNotNull(mergeKomgaOfflineMemo(localMemo, remoteMemo))
+
+        assertEquals(libraryIds, merged[KOMGA_LIBRARY_IDS_MEMO_KEY])
+        assertFalse(KOMGA_LIBRARY_ID_MEMO_KEY in merged)
     }
 }

--- a/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
+++ b/app/src/test/java/koharia/komga/download/KomgaChapterMemoTest.kt
@@ -35,6 +35,21 @@ class KomgaChapterMemoTest {
     }
 
     @Test
+    fun `book memo keeps library membership for offline read lists`() {
+        val book = BookDto(
+            id = "book-id",
+            libraryId = "library-id",
+            name = "book.cbz",
+            fileLastModified = "2026-08-11T00:00:00Z",
+            metadata = BookMetadataDto(title = "Book"),
+        )
+
+        val memo = KomgaChapterMemo.buildMemo("https://komga.test", book)
+
+        assertEquals("library-id", KomgaChapterMemo.libraryId(memo))
+    }
+
+    @Test
     fun `legacy memo without page compatibility remains unknown`() {
         val memo = buildJsonObject {
             put(KomgaChapterMemo.IS_EPUB, true)

--- a/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
+++ b/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
@@ -1,0 +1,93 @@
+package koharia.komga.ui.library
+
+import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import koharia.core.common.extensions.EMPTY
+import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.manga.model.Manga
+
+class KomgaCachedOnlySearchTest {
+
+    @Test
+    fun `cached search matches local metadata without case sensitivity`() {
+        val manga = manga(
+            title = "The Sandman",
+            author = "Neil Gaiman",
+            genres = listOf("Fantasy"),
+        )
+
+        assertTrue(manga.matchesCachedOnlyQuery("sand"))
+        assertTrue(manga.matchesCachedOnlyQuery("GAIMAN"))
+        assertTrue(manga.matchesCachedOnlyQuery("fantasy"))
+        assertFalse(manga.matchesCachedOnlyQuery("science"))
+    }
+
+    @Test
+    fun `blank cached search includes every local item`() {
+        assertTrue(manga(title = "Anything").matchesCachedOnlyQuery(null))
+        assertTrue(manga(title = "Anything").matchesCachedOnlyQuery("  "))
+    }
+
+    @Test
+    fun `cached paging is complete in every direction`() {
+        assertTrue(CACHED_ONLY_LOAD_STATES.refresh.endOfPaginationReached)
+        assertTrue(CACHED_ONLY_LOAD_STATES.prepend.endOfPaginationReached)
+        assertTrue(CACHED_ONLY_LOAD_STATES.append.endOfPaginationReached)
+    }
+
+    @Test
+    fun `cached library filter keeps items in their assigned shelf`() {
+        val comic = manga(title = "Comic", libraryId = "comic-library")
+        val book = manga(title = "Book", libraryId = "book-library")
+
+        assertTrue(comic.matchesCachedLibraryFilter(setOf("comic-library")))
+        assertFalse(comic.matchesCachedLibraryFilter(setOf("book-library")))
+        assertTrue(book.matchesCachedLibraryFilter(setOf("book-library")))
+        assertTrue(book.matchesCachedLibraryFilter(emptySet()))
+    }
+
+    @Test
+    fun `cached library filter excludes legacy items with unknown shelf`() {
+        assertFalse(manga(title = "Unknown").matchesCachedLibraryFilter(setOf("comic-library")))
+    }
+
+    private fun manga(
+        title: String,
+        author: String? = null,
+        genres: List<String>? = null,
+        libraryId: String? = null,
+    ) = Manga(
+        id = 1L,
+        source = 1L,
+        favorite = false,
+        lastUpdate = 0L,
+        nextUpdate = 0L,
+        fetchInterval = 0,
+        dateAdded = 0L,
+        viewerFlags = 0L,
+        chapterFlags = 0L,
+        coverLastModified = 0L,
+        url = "https://komga.test/api/v1/series/1",
+        title = title,
+        artist = null,
+        author = author,
+        description = null,
+        genre = genres,
+        status = 0L,
+        thumbnailUrl = null,
+        updateStrategy = UpdateStrategy.ALWAYS_UPDATE,
+        initialized = true,
+        lastModifiedAt = 0L,
+        favoriteModifiedAt = null,
+        version = 0L,
+        notes = "",
+        memo = libraryId?.let {
+            buildJsonObject { put(KOMGA_LIBRARY_ID_MEMO_KEY, it) }
+        } ?: JsonObject.EMPTY,
+    )
+}

--- a/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
+++ b/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
@@ -1,18 +1,33 @@
 package koharia.komga.ui.library
 
+import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import koharia.core.common.extensions.EMPTY
+import koharia.komga.api.dto.KOMGA_LIBRARY_IDS_MEMO_KEY
 import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
+import koharia.komga.api.dto.KomgaOfflineAuthor
+import koharia.komga.api.dto.KomgaOfflineFilterMetadata
+import koharia.komga.api.dto.withOfflineFilterMetadata
+import koharia.source.komga.AuthorGroup
+import koharia.source.komga.OneshotFilter
+import koharia.source.komga.ReadingStateGroup
+import koharia.source.komga.SeriesSort
 import koharia.source.komga.TYPE_ALL_INDEX
 import koharia.source.komga.TYPE_BOOKS_INDEX
 import koharia.source.komga.TYPE_READ_LISTS_INDEX
 import koharia.source.komga.TYPE_SERIES_INDEX
+import koharia.source.komga.TypeSelect
+import koharia.source.komga.UriMultiSelectFilter
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.model.Chapter
 import tachiyomi.domain.manga.model.Manga
 
 class KomgaCachedOnlySearchTest {
@@ -61,6 +76,19 @@ class KomgaCachedOnlySearchTest {
     }
 
     @Test
+    fun `cached read list matches any library represented by its books`() {
+        val readList = manga(
+            title = "Mixed read list",
+            libraryIds = setOf("comic-library", "book-library"),
+            url = "https://komga.test/api/v1/readlists/1",
+        )
+
+        assertTrue(readList.matchesCachedLibraryFilter(setOf("comic-library")))
+        assertTrue(readList.matchesCachedLibraryFilter(setOf("book-library")))
+        assertFalse(readList.matchesCachedLibraryFilter(setOf("other-library")))
+    }
+
+    @Test
     fun `cached content type follows Komga URL kind`() {
         val series = manga(title = "Series", url = "https://komga.test/api/v1/series/1")
         val readList = manga(title = "Read list", url = "https://komga.test/api/v1/readlists/2")
@@ -75,14 +103,145 @@ class KomgaCachedOnlySearchTest {
         assertTrue(book.matchesCachedContentType(TYPE_ALL_INDEX))
     }
 
+    @Test
+    fun `cached advanced filters use structured detail metadata`() {
+        val manga = manga(
+            title = "Series",
+            offlineMetadata = KomgaOfflineFilterMetadata(
+                status = "ENDED",
+                genres = setOf("Fantasy"),
+                tags = setOf("Award winner"),
+                publisher = "Publisher",
+                authors = setOf(KomgaOfflineAuthor("Writer", "writer")),
+                oneShot = true,
+            ),
+        )
+
+        assertTrue(
+            manga.matchesCachedAdvancedFilters(
+                CachedAdvancedFilterSelection(
+                    statuses = setOf("ENDED"),
+                    genres = setOf("Fantasy"),
+                    tags = setOf("Award winner"),
+                    publishers = setOf("Publisher"),
+                    authors = setOf(KomgaOfflineAuthor("Writer", "writer")),
+                    oneShot = true,
+                ),
+            ),
+        )
+        assertFalse(
+            manga.matchesCachedAdvancedFilters(
+                CachedAdvancedFilterSelection(tags = setOf("Missing")),
+            ),
+        )
+    }
+
+    @Test
+    fun `cached reading status follows local chapters`() {
+        val manga = manga(title = "Series")
+
+        assertTrue(
+            manga.matchesCachedAdvancedFilters(
+                CachedAdvancedFilterSelection(readingStatuses = setOf("UNREAD")),
+                chapters = listOf(chapter(read = false)),
+            ),
+        )
+        assertTrue(
+            manga.matchesCachedAdvancedFilters(
+                CachedAdvancedFilterSelection(readingStatuses = setOf("IN_PROGRESS")),
+                chapters = listOf(chapter(read = true), chapter(read = false)),
+            ),
+        )
+        assertTrue(
+            manga.matchesCachedAdvancedFilters(
+                CachedAdvancedFilterSelection(readingStatuses = setOf("READ")),
+                chapters = listOf(chapter(read = true)),
+            ),
+        )
+    }
+
+    @Test
+    fun `cached sort uses detail title and timestamps`() {
+        val laterTitle = manga(
+            id = 1L,
+            title = "Displayed A",
+            offlineMetadata = KomgaOfflineFilterMetadata(
+                titleSort = "Zulu",
+                createdDate = "2026-02-01T00:00:00Z",
+            ),
+        )
+        val earlierTitle = manga(
+            id = 2L,
+            title = "Displayed Z",
+            offlineMetadata = KomgaOfflineFilterMetadata(
+                titleSort = "Alpha",
+                createdDate = "2026-01-01T00:00:00Z",
+            ),
+        )
+
+        assertEquals(
+            listOf(earlierTitle, laterTitle),
+            listOf(laterTitle, earlierTitle).sortedForCachedFilters(
+                CachedAdvancedFilterSelection(sortIndex = 1),
+                randomSeed = 0,
+            ),
+        )
+        assertEquals(
+            listOf(earlierTitle, laterTitle),
+            listOf(laterTitle, earlierTitle).sortedForCachedFilters(
+                CachedAdvancedFilterSelection(sortIndex = 2),
+                randomSeed = 0,
+            ),
+        )
+    }
+
+    @Test
+    fun `cached filter options are derived from persisted detail metadata`() {
+        val cachedManga = manga(
+            title = "Series",
+            offlineMetadata = KomgaOfflineFilterMetadata(
+                tags = setOf("Offline tag"),
+                authors = setOf(KomgaOfflineAuthor("Offline writer", "writer")),
+            ),
+        )
+        val filters = FilterList(
+            UriMultiSelectFilter("Tags", emptyList()),
+            SeriesSort(),
+        ).withCachedMetadataOptions(listOf(cachedManga))
+
+        assertEquals(
+            listOf("Offline tag"),
+            filters.filterIsInstance<UriMultiSelectFilter>().single().state.map { it.id },
+        )
+        assertEquals(
+            listOf("Offline writer"),
+            filters.filterIsInstance<AuthorGroup>().single().state.map { it.author.name },
+        )
+    }
+
+    @Test
+    fun `cached one shot filter only applies to series`() {
+        val type = TypeSelect().apply { state = TYPE_BOOKS_INDEX }
+        val reading = ReadingStateGroup().apply {
+            state.filterIsInstance<OneshotFilter>().single().state = true
+        }
+
+        val selection = FilterList(type, reading).cachedAdvancedFilterSelection()
+
+        assertFalse(selection.oneShot)
+    }
+
     private fun manga(
+        id: Long = 1L,
         title: String,
         author: String? = null,
         genres: List<String>? = null,
         libraryId: String? = null,
+        libraryIds: Set<String> = emptySet(),
+        offlineMetadata: KomgaOfflineFilterMetadata? = null,
         url: String = "https://komga.test/api/v1/series/1",
     ) = Manga(
-        id = 1L,
+        id = id,
         source = 1L,
         favorite = false,
         lastUpdate = 0L,
@@ -106,8 +265,15 @@ class KomgaCachedOnlySearchTest {
         favoriteModifiedAt = null,
         version = 0L,
         notes = "",
-        memo = libraryId?.let {
-            buildJsonObject { put(KOMGA_LIBRARY_ID_MEMO_KEY, it) }
-        } ?: JsonObject.EMPTY,
+        memo = buildJsonObject {
+            libraryId?.let { put(KOMGA_LIBRARY_ID_MEMO_KEY, it) }
+            if (libraryIds.isNotEmpty()) {
+                put(KOMGA_LIBRARY_IDS_MEMO_KEY, JsonArray(libraryIds.map(::JsonPrimitive)))
+            }
+        }.let { memo ->
+            offlineMetadata?.let { memo.withOfflineFilterMetadata(it) } ?: memo
+        }.takeUnless { it.isEmpty() } ?: JsonObject.EMPTY,
     )
+
+    private fun chapter(read: Boolean) = Chapter.create().copy(read = read)
 }

--- a/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
+++ b/app/src/test/java/koharia/komga/ui/library/KomgaCachedOnlySearchTest.kt
@@ -3,6 +3,10 @@ package koharia.komga.ui.library
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import koharia.core.common.extensions.EMPTY
 import koharia.komga.api.dto.KOMGA_LIBRARY_ID_MEMO_KEY
+import koharia.source.komga.TYPE_ALL_INDEX
+import koharia.source.komga.TYPE_BOOKS_INDEX
+import koharia.source.komga.TYPE_READ_LISTS_INDEX
+import koharia.source.komga.TYPE_SERIES_INDEX
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -56,11 +60,27 @@ class KomgaCachedOnlySearchTest {
         assertFalse(manga(title = "Unknown").matchesCachedLibraryFilter(setOf("comic-library")))
     }
 
+    @Test
+    fun `cached content type follows Komga URL kind`() {
+        val series = manga(title = "Series", url = "https://komga.test/api/v1/series/1")
+        val readList = manga(title = "Read list", url = "https://komga.test/api/v1/readlists/2")
+        val book = manga(title = "Book", url = "https://komga.test/api/v1/books/3")
+
+        assertTrue(series.matchesCachedContentType(TYPE_SERIES_INDEX))
+        assertFalse(series.matchesCachedContentType(TYPE_BOOKS_INDEX))
+        assertTrue(readList.matchesCachedContentType(TYPE_READ_LISTS_INDEX))
+        assertTrue(book.matchesCachedContentType(TYPE_BOOKS_INDEX))
+        assertTrue(series.matchesCachedContentType(TYPE_ALL_INDEX))
+        assertTrue(readList.matchesCachedContentType(TYPE_ALL_INDEX))
+        assertTrue(book.matchesCachedContentType(TYPE_ALL_INDEX))
+    }
+
     private fun manga(
         title: String,
         author: String? = null,
         genres: List<String>? = null,
         libraryId: String? = null,
+        url: String = "https://komga.test/api/v1/series/1",
     ) = Manga(
         id = 1L,
         source = 1L,
@@ -72,7 +92,7 @@ class KomgaCachedOnlySearchTest {
         viewerFlags = 0L,
         chapterFlags = 0L,
         coverLastModified = 0L,
-        url = "https://komga.test/api/v1/series/1",
+        url = url,
         title = title,
         artist = null,
         author = author,

--- a/app/src/test/java/koharia/source/komga/KomgaMetadataCacheStoreTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaMetadataCacheStoreTest.kt
@@ -46,6 +46,41 @@ class KomgaMetadataCacheStoreTest {
         assertFalse(store.isEligible(nonJson))
     }
 
+    @Test
+    fun `read list library membership comes from its cached books`() {
+        val store = KomgaMetadataCacheStore(context())
+        val readListUrl = "https://komga.test/api/v1/readlists/read-list-id"
+        val booksRequest = Request.Builder()
+            .url("$readListUrl/books?unpaged=true&media_status=READY&deleted=false")
+            .build()
+        val body = """
+            {
+              "content": [
+                { "id": "book-1", "libraryId": "library-a" },
+                { "id": "book-2", "libraryId": "library-b" },
+                { "id": "book-3", "libraryId": "library-a" }
+              ]
+            }
+        """.trimIndent()
+
+        store.save(booksRequest, response(booksRequest, body)).close()
+
+        assertEquals(setOf("library-a", "library-b"), store.findLibraryIds(readListUrl))
+    }
+
+    @Test
+    fun `malformed read list books cache has no library membership`() {
+        val store = KomgaMetadataCacheStore(context())
+        val readListUrl = "https://komga.test/api/v1/readlists/read-list-id"
+        val booksRequest = Request.Builder()
+            .url("$readListUrl/books?unpaged=true&media_status=READY&deleted=false")
+            .build()
+
+        store.save(booksRequest, response(booksRequest, """{ "content": {} }""")).close()
+
+        assertEquals(emptySet<String>(), store.findLibraryIds(readListUrl))
+    }
+
     private fun context(): Context = mockk {
         every { getExternalFilesDir(any()) } returns File(tempDir, "external")
         every { cacheDir } returns File(tempDir, "legacy")

--- a/app/src/test/java/koharia/source/komga/KomgaOfflineModeTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaOfflineModeTest.kt
@@ -1,0 +1,20 @@
+package koharia.source.komga
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaOfflineModeTest {
+
+    @Test
+    fun `cached-only mode never permits Komga network access`() {
+        assertFalse(shouldUseKomgaNetwork(cachedOnly = true, isOnline = true))
+        assertFalse(shouldUseKomgaNetwork(cachedOnly = true, isOnline = false))
+    }
+
+    @Test
+    fun `normal mode follows device connectivity`() {
+        assertTrue(shouldUseKomgaNetwork(cachedOnly = false, isOnline = true))
+        assertFalse(shouldUseKomgaNetwork(cachedOnly = false, isOnline = false))
+    }
+}

--- a/app/src/test/java/koharia/source/komga/KomgaOfflineModeTest.kt
+++ b/app/src/test/java/koharia/source/komga/KomgaOfflineModeTest.kt
@@ -1,5 +1,6 @@
 package koharia.source.komga
 
+import koharia.epub.service.shouldUseKomgaReadiumNetwork
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -16,5 +17,11 @@ class KomgaOfflineModeTest {
     fun `normal mode follows device connectivity`() {
         assertTrue(shouldUseKomgaNetwork(cachedOnly = false, isOnline = true))
         assertFalse(shouldUseKomgaNetwork(cachedOnly = false, isOnline = false))
+    }
+
+    @Test
+    fun `cached-only mode blocks Readium network access`() {
+        assertFalse(shouldUseKomgaReadiumNetwork(cachedOnly = true))
+        assertTrue(shouldUseKomgaReadiumNetwork(cachedOnly = false))
     }
 }

--- a/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/manga/MangaRepositoryImpl.kt
@@ -59,6 +59,12 @@ class MangaRepositoryImpl(
             .subscribeToOneOrNull()
     }
 
+    override fun getMangaBySourceIdAsFlow(sourceId: Long): Flow<List<Manga>> {
+        return database.mangasQueries
+            .getMangaBySourceId(sourceId, MangaMapper::mapManga)
+            .subscribeToList()
+    }
+
     override suspend fun getFavorites(): List<Manga> {
         return database.mangasQueries
             .getFavorites(MangaMapper::mapManga)

--- a/data/src/main/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/main/sqldelight/tachiyomi/data/mangas.sq
@@ -77,6 +77,12 @@ WHERE url = :url
 AND source = :source
 LIMIT 1;
 
+getMangaBySourceId:
+SELECT *
+FROM mangas
+WHERE source = :sourceId
+ORDER BY title COLLATE NOCASE;
+
 getFavorites:
 SELECT *
 FROM mangas

--- a/domain/src/main/java/koharia/domain/manga/model/SManga.kt
+++ b/domain/src/main/java/koharia/domain/manga/model/SManga.kt
@@ -16,5 +16,6 @@ fun SManga.toDomainManga(sourceId: Long): Manga {
         updateStrategy = update_strategy,
         initialized = initialized,
         source = sourceId,
+        memo = memo,
     )
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/interactor/GetManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/interactor/GetManga.kt
@@ -26,4 +26,8 @@ class GetManga(
     fun subscribe(url: String, sourceId: Long): Flow<Manga?> {
         return mangaRepository.getMangaByUrlAndSourceIdAsFlow(url, sourceId)
     }
+
+    fun subscribeBySourceId(sourceId: Long): Flow<List<Manga>> {
+        return mangaRepository.getMangaBySourceIdAsFlow(sourceId)
+    }
 }

--- a/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/manga/repository/MangaRepository.kt
@@ -20,6 +20,8 @@ interface MangaRepository {
 
     fun getMangaByUrlAndSourceIdAsFlow(url: String, sourceId: Long): Flow<Manga?>
 
+    fun getMangaBySourceIdAsFlow(sourceId: Long): Flow<List<Manga>>
+
     suspend fun getFavorites(): List<Manga>
 
     suspend fun getReadMangaNotInLibrary(): List<Manga>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -783,7 +783,7 @@
     <string name="fdroid_warning">F-Droid builds are not officially supported.\nTap to learn more.</string>
     <string name="label_downloaded_only">Downloaded only</string>
     <string name="komga_label_cached_only">Cached only</string>
-    <string name="komga_cached_only_summary">Only show content available offline</string>
+    <string name="komga_cached_only_summary">Only show locally cached content and pause server connections</string>
     <string name="pref_incognito_mode">Incognito mode</string>
     <string name="pref_incognito_mode_summary">Pauses reading history</string>
     <string name="pref_incognito_mode_extension_summary">Pause reading history for extension</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -450,7 +450,7 @@
     <string name="in_library">在书架中</string>
     <string name="label_downloaded_only">仅限已下载内容</string>
     <string name="komga_label_cached_only">仅显示已缓存</string>
-    <string name="komga_cached_only_summary">仅显示已完成离线缓存的内容</string>
+    <string name="komga_cached_only_summary">仅显示已完成离线缓存的内容，并暂停服务器连接</string>
     <string name="creating_backup_error">备份失败</string>
     <string name="restoring_backup_canceled">已取消还原</string>
     <string name="restoring_backup_error">还原备份失败</string>


### PR DESCRIPTION
## 中文

### 改动内容

- “仅显示缓存”模式改为从本地数据库枚举可离线作品，不再依赖 Komga 远程分页。
- 将手动下载和完整 EPUB 缓存都识别为可离线内容，同时保持两类状态相互独立。
- 在该模式下禁止 Komga 元数据、阅读器资源等网络回退，并暂停 SSE 连接。
- 为本地 Paging 明确发布加载完成状态，消除漫画和书籍页面持续转圈。
- 保存并回填作品所属的 Komga `libraryId`，恢复漫画、书籍、内容类型及具体书架筛选。
- 修复书籍列表能看到缓存、详情页却显示 0 章的问题，并同步修复阅读器上下章筛选。
- 补充仅缓存模式、书架分类和章节离线可用性回归测试。

### 问题原因

原实现仍会创建 Komga 分页并尝试连接服务器。迁移到本地枚举后，`PagingData.from` 未声明分页结束状态，本地作品也没有完整参与 Komga 库与内容类型筛选。此外，详情页和阅读器把全局“仅显示缓存”直接等同于“仅显示手动下载”，因此位于独立缓存目录中的完整 EPUB 会被过滤。

### 用户影响

开启“仅显示缓存”后，应用可以在服务器不可达时直接显示并打开本地内容，不会建立 Komga 网络或 SSE 连接。漫画、书籍、内容类型和具体书架分类继续生效；书籍详情会显示手动下载或具有完整 EPUB 缓存的章节。

### 验证

- `spotlessCheck`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- 12 项仅缓存模式针对性单元测试
- Android 虚拟机断网回归：漫画页、书籍页和具体书架正常，无持续加载圈
- “义妹生活”详情由 0 章恢复为 2 个完整缓存章节，并可离线进入 EPUB 阅读器
- 两部缓存漫画详情均正常显示其本地章节

## English

### Changes

- Enumerate offline-capable titles from the local database in cached-only mode instead of relying on Komga remote paging.
- Treat both manual downloads and complete EPUB caches as offline-capable while keeping their states distinct.
- Block metadata, reader-resource, and other Komga network fallbacks and suspend SSE connections in cached-only mode.
- Publish terminal local Paging load states to remove persistent loading indicators.
- Persist and backfill each title's Komga `libraryId` so comic, book, content-type, and individual shelf filters remain effective.
- Fix cached books appearing in the list but showing zero chapters in details, including reader chapter navigation.
- Add regression coverage for cached-only behavior, shelf classification, and chapter offline availability.

### Root cause

The previous implementation still created Komga paging requests and attempted to contact the server. After switching to local enumeration, `PagingData.from` did not declare terminal load states, and local titles bypassed parts of the Komga library and content-type filters. The details screen and reader also treated global cached-only mode as manual-download-only, filtering out complete EPUB files stored in the separate EPUB cache.

### User impact

Cached-only mode now lists and opens local content while the server is unavailable, without Komga network or SSE connections. Comic, book, content-type, and individual shelf classification remain effective, and book details retain chapters that are manually downloaded or have a complete EPUB cache.

### Validation

- `spotlessCheck`
- `:app:compileDebugKotlin`
- `:app:assembleDebug`
- 12 focused cached-only unit tests
- Offline Android emulator regression covering comic, book, and individual shelf views without persistent loading indicators
- “Days with My Stepsister” details restored from zero to two complete cached chapters, with successful offline EPUB opening
- Both cached comic details correctly displayed their local chapters
