### PR TITLE
修复 Komga 未读与进度同步 / Fix Komga unread and progress synchronization

### DIFF
--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -150,7 +150,7 @@ class DomainModule : InjektModule {
         addFactory { GetTracks(get()) }
         addFactory { InsertTrack(get()) }
         addFactory { SyncChapterProgressWithTrack(get(), get(), get()) }
-        addFactory {
+        addSingletonFactory {
             KomgaProgressSyncService(
                 get(),
                 get(),

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -150,7 +150,21 @@ class DomainModule : InjektModule {
         addFactory { GetTracks(get()) }
         addFactory { InsertTrack(get()) }
         addFactory { SyncChapterProgressWithTrack(get(), get(), get()) }
-        addFactory { KomgaProgressSyncService(get(), get(), get(), get(), get(), get(), get(), get()) }
+        addFactory {
+            KomgaProgressSyncService(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+            )
+        }
 
         addSingletonFactory<ChapterRepository> { ChapterRepositoryImpl(get()) }
         addFactory { GetChapter(get()) }

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -158,7 +158,7 @@ class DomainModule : InjektModule {
         addFactory { GetBookmarkedChaptersByMangaId(get()) }
         addFactory { GetChapterByUrlAndMangaId(get()) }
         addFactory { UpdateChapter(get()) }
-        addFactory { SetReadStatus(get(), get(), get(), get()) }
+        addFactory { SetReadStatus(get(), get(), get(), get(), get()) }
         addFactory { ShouldUpdateDbChapter() }
         addFactory { SyncChaptersWithSource(get(), get(), get(), get(), get(), get(), get(), get(), get()) }
         addFactory { GetAvailableScanlators(get()) }

--- a/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
+++ b/app/src/main/java/eu/kanade/domain/chapter/interactor/SetReadStatus.kt
@@ -1,6 +1,7 @@
 package eu.kanade.domain.chapter.interactor
 
 import eu.kanade.domain.download.interactor.DeleteDownload
+import koharia.connection.ConnectionReadStatusAdapter
 import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.core.common.util.system.logcat
@@ -10,12 +11,14 @@ import tachiyomi.domain.chapter.repository.ChapterRepository
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.manga.model.Manga
 import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.source.service.SourceManager
 
 class SetReadStatus(
     private val downloadPreferences: DownloadPreferences,
     private val deleteDownload: DeleteDownload,
     private val mangaRepository: MangaRepository,
     private val chapterRepository: ChapterRepository,
+    private val sourceManager: SourceManager,
 ) {
 
     private val mapper = { chapter: Chapter, read: Boolean ->
@@ -46,6 +49,8 @@ class SetReadStatus(
             return@withNonCancellableContext Result.InternalError(e)
         }
 
+        pushConnectionReadStatus(chaptersToUpdate, read)
+
         if (read && downloadPreferences.removeAfterMarkedAsRead.get()) {
             chaptersToUpdate
                 .groupBy { it.mangaId }
@@ -58,6 +63,31 @@ class SetReadStatus(
         }
 
         Result.Success
+    }
+
+    private suspend fun pushConnectionReadStatus(chapters: List<Chapter>, read: Boolean) {
+        chapters
+            .groupBy { it.mangaId }
+            .forEach { (mangaId, mangaChapters) ->
+                val manga = runCatching { mangaRepository.getMangaById(mangaId) }
+                    .onFailure { error ->
+                        logcat(LogPriority.WARN, error) {
+                            "Failed to resolve connection for read-status update mangaId=$mangaId"
+                        }
+                    }
+                    .getOrNull() ?: return@forEach
+                val adapter = sourceManager.get(manga.source) as? ConnectionReadStatusAdapter ?: return@forEach
+
+                mangaChapters.forEach { chapter ->
+                    runCatching {
+                        adapter.setChapterReadStatus(chapter.url, read)
+                    }.onFailure { error ->
+                        logcat(LogPriority.WARN, error) {
+                            "Failed to push connection read status for chapterId=${chapter.id}"
+                        }
+                    }
+                }
+            }
     }
 
     suspend fun await(mangaId: Long, read: Boolean): Result = withNonCancellableContext {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -129,9 +129,13 @@ class KomgaApi(
             }
         }
 
-    suspend fun getBookProgress(bookUrl: String): BookProgressSnapshot? =
+    suspend fun getBookProgress(bookUrl: String, sourceId: Long? = null): BookProgressSnapshot? =
         withIOContext {
-            val source = resolveSourceForUrl(bookUrl) ?: return@withIOContext null
+            val source = if (sourceId == null) {
+                resolveSourceForUrl(bookUrl)
+            } else {
+                resolveSource(sourceId)?.takeIf { bookUrl.belongsTo(it) }
+            } ?: return@withIOContext null
             with(json) {
                 val request = GET(bookUrl, source.currentHeaders())
                     .newBuilder()
@@ -263,6 +267,10 @@ class KomgaApi(
             .firstOrNull { it.baseUrl.trimEnd('/') == targetBaseUrl }
             ?: resolveSource(null)
                 ?.takeIf { url.startsWith(it.baseUrl.trimEnd('/')) }
+    }
+
+    private fun String.belongsTo(source: KomgaSource): Boolean {
+        return substringBefore("/api/").trimEnd('/') == source.baseUrl.trimEnd('/')
     }
 
     private fun SeriesDto.toTrack(): TrackSearch = TrackSearch.create(trackId).also {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaApi.kt
@@ -109,7 +109,10 @@ class KomgaApi(
             with(json) {
                 val baseUrl = url.substringBefore("/api/v1/series/")
                 source.client.newCall(
-                    GET("$url/books?unpaged=true&media_status=READY&deleted=false", source.currentHeaders()),
+                    GET("$url/books?unpaged=true&media_status=READY&deleted=false", source.currentHeaders())
+                        .newBuilder()
+                        .cacheControl(CacheControl.FORCE_NETWORK)
+                        .build(),
                 )
                     .awaitSuccess()
                     .parseAs<PageWrapperDto<BookDto>>()
@@ -139,6 +142,10 @@ class KomgaApi(
                     .parseAs<BookDto>()
                 BookProgressSnapshot(
                     url = bookUrl,
+                    seriesUrl = book.seriesId.takeIf(String::isNotBlank)?.let {
+                        "${bookUrl.substringBefore("/api/")}/api/v1/series/$it"
+                    },
+                    readProgress = book.readProgress,
                     pageIndex = book.readProgress?.page?.let { (it - 1).coerceAtLeast(0) },
                     totalPages = book.media?.pagesCount ?: 0,
                     completed = book.readProgress?.completed ?: false,
@@ -153,7 +160,10 @@ class KomgaApi(
             }
         }
 
-    suspend fun getInProgressBookProgress(sourceId: Long? = null): List<SeriesBookProgress> =
+    suspend fun getInProgressBookProgress(
+        sourceId: Long? = null,
+        includeCompleted: Boolean = false,
+    ): List<SeriesBookProgress> =
         withIOContext {
             val source = resolveSource(sourceId) ?: return@withIOContext emptyList()
             with(json) {
@@ -162,12 +172,15 @@ class KomgaApi(
                     logcat(LogPriority.WARN) { "KomgaApi.getInProgressBookProgress: blank server base URL" }
                     emptyList()
                 } else {
+                    val readStatus = if (includeCompleted) "" else "&read_status=IN_PROGRESS"
                     source.client
                         .newCall(
                             GET(
-                                "$baseUrl/api/v1/books?unpaged=true&read_status=IN_PROGRESS&deleted=false",
+                                "$baseUrl/api/v1/books?unpaged=true$readStatus&deleted=false",
                                 source.currentHeaders(),
-                            ),
+                            ).newBuilder()
+                                .cacheControl(CacheControl.FORCE_NETWORK)
+                                .build(),
                         )
                         .awaitSuccess()
                         .parseAs<PageWrapperDto<BookDto>>()
@@ -272,6 +285,8 @@ class KomgaApi(
 
     data class BookProgressSnapshot(
         val url: String,
+        val seriesUrl: String?,
+        val readProgress: BookReadProgressDto?,
         val pageIndex: Int?,
         val totalPages: Int,
         val completed: Boolean,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -4,9 +4,15 @@ import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.track.TrackerManager
 import koharia.connection.ConnectionEpubProgressAdapter
+import koharia.domain.epub.interactor.GetEpubProgress
+import koharia.domain.epub.interactor.GetEpubRemoteProgressCache
+import koharia.domain.epub.interactor.UpsertEpubRemoteProgressCache
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.model.EpubRemoteProgressCache
 import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
@@ -33,6 +39,9 @@ class KomgaProgressSyncService(
     private val syncChaptersWithSource: SyncChaptersWithSource,
     private val sourceManager: SourceManager,
     private val komgaServerPreferences: KomgaServerPreferences,
+    private val getEpubProgress: GetEpubProgress,
+    private val getEpubRemoteProgressCache: GetEpubRemoteProgressCache,
+    private val upsertEpubRemoteProgressCache: UpsertEpubRemoteProgressCache,
 ) {
 
     private val syncMutex = Mutex()
@@ -41,7 +50,7 @@ class KomgaProgressSyncService(
         syncMutex.withLock {
             if (!manga.isKomgaSeries()) return@withLock
 
-            runCatching {
+            runCatchingCancellable {
                 val remoteBooks = trackerManager.komga.api.getSeriesBookProgress(manga.url)
                 applyRemoteProgress(
                     syncName = "series sync",
@@ -61,11 +70,7 @@ class KomgaProgressSyncService(
         chapterUrl: String,
     ): KomgaApi.BookProgressSnapshot? {
         if (sourceManager.get(sourceId) !is KomgaSource || !chapterUrl.contains("/api/v1/books/")) return null
-        return runCatching {
-            trackerManager.komga.api.getBookProgress(chapterUrl)
-        }.onFailure { error ->
-            logcat(LogPriority.WARN, error) { "Failed to pull Komga page progress for $chapterUrl" }
-        }.getOrNull()
+        return trackerManager.komga.api.getBookProgress(chapterUrl, sourceId)
     }
 
     /**
@@ -80,15 +85,16 @@ class KomgaProgressSyncService(
         syncMutex.withLock {
             if (sourceManager.get(sourceId) !is KomgaSource || !chapterUrl.contains("/api/v1/books/")) return@withLock
 
-            runCatching {
-                val remote = trackerManager.komga.api.getBookProgress(chapterUrl) ?: return@runCatching
-                val seriesUrl = remote.seriesUrl ?: return@runCatching
+            runCatchingCancellable {
+                val remote = trackerManager.komga.api.getBookProgress(chapterUrl, sourceId)
+                    ?: return@runCatchingCancellable
+                val seriesUrl = remote.seriesUrl ?: return@runCatchingCancellable
                 val manga = mangaRepository.getMangaByUrlAndSourceId(seriesUrl, sourceId)
                     ?: run {
                         logcat(LogPriority.INFO) {
                             "Komga book sync: local series is not indexed sourceId=$sourceId seriesUrl=$seriesUrl"
                         }
-                        return@runCatching
+                        return@runCatchingCancellable
                     }
                 applyRemoteProgress(
                     syncName = "book sync",
@@ -104,7 +110,7 @@ class KomgaProgressSyncService(
                     localMangaBySeriesUrl = mapOf(seriesUrl to manga),
                 )
 
-                if (remote.isEpub) {
+                if (remote.isEpub && remote.readProgress != null) {
                     syncBookEpubProgress(sourceId, manga, remote.url)
                 }
             }.onFailure { error ->
@@ -119,13 +125,45 @@ class KomgaProgressSyncService(
     suspend fun syncEpubProgressFromServer(sourceId: Long) {
         syncMutex.withLock {
             val source = sourceManager.get(sourceId) as? ConnectionEpubProgressAdapter ?: return@withLock
+            val remoteInProgressBookUrls = runCatchingCancellable {
+                trackerManager.komga.api.getInProgressBookProgress(sourceId)
+                    .asSequence()
+                    .filter { it.isEpub }
+                    .map { it.url.normalizedBookUrl() }
+                    .toSet()
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to load active Komga EPUB progress sourceId=$sourceId"
+                }
+            }.getOrDefault(emptySet())
+
             mangaRepository.getMangaBySourceId(sourceId).forEach { manga ->
                 val chapters = getChaptersByMangaId.await(manga.id)
                 if (chapters.isEmpty()) return@forEach
-                runCatching {
+                val localProgress = getEpubProgress.awaitByMangaId(manga.id)
+                val remoteProgress = getEpubRemoteProgressCache.awaitByMangaId(manga.id)
+                val remoteProgressByChapter = remoteProgress.associateBy(EpubRemoteProgressCache::chapterId)
+                val localProgressChapterIds = localProgress
+                    .filter { progress ->
+                        val remote = remoteProgressByChapter[progress.chapterId]
+                        remote == null || remote.hasProgress() || remote.checkedAt.before(progress.updatedAt)
+                    }
+                    .mapTo(mutableSetOf()) { it.chapterId }
+                val remoteProgressChapterIds = remoteProgress
+                    .filter(EpubRemoteProgressCache::hasProgress)
+                    .mapTo(mutableSetOf(), EpubRemoteProgressCache::chapterId)
+                val relevantChapters = selectRelevantKomgaEpubChapters(
+                    chapters = chapters,
+                    remoteInProgressBookUrls = remoteInProgressBookUrls,
+                    localProgressChapterIds = localProgressChapterIds,
+                    remoteProgressChapterIds = remoteProgressChapterIds,
+                )
+                if (relevantChapters.isEmpty()) return@forEach
+
+                runCatchingCancellable {
                     source.syncMangaEpubProgress(
                         mangaId = manga.id,
-                        chapters = chapters,
+                        chapters = relevantChapters,
                         force = true,
                     )
                 }.onFailure { error ->
@@ -146,13 +184,13 @@ class KomgaProgressSyncService(
     suspend fun syncHistoryFromServer(sourceId: Long, includeCompleted: Boolean = false) {
         syncMutex.withLock {
             if (sourceManager.get(sourceId) !is KomgaSource) return@withLock
-            runCatching {
+            runCatchingCancellable {
                 val remoteBooks = trackerManager.komga.api.getInProgressBookProgress(
                     sourceId = sourceId,
                     includeCompleted = includeCompleted,
                 )
                 if (remoteBooks.isEmpty()) {
-                    return@runCatching
+                    return@runCatchingCancellable
                 }
                 val remoteSeriesUrls = remoteBooks
                     .mapNotNull { it.seriesUrl }
@@ -184,7 +222,7 @@ class KomgaProgressSyncService(
         if (sourceManager.get(sourceId) !is KomgaSource || !chapterUrl.contains("/api/v1/books/")) return
         if (totalPages <= 0) return
 
-        runCatching {
+        runCatchingCancellable {
             val page = (pageIndex + 1).coerceIn(1, totalPages)
             val completed = page >= totalPages
             trackerManager.komga.api.updateBookProgress(
@@ -209,6 +247,9 @@ class KomgaProgressSyncService(
         val localChaptersByMangaId = mutableMapOf<Long, Map<String, Chapter>>()
         val historyUpdates = mutableListOf<HistoryUpdate>()
         val chapterUpdates = mutableListOf<ChapterUpdate>()
+        val epubCacheClears = mutableListOf<EpubRemoteProgressCache>()
+        val localEpubProgressByMangaId = mutableMapOf<Long, Map<Long, EpubProgress>>()
+        val remoteEpubProgressByMangaId = mutableMapOf<Long, Map<Long, EpubRemoteProgressCache>>()
         val missingSeriesSamples = mutableListOf<String>()
         val missingChapterSamples = mutableListOf<String>()
         var matchedSeriesCount = 0
@@ -252,18 +293,43 @@ class KomgaProgressSyncService(
                 }
 
             remote.toChapterUpdate(localChapter)?.let(chapterUpdates::add)
+            if (remote.isEpub && remote.readProgress == null) {
+                val localEpubProgress = localEpubProgressByMangaId[localManga.id]
+                    ?: getEpubProgress.awaitByMangaId(localManga.id)
+                        .associateBy(EpubProgress::chapterId)
+                        .also { localEpubProgressByMangaId[localManga.id] = it }
+                val remoteEpubProgress = remoteEpubProgressByMangaId[localManga.id]
+                    ?: getEpubRemoteProgressCache.awaitByMangaId(localManga.id)
+                        .associateBy(EpubRemoteProgressCache::chapterId)
+                        .also { remoteEpubProgressByMangaId[localManga.id] = it }
+                if (hasEpubProgressToClear(localEpubProgress[localChapter.id], remoteEpubProgress[localChapter.id])) {
+                    epubCacheClears += EpubRemoteProgressCache(
+                        chapterId = localChapter.id,
+                        mangaId = localManga.id,
+                        bookUrl = remote.url.normalizedBookUrl(),
+                        locatorJson = null,
+                        progression = null,
+                        positionIndex = null,
+                        modifiedAt = null,
+                        checkedAt = Date(),
+                        serverDate = null,
+                    )
+                }
+            }
         }
 
         if (chapterUpdates.isNotEmpty()) {
             updateChapter.awaitAll(chapterUpdates)
         }
         historyUpdates.forEach { upsertHistory.await(it) }
+        epubCacheClears.forEach { upsertEpubRemoteProgressCache.await(it) }
         if (missingSeriesCount > 0 || missingChapterCount > 0 || chapterUpdates.isNotEmpty() ||
             historyUpdates.isNotEmpty() ||
+            epubCacheClears.isNotEmpty() ||
             refreshedChapterSets > 0
         ) {
             logcat(LogPriority.INFO) {
-                "Komga $syncName result: remoteBooks=${remoteBooks.size}, matchedSeries=$matchedSeriesCount, matchedChapters=$matchedChapterCount, missingSeries=$missingSeriesCount, missingChapters=$missingChapterCount, refreshedChapterSets=$refreshedChapterSets, chapterUpdates=${chapterUpdates.size}, historyUpdates=${historyUpdates.size}"
+                "Komga $syncName result: remoteBooks=${remoteBooks.size}, matchedSeries=$matchedSeriesCount, matchedChapters=$matchedChapterCount, missingSeries=$missingSeriesCount, missingChapters=$missingChapterCount, refreshedChapterSets=$refreshedChapterSets, chapterUpdates=${chapterUpdates.size}, historyUpdates=${historyUpdates.size}, epubCacheClears=${epubCacheClears.size}"
             }
         }
         if (missingSeriesSamples.isNotEmpty()) {
@@ -298,7 +364,7 @@ class KomgaProgressSyncService(
 
         if (chapters.isEmpty()) {
             val source = sourceManager.getOrStub(manga.source)
-            runCatching {
+            runCatchingCancellable {
                 val sourceChapters = source.getChapterList(manga.toSManga())
                 syncChaptersWithSource.await(sourceChapters, manga, source, manualFetch = false)
                 chapters = getChaptersByMangaId.await(manga.id)
@@ -323,7 +389,7 @@ class KomgaProgressSyncService(
     ) {
         val source = sourceManager.get(sourceId) as? ConnectionEpubProgressAdapter ?: return
         val chapter = getChaptersByMangaId.await(manga.id).firstOrNull { it.url == chapterUrl } ?: return
-        runCatching {
+        runCatchingCancellable {
             source.refreshEpubProgress(manga.id, chapter)
         }.onFailure { error ->
             logcat(LogPriority.WARN, error) {
@@ -336,6 +402,45 @@ class KomgaProgressSyncService(
         val chapters: Map<String, Chapter>,
         val refreshed: Boolean,
     )
+}
+
+internal fun selectRelevantKomgaEpubChapters(
+    chapters: List<Chapter>,
+    remoteInProgressBookUrls: Set<String>,
+    localProgressChapterIds: Set<Long>,
+    remoteProgressChapterIds: Set<Long>,
+): List<Chapter> {
+    return chapters.filter { chapter ->
+        val bookUrl = chapter.url.normalizedBookUrl()
+        val hasRelevantProgress = bookUrl in remoteInProgressBookUrls ||
+            chapter.id in localProgressChapterIds ||
+            chapter.id in remoteProgressChapterIds
+        val isKnownEpub = KomgaChapterMemo.isEpub(chapter.memo) == true || hasRelevantProgress
+        isKnownEpub && hasRelevantProgress && (!chapter.read || bookUrl in remoteInProgressBookUrls)
+    }
+}
+
+private fun EpubRemoteProgressCache.hasProgress(): Boolean =
+    locatorJson != null || progression != null || positionIndex != null
+
+internal fun hasEpubProgressToClear(
+    local: EpubProgress?,
+    remote: EpubRemoteProgressCache?,
+): Boolean {
+    return remote?.hasProgress() == true ||
+        (local != null && (remote == null || remote.checkedAt.before(local.updatedAt)))
+}
+
+private fun String.normalizedBookUrl(): String = substringBefore('#').removeSuffix("/")
+
+private inline fun <T> runCatchingCancellable(block: () -> T): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (error: CancellationException) {
+        throw error
+    } catch (error: Throwable) {
+        Result.failure(error)
+    }
 }
 
 internal fun KomgaApi.SeriesBookProgress.toChapterUpdate(localChapter: Chapter): ChapterUpdate? {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncService.kt
@@ -3,9 +3,12 @@ package eu.kanade.tachiyomi.data.track.komga
 import eu.kanade.domain.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.manga.model.toSManga
 import eu.kanade.tachiyomi.data.track.TrackerManager
+import koharia.connection.ConnectionEpubProgressAdapter
 import koharia.komga.download.KomgaChapterMemo
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.komga.KomgaSource
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.chapter.interactor.GetChaptersByMangaId
@@ -32,18 +35,24 @@ class KomgaProgressSyncService(
     private val komgaServerPreferences: KomgaServerPreferences,
 ) {
 
-    suspend fun syncFromServer(manga: Manga) {
-        if (!manga.isKomgaSeries()) return
+    private val syncMutex = Mutex()
 
-        runCatching {
-            val remoteBooks = trackerManager.komga.api.getSeriesBookProgress(manga.url)
-            applyRemoteProgress(
-                syncName = "series sync",
-                remoteBooks = remoteBooks,
-                localMangaBySeriesUrl = mapOf(manga.url to manga),
-            )
-        }.onFailure { error ->
-            logcat(LogPriority.WARN, error) { "Failed to sync Komga progress from server for mangaId=${manga.id}" }
+    suspend fun syncFromServer(manga: Manga) {
+        syncMutex.withLock {
+            if (!manga.isKomgaSeries()) return@withLock
+
+            runCatching {
+                val remoteBooks = trackerManager.komga.api.getSeriesBookProgress(manga.url)
+                applyRemoteProgress(
+                    syncName = "series sync",
+                    remoteBooks = remoteBooks,
+                    localMangaBySeriesUrl = mapOf(manga.url to manga),
+                )
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to sync Komga progress from server for mangaId=${manga.id}"
+                }
+            }
         }
     }
 
@@ -59,36 +68,110 @@ class KomgaProgressSyncService(
         }.getOrNull()
     }
 
-    suspend fun syncHistoryFromServer() {
-        val activeServerId = komgaServerPreferences.activeServerId.get()
-        if (activeServerId == KomgaServerPreferences.NO_ACTIVE_SERVER) return
-        syncHistoryFromServer(activeServerId)
+    /**
+     * Applies a single book change received from Komga SSE. Keeping this path
+     * separate from the full history scan avoids downloading every book when
+     * only one book changed.
+     */
+    suspend fun syncBookProgress(
+        sourceId: Long,
+        chapterUrl: String,
+    ) {
+        syncMutex.withLock {
+            if (sourceManager.get(sourceId) !is KomgaSource || !chapterUrl.contains("/api/v1/books/")) return@withLock
+
+            runCatching {
+                val remote = trackerManager.komga.api.getBookProgress(chapterUrl) ?: return@runCatching
+                val seriesUrl = remote.seriesUrl ?: return@runCatching
+                val manga = mangaRepository.getMangaByUrlAndSourceId(seriesUrl, sourceId)
+                    ?: run {
+                        logcat(LogPriority.INFO) {
+                            "Komga book sync: local series is not indexed sourceId=$sourceId seriesUrl=$seriesUrl"
+                        }
+                        return@runCatching
+                    }
+                applyRemoteProgress(
+                    syncName = "book sync",
+                    remoteBooks = listOf(
+                        KomgaApi.SeriesBookProgress(
+                            seriesUrl = seriesUrl,
+                            url = remote.url,
+                            readProgress = remote.readProgress,
+                            isEpub = remote.isEpub,
+                            isDivinaCompatibleEpub = remote.isDivinaCompatibleEpub,
+                        ),
+                    ),
+                    localMangaBySeriesUrl = mapOf(seriesUrl to manga),
+                )
+
+                if (remote.isEpub) {
+                    syncBookEpubProgress(sourceId, manga, remote.url)
+                }
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) {
+                    "Failed to sync Komga book progress sourceId=$sourceId chapterUrl=$chapterUrl"
+                }
+            }
+        }
     }
 
-    suspend fun syncHistoryFromServer(sourceId: Long) {
-        if (sourceManager.get(sourceId) !is KomgaSource) return
-        runCatching {
-            val remoteBooks = trackerManager.komga.api.getInProgressBookProgress(sourceId)
-            if (remoteBooks.isEmpty()) {
-                return
-            }
-            val remoteSeriesUrls = remoteBooks
-                .mapNotNull { it.seriesUrl }
-                .distinct()
-
-            val localMangaBySeriesUrl = remoteSeriesUrls
-                .mapNotNull { seriesUrl ->
-                    mangaRepository.getMangaByUrlAndSourceId(seriesUrl, sourceId)?.let { seriesUrl to it }
+    /** Refresh EPUB locator data for locally indexed Komga books during an explicit full refresh. */
+    suspend fun syncEpubProgressFromServer(sourceId: Long) {
+        syncMutex.withLock {
+            val source = sourceManager.get(sourceId) as? ConnectionEpubProgressAdapter ?: return@withLock
+            mangaRepository.getMangaBySourceId(sourceId).forEach { manga ->
+                val chapters = getChaptersByMangaId.await(manga.id)
+                if (chapters.isEmpty()) return@forEach
+                runCatching {
+                    source.syncMangaEpubProgress(
+                        mangaId = manga.id,
+                        chapters = chapters,
+                        force = true,
+                    )
+                }.onFailure { error ->
+                    logcat(LogPriority.WARN, error) {
+                        "Failed to sync Komga EPUB progress sourceId=$sourceId mangaId=${manga.id}"
+                    }
                 }
-                .toMap()
+            }
+        }
+    }
 
-            applyRemoteProgress(
-                syncName = "history sync",
-                remoteBooks = remoteBooks,
-                localMangaBySeriesUrl = localMangaBySeriesUrl,
-            )
-        }.onFailure { error ->
-            logcat(LogPriority.WARN, error) { "Failed to sync Komga continue reading from server" }
+    suspend fun syncHistoryFromServer(includeCompleted: Boolean = false) {
+        val activeServerId = komgaServerPreferences.activeServerId.get()
+        if (activeServerId == KomgaServerPreferences.NO_ACTIVE_SERVER) return
+        syncHistoryFromServer(activeServerId, includeCompleted)
+    }
+
+    suspend fun syncHistoryFromServer(sourceId: Long, includeCompleted: Boolean = false) {
+        syncMutex.withLock {
+            if (sourceManager.get(sourceId) !is KomgaSource) return@withLock
+            runCatching {
+                val remoteBooks = trackerManager.komga.api.getInProgressBookProgress(
+                    sourceId = sourceId,
+                    includeCompleted = includeCompleted,
+                )
+                if (remoteBooks.isEmpty()) {
+                    return@runCatching
+                }
+                val remoteSeriesUrls = remoteBooks
+                    .mapNotNull { it.seriesUrl }
+                    .distinct()
+
+                val localMangaBySeriesUrl = remoteSeriesUrls
+                    .mapNotNull { seriesUrl ->
+                        mangaRepository.getMangaByUrlAndSourceId(seriesUrl, sourceId)?.let { seriesUrl to it }
+                    }
+                    .toMap()
+
+                applyRemoteProgress(
+                    syncName = "history sync",
+                    remoteBooks = remoteBooks,
+                    localMangaBySeriesUrl = localMangaBySeriesUrl,
+                )
+            }.onFailure { error ->
+                logcat(LogPriority.WARN, error) { "Failed to sync Komga continue reading from server" }
+            }
         }
     }
 
@@ -135,7 +218,6 @@ class KomgaProgressSyncService(
         var refreshedChapterSets = 0
 
         remoteBooks.forEach { remote ->
-            val remoteProgress = remote.readProgress ?: return@forEach
             val seriesUrl = remote.seriesUrl
             if (seriesUrl == null) {
                 missingSeriesCount++
@@ -159,11 +241,7 @@ class KomgaProgressSyncService(
                 return@forEach
             }
             matchedChapterCount++
-            val newRead = remoteProgress.completed
-            val newLastPageRead = remoteProgress.page
-                ?.let { (it - 1).coerceAtLeast(0).toLong() }
-
-            remoteProgress.readDate
+            remote.readProgress?.readDate
                 ?.let(::parseReadDate)
                 ?.let { readAt ->
                     historyUpdates += HistoryUpdate(
@@ -173,20 +251,7 @@ class KomgaProgressSyncService(
                     )
                 }
 
-            val usesPageProgress = !remote.isEpub ||
-                remote.isDivinaCompatibleEpub ||
-                KomgaChapterMemo.canOpenEpubAsPages(localChapter.memo)
-            val shouldUpdatePage = usesPageProgress &&
-                newLastPageRead != null &&
-                newLastPageRead != localChapter.lastPageRead
-
-            if (newRead != localChapter.read || shouldUpdatePage) {
-                chapterUpdates += ChapterUpdate(
-                    id = localChapter.id,
-                    read = newRead,
-                    lastPageRead = newLastPageRead.takeIf { usesPageProgress },
-                )
-            }
+            remote.toChapterUpdate(localChapter)?.let(chapterUpdates::add)
         }
 
         if (chapterUpdates.isNotEmpty()) {
@@ -251,10 +316,54 @@ class KomgaProgressSyncService(
         )
     }
 
+    private suspend fun syncBookEpubProgress(
+        sourceId: Long,
+        manga: Manga,
+        chapterUrl: String,
+    ) {
+        val source = sourceManager.get(sourceId) as? ConnectionEpubProgressAdapter ?: return
+        val chapter = getChaptersByMangaId.await(manga.id).firstOrNull { it.url == chapterUrl } ?: return
+        runCatching {
+            source.refreshEpubProgress(manga.id, chapter)
+        }.onFailure { error ->
+            logcat(LogPriority.WARN, error) {
+                "Failed to sync Komga EPUB book progression sourceId=$sourceId chapterUrl=$chapterUrl"
+            }
+        }
+    }
+
     private data class LocalChapterLoadResult(
         val chapters: Map<String, Chapter>,
         val refreshed: Boolean,
     )
+}
+
+internal fun KomgaApi.SeriesBookProgress.toChapterUpdate(localChapter: Chapter): ChapterUpdate? {
+    // Komga represents an unread book by omitting readProgress entirely.
+    // Treat that as an explicit unread state so a server-side reset also
+    // clears the local read flag and page position.
+    val newRead = readProgress?.completed ?: false
+    val newLastPageRead = if (readProgress == null) {
+        0L
+    } else {
+        readProgress.page?.let { (it - 1).coerceAtLeast(0).toLong() }
+    }
+    val usesPageProgress = !isEpub ||
+        isDivinaCompatibleEpub ||
+        KomgaChapterMemo.canOpenEpubAsPages(localChapter.memo)
+    val shouldUpdatePage = usesPageProgress &&
+        newLastPageRead != null &&
+        newLastPageRead != localChapter.lastPageRead
+
+    return if (newRead != localChapter.read || shouldUpdatePage) {
+        ChapterUpdate(
+            id = localChapter.id,
+            read = newRead,
+            lastPageRead = newLastPageRead?.takeIf { usesPageProgress },
+        )
+    } else {
+        null
+    }
 }
 
 private fun MutableList<String>.addSample(value: String) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaScreenModel.kt
@@ -119,11 +119,11 @@ private fun mergeEpubProgressions(
         .mapNotNull { chapterId ->
             val local = localByChapter[chapterId]
             val remote = remoteByChapter[chapterId]
-            val remoteModifiedAt = remote?.modifiedAt
-            val progression = if (remoteModifiedAt != null &&
-                (local == null || remoteModifiedAt.time > local.updatedAt.time)
+            val remoteUpdatedAt = remote?.modifiedAt ?: remote?.checkedAt
+            val progression = if (remoteUpdatedAt != null &&
+                (local == null || remoteUpdatedAt.time > local.updatedAt.time)
             ) {
-                remote.progression
+                remote?.progression
             } else {
                 local?.progression
             }
@@ -372,7 +372,14 @@ class MangaScreenModel(
             updateSuccessState { it.copy(isRefreshingData = false) }
 
             successState?.let { current ->
-                syncEpubProgressInBackground(source, current.chapters.map { it.chapter })
+                // A series screen is a user-visible refresh point. Pull Komga's EPUB
+                // progression from the network so changes made in the web reader are
+                // not hidden behind the short-lived local remote-progress cache.
+                syncEpubProgressInBackground(
+                    source = source,
+                    chapters = current.chapters.map { it.chapter },
+                    force = true,
+                )
             }
             syncConnectionProgressInBackground(source)
         }
@@ -439,11 +446,11 @@ class MangaScreenModel(
                     chapters = state.chapters.map { item ->
                         val localProgress = local[item.chapter.id]
                         val remoteProgress = remote[item.chapter.id]
-                        val remoteModifiedAt = remoteProgress?.modifiedAt
-                        val progression = if (remoteModifiedAt != null &&
-                            (localProgress == null || remoteModifiedAt.time > localProgress.updatedAt.time)
+                        val remoteUpdatedAt = remoteProgress?.modifiedAt ?: remoteProgress?.checkedAt
+                        val progression = if (remoteUpdatedAt != null &&
+                            (localProgress == null || remoteUpdatedAt.time > localProgress.updatedAt.time)
                         ) {
-                            remoteProgress.progression
+                            remoteProgress?.progression
                         } else {
                             localProgress?.progression
                         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.core.content.getSystemService
 import androidx.core.graphics.Insets
 import androidx.core.net.toUri
@@ -355,7 +356,7 @@ class ReaderActivity : BaseActivity() {
             ?.takeIf { state.dialog == null }
             ?.let { conflict ->
                 AlertDialog(
-                    onDismissRequest = viewModel::keepLocalProgress,
+                    onDismissRequest = {},
                     title = { Text(stringResource(MR.strings.epub_reader_remote_progress_title)) },
                     text = {
                         Text(
@@ -380,6 +381,10 @@ class ReaderActivity : BaseActivity() {
                             Text(stringResource(MR.strings.epub_reader_jump_remote_progress))
                         }
                     },
+                    properties = DialogProperties(
+                        dismissOnBackPress = false,
+                        dismissOnClickOutside = false,
+                    ),
                 )
             }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -74,7 +74,6 @@ import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.download.service.DownloadPreferences
-import tachiyomi.domain.history.interactor.GetHistory
 import tachiyomi.domain.history.interactor.GetNextChapters
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.model.HistoryUpdate
@@ -105,7 +104,6 @@ class ReaderViewModel @JvmOverloads constructor(
     private val getManga: GetManga = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
     private val getNextChapters: GetNextChapters = Injekt.get(),
-    private val getHistory: GetHistory = Injekt.get(),
     private val upsertHistory: UpsertHistory = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
@@ -710,15 +708,13 @@ class ReaderViewModel @JvmOverloads constructor(
             remoteProgressOpeningPages[chapterId]
         }?.coerceIn(0, pages.lastIndex) ?: localPageIndex
         val migratesLegacyEpubProgress = legacyEpubProgress != null
-        val localUpdatedAtMillis = getHistory.await(manga.id)
-            .firstOrNull { it.chapterId == chapterId }
-            ?.readAt
-            ?.time
         val remoteUpdatedAtMillis = remote.readDate?.toRemoteProgressTimestamp()
             ?: legacyEpubProgress?.modifiedAt?.time
         when (
             RemoteProgressConflictPolicy.decide(
-                localUpdatedAtMillis = localUpdatedAtMillis,
+                // History timestamps track reading sessions, not page changes, so they cannot
+                // safely prove that a different local page is newer than Komga's position.
+                localUpdatedAtMillis = null,
                 remoteUpdatedAtMillis = remoteUpdatedAtMillis,
                 sameLocation = remotePageIndex == localPageIndex,
                 localChangedDuringCheck = localPageIndex != openingLocalPageIndex,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -74,6 +74,7 @@ import tachiyomi.domain.chapter.interactor.UpdateChapter
 import tachiyomi.domain.chapter.model.ChapterUpdate
 import tachiyomi.domain.chapter.service.getChapterSort
 import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.history.interactor.GetHistory
 import tachiyomi.domain.history.interactor.GetNextChapters
 import tachiyomi.domain.history.interactor.UpsertHistory
 import tachiyomi.domain.history.model.HistoryUpdate
@@ -84,6 +85,7 @@ import tachiyomi.domain.source.service.SourceManager
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.time.Instant
+import java.time.OffsetDateTime
 import java.util.Date
 
 /**
@@ -103,6 +105,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private val getManga: GetManga = Injekt.get(),
     private val getChaptersByMangaId: GetChaptersByMangaId = Injekt.get(),
     private val getNextChapters: GetNextChapters = Injekt.get(),
+    private val getHistory: GetHistory = Injekt.get(),
     private val upsertHistory: UpsertHistory = Injekt.get(),
     private val updateChapter: UpdateChapter = Injekt.get(),
     private val setMangaViewerFlags: SetMangaViewerFlags = Injekt.get(),
@@ -172,6 +175,7 @@ class ReaderViewModel @JvmOverloads constructor(
     private var chapterToDownload: Download? = null
     private val currentChapterAutoCacheRequests = mutableSetOf<Long>()
     private val remoteProgressChecksStarted = mutableSetOf<Long>()
+    private val remoteProgressWritesAllowed = mutableSetOf<Long>()
     private val remoteProgressVersionsHandled = mutableSetOf<String>()
     private val remoteProgressOpeningPages = mutableMapOf<Long, Int>()
 
@@ -596,15 +600,28 @@ class ReaderViewModel @JvmOverloads constructor(
         val chapter = readerChapter.chapter
         val chapterId = chapter.id ?: return
         logcat { "MangaStartup: remote progress check start chapterId=$chapterId" }
-        val remote = progressAdapter.pullPageProgress(
-            chapterUrl = chapter.url,
-            chapterMemo = chapter.memo,
-        )
+        val remote = try {
+            progressAdapter.pullPageProgress(
+                chapterUrl = chapter.url,
+                chapterMemo = chapter.memo,
+            )
+        } catch (error: Exception) {
+            if (error is CancellationException) throw error
+            logcat(LogPriority.WARN, error) {
+                "MangaStartup: remote progress check failed; keeping writes blocked chapterId=$chapterId"
+            }
+            return
+        }
         logcat {
             "MangaStartup: remote progress check complete chapterId=$chapterId " +
                 "found=${remote != null}"
         }
-        if (remote == null) return
+        if (remote == null) {
+            logcat(LogPriority.WARN) {
+                "MangaStartup: remote progress unavailable; keeping writes blocked chapterId=$chapterId"
+            }
+            return
+        }
 
         val oldMemo = chapter.memo
         val oldPublicationVersion = remote.previousPublicationVersion
@@ -685,7 +702,7 @@ class ReaderViewModel @JvmOverloads constructor(
                 EpubPageProgress.pageIndex(
                     progression = legacyEpubProgress?.locator?.locations?.totalProgression,
                     totalPages = pages.size,
-                ) ?: return
+                ) ?: 0
             }
         if (remotePageIndex !in pages.indices) return
         val localPageIndex = readerChapter.requestedPage.coerceIn(0, pages.lastIndex)
@@ -693,20 +710,38 @@ class ReaderViewModel @JvmOverloads constructor(
             remoteProgressOpeningPages[chapterId]
         }?.coerceIn(0, pages.lastIndex) ?: localPageIndex
         val migratesLegacyEpubProgress = legacyEpubProgress != null
-        if (!RemoteProgressConflictPolicy.hasConflict(openingLocalPageIndex, localPageIndex, remotePageIndex)) {
-            if (migratesLegacyEpubProgress) {
-                progressAdapter.pushPageProgress(
-                    chapterUrl = chapter.url,
-                    pageIndex = localPageIndex,
-                    totalPages = pages.size,
-                )
+        val localUpdatedAtMillis = getHistory.await(manga.id)
+            .firstOrNull { it.chapterId == chapterId }
+            ?.readAt
+            ?.time
+        val remoteUpdatedAtMillis = remote.readDate?.toRemoteProgressTimestamp()
+            ?: legacyEpubProgress?.modifiedAt?.time
+        when (
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = localUpdatedAtMillis,
+                remoteUpdatedAtMillis = remoteUpdatedAtMillis,
+                sameLocation = remotePageIndex == localPageIndex,
+                localChangedDuringCheck = localPageIndex != openingLocalPageIndex,
+            )
+        ) {
+            RemoteProgressDecision.SAME_LOCATION -> {
+                allowRemoteProgressWrites(chapterId)
+                if (migratesLegacyEpubProgress) {
+                    pushPageProgressIfAllowed(readerChapter, localPageIndex, pages.size)
+                }
+                return
             }
-            return
+            RemoteProgressDecision.KEEP_LOCAL -> {
+                allowRemoteProgressWrites(chapterId)
+                pushPageProgressIfAllowed(readerChapter, localPageIndex, pages.size)
+                return
+            }
+            RemoteProgressDecision.KEEP_REMOTE -> Unit
         }
 
         val remoteVersion = listOf(
             chapterId,
-            remote.readDate ?: legacyEpubProgress?.modifiedAt?.time?.toString().orEmpty(),
+            remoteUpdatedAtMillis?.toString().orEmpty(),
             remotePageIndex,
             remote.totalPages.takeIf { it > 0 } ?: pages.size,
             remote.completed,
@@ -776,6 +811,36 @@ class ReaderViewModel @JvmOverloads constructor(
         return sourceManager.get(sourceId) as? ConnectionPageProgressAdapter
     }
 
+    private fun allowRemoteProgressWrites(chapterId: Long) {
+        synchronized(remoteProgressWritesAllowed) {
+            remoteProgressWritesAllowed.add(chapterId)
+        }
+    }
+
+    private fun canWriteRemoteProgress(chapterId: Long): Boolean =
+        synchronized(remoteProgressWritesAllowed) {
+            chapterId in remoteProgressWritesAllowed
+        }
+
+    private suspend fun pushPageProgressIfAllowed(
+        readerChapter: ReaderChapter,
+        pageIndex: Int,
+        totalPages: Int,
+    ) {
+        val chapterId = readerChapter.chapter.id ?: return
+        if (!canWriteRemoteProgress(chapterId)) {
+            logcat(LogPriority.DEBUG) {
+                "Skipping remote page progress write before successful comparison chapterId=$chapterId"
+            }
+            return
+        }
+        connectionPageProgressAdapter()?.pushPageProgress(
+            chapterUrl = readerChapter.chapter.url,
+            pageIndex = pageIndex,
+            totalPages = totalPages,
+        )
+    }
+
     fun keepLocalProgress() {
         val conflict = state.value.remoteProgressConflict ?: return
         mutableState.update { it.copy(remoteProgressConflict = null) }
@@ -785,12 +850,9 @@ class ReaderViewModel @JvmOverloads constructor(
         synchronized(remoteProgressOpeningPages) {
             remoteProgressOpeningPages[conflict.chapterId] = localPageIndex
         }
+        allowRemoteProgressWrites(conflict.chapterId)
         viewModelScope.launchIO {
-            connectionPageProgressAdapter()?.pushPageProgress(
-                chapterUrl = currentChapter.chapter.url,
-                pageIndex = localPageIndex,
-                totalPages = pages.size,
-            )
+            pushPageProgressIfAllowed(currentChapter, localPageIndex, pages.size)
         }
     }
 
@@ -807,6 +869,7 @@ class ReaderViewModel @JvmOverloads constructor(
         synchronized(remoteProgressOpeningPages) {
             remoteProgressOpeningPages[conflict.chapterId] = targetPage.index
         }
+        allowRemoteProgressWrites(conflict.chapterId)
         state.value.viewer?.restorePage(targetPage)
         if (!incognitoMode) {
             viewModelScope.launchNonCancellable {
@@ -818,11 +881,7 @@ class ReaderViewModel @JvmOverloads constructor(
                     ),
                 )
                 if (conflict.migratesLegacyEpubProgress) {
-                    connectionPageProgressAdapter()?.pushPageProgress(
-                        chapterUrl = currentChapter.chapter.url,
-                        pageIndex = targetPage.index,
-                        totalPages = pages.size,
-                    )
+                    pushPageProgressIfAllowed(currentChapter, targetPage.index, pages.size)
                 }
             }
         }
@@ -956,8 +1015,8 @@ class ReaderViewModel @JvmOverloads constructor(
         updateTrackChapterRead(readerChapter)
         deleteChapterIfNeeded(readerChapter)
 
-        connectionPageProgressAdapter()?.pushPageProgress(
-            chapterUrl = readerChapter.chapter.url,
+        pushPageProgressIfAllowed(
+            readerChapter = readerChapter,
             pageIndex = readerChapter.pages?.lastIndex ?: 0,
             totalPages = readerChapter.pages?.size ?: 0,
         )
@@ -997,8 +1056,8 @@ class ReaderViewModel @JvmOverloads constructor(
             val sessionReadDuration = chapterReadStartTime?.let { endTime.time - it } ?: 0
 
             if (sessionReadDuration > 0) {
-                connectionPageProgressAdapter()?.pushPageProgress(
-                    chapterUrl = readerChapter.chapter.url,
+                pushPageProgressIfAllowed(
+                    readerChapter = readerChapter,
                     pageIndex = readerChapter.chapter.last_page_read,
                     totalPages = readerChapter.pages?.size ?: 0,
                 )
@@ -1396,3 +1455,8 @@ class ReaderViewModel @JvmOverloads constructor(
         data class CopyImage(val uri: Uri) : Event
     }
 }
+
+private fun String.toRemoteProgressTimestamp(): Long? =
+    runCatching { Instant.parse(this).toEpochMilli() }
+        .recoverCatching { OffsetDateTime.parse(this).toInstant().toEpochMilli() }
+        .getOrNull()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicy.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicy.kt
@@ -1,5 +1,11 @@
 package eu.kanade.tachiyomi.ui.reader
 
+internal enum class RemoteProgressDecision {
+    KEEP_LOCAL,
+    KEEP_REMOTE,
+    SAME_LOCATION,
+}
+
 internal object RemoteProgressConflictPolicy {
 
     fun hasConflict(
@@ -8,5 +14,19 @@ internal object RemoteProgressConflictPolicy {
         remotePageIndex: Int,
     ): Boolean {
         return remotePageIndex != openingPageIndex && remotePageIndex != currentPageIndex
+    }
+
+    fun decide(
+        localUpdatedAtMillis: Long?,
+        remoteUpdatedAtMillis: Long?,
+        sameLocation: Boolean,
+        localChangedDuringCheck: Boolean,
+    ): RemoteProgressDecision = when {
+        sameLocation -> RemoteProgressDecision.SAME_LOCATION
+        localChangedDuringCheck -> RemoteProgressDecision.KEEP_LOCAL
+        localUpdatedAtMillis != null &&
+            remoteUpdatedAtMillis != null &&
+            localUpdatedAtMillis > remoteUpdatedAtMillis -> RemoteProgressDecision.KEEP_LOCAL
+        else -> RemoteProgressDecision.KEEP_REMOTE
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicy.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicy.kt
@@ -8,14 +8,6 @@ internal enum class RemoteProgressDecision {
 
 internal object RemoteProgressConflictPolicy {
 
-    fun hasConflict(
-        openingPageIndex: Int,
-        currentPageIndex: Int,
-        remotePageIndex: Int,
-    ): Boolean {
-        return remotePageIndex != openingPageIndex && remotePageIndex != currentPageIndex
-    }
-
     fun decide(
         localUpdatedAtMillis: Long?,
         remoteUpdatedAtMillis: Long?,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/NetworkStateTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/NetworkStateTracker.kt
@@ -36,6 +36,7 @@ fun Context.networkStateFlow() = callbackFlow {
     }
 
     connectivityManager.registerDefaultNetworkCallback(networkCallback)
+    trySend(activeNetworkState())
     awaitClose {
         connectivityManager.unregisterNetworkCallback(networkCallback)
     }

--- a/app/src/main/java/koharia/connection/ConnectionCapabilities.kt
+++ b/app/src/main/java/koharia/connection/ConnectionCapabilities.kt
@@ -362,8 +362,18 @@ interface ConnectionMangaProgressAdapter {
     suspend fun syncMangaProgress(manga: Manga)
 }
 
+/** Writes an explicit chapter read/unread action back to the owning connection. */
+interface ConnectionReadStatusAdapter {
+    suspend fun setChapterReadStatus(chapterUrl: String, read: Boolean)
+}
+
 interface ConnectionHistorySyncAdapter {
     suspend fun syncConnectionHistory()
+}
+
+/** Optional full refresh of Readium locator progress for locally indexed EPUB books. */
+interface ConnectionEpubHistorySyncAdapter {
+    suspend fun syncConnectionEpubProgress()
 }
 
 interface ConnectionPageProgressAdapter {

--- a/app/src/main/java/koharia/epub/EpubReaderActivity.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderActivity.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -763,7 +764,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
 
             state.remoteProgressConflict?.let { conflict ->
                 AlertDialog(
-                    onDismissRequest = viewModel::dismissRemoteProgressConflict,
+                    onDismissRequest = {},
                     title = { Text(stringResource(MR.strings.epub_reader_remote_progress_title)) },
                     text = {
                         Text(
@@ -782,7 +783,7 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                         )
                     },
                     dismissButton = {
-                        TextButton(onClick = viewModel::dismissRemoteProgressConflict) {
+                        TextButton(onClick = viewModel::keepLocalProgress) {
                             Text(stringResource(MR.strings.epub_reader_keep_local_progress))
                         }
                     },
@@ -797,6 +798,10 @@ class EpubReaderActivity : BaseActivity(), EpubReaderFragment.Host {
                             Text(stringResource(MR.strings.epub_reader_jump_remote_progress))
                         }
                     },
+                    properties = DialogProperties(
+                        dismissOnBackPress = false,
+                        dismissOnClickOutside = false,
+                    ),
                 )
             }
 

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -1289,7 +1289,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         return locator
     }
 
-    fun dismissRemoteProgressConflict() {
+    fun keepLocalProgress() {
         mutableState.update { it.copy(remoteProgressConflict = null) }
         remoteProgressWriteBaseline = null
         remoteProgressWriteAllowed = true

--- a/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
+++ b/app/src/main/java/koharia/epub/EpubReaderViewModel.kt
@@ -39,6 +39,8 @@ import koharia.epub.model.EpubOpenRequest
 import koharia.epub.model.EpubSearchResult
 import koharia.epub.model.EpubTocEntry
 import koharia.epub.model.RemotePublicationRef
+import koharia.epub.progress.EpubRemoteProgressDecision
+import koharia.epub.progress.EpubRemoteProgressPolicy
 import koharia.epub.service.EpubPublicationResolver
 import koharia.epub.session.EpubReaderSession
 import koharia.epub.session.EpubReaderSessionRepository
@@ -202,6 +204,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
     private var positionsRefreshStarted = false
     private var lastPrefetchedHref: String? = null
     private var remoteProgressChecked = false
+    private var remoteProgressWriteAllowed = false
+    private var remoteProgressWriteBaseline: Locator? = null
+    private var localProgressUpdatedAtSessionOpen: Long? = null
     private var initiallyAcceptedRemoteLocator: Locator? = null
     private var initiallyAcceptedRemoteModifiedAt: Date? = null
     private var layoutChangeRevision = 0L
@@ -260,7 +265,12 @@ class EpubReaderViewModel @JvmOverloads constructor(
         initiallyAcceptedRemoteModifiedAt = null
         layoutChangeRevision += 1
         this.preserveLocalProgressAfterLayoutChange = preserveLocalProgressAfterLayoutChange
-        remoteProgressChecked = preserveLocalProgressAfterLayoutChange
+        if (!preserveLocalProgressAfterLayoutChange) {
+            remoteProgressChecked = false
+            remoteProgressWriteAllowed = false
+            remoteProgressWriteBaseline = null
+            localProgressUpdatedAtSessionOpen = null
+        }
         this.mangaId = mangaId
         this.chapterId = chapterId
         mutableState.update {
@@ -451,6 +461,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         }
                         .getOrNull()
                 }
+                localProgressUpdatedAtSessionOpen = localProgress?.updatedAt?.time
                 val remoteProgress = remoteCache?.let { cache ->
                     val locator = cache.locatorJson
                         ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
@@ -594,11 +605,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
                         )
                         currentProgress = syncedProgress
                         upsertEpubProgress.await(syncedProgress)
-                    } else if (remoteBookUrl != null && localProgress != null && persistedLocator != null &&
-                        epubReaderPreferences.syncRemoteProgression.get() &&
-                        (remoteProgress == null || localProgress.updatedAt.time > remoteProgress.modifiedAt.time)
-                    ) {
-                        syncPersistedProgress(localProgress, persistedLocator)
                     }
                 }
             }
@@ -1125,8 +1131,8 @@ class EpubReaderViewModel @JvmOverloads constructor(
         if (remoteProgressChecked || isIncognito() || !epubReaderPreferences.syncRemoteProgression.get()) return
         val chapter = currentChapter ?: return
         val progressAdapter = currentEpubProgressAdapter ?: return
-        val checkLayoutRevision = layoutChangeRevision
         val localLocatorAtCheck = latestLocator
+        val checkStartedAt = System.currentTimeMillis()
         remoteProgressChecked = true
         viewModelScope.launch {
             val remote = runCatching {
@@ -1136,10 +1142,32 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     "Failed to refresh EPUB remote progress for chapterId=$chapterId"
                 }
             }.getOrNull() ?: return@launch
+            if (!EpubRemoteProgressPolicy.isFreshResult(checkStartedAt, remote.checkedAt.time)) {
+                logcat(LogPriority.WARN) {
+                    "Keeping EPUB remote writes blocked after stale refresh result chapterId=$chapterId " +
+                        "checkedAt=${remote.checkedAt.time} startedAt=$checkStartedAt"
+                }
+                return@launch
+            }
             val locator = remote.locatorJson
                 ?.let { json -> runCatching { Locator.fromJSON(JSONObject(json)) }.getOrNull() }
-                ?: return@launch
-            val modifiedAt = remote.modifiedAt ?: return@launch
+            val modifiedAt = remote.modifiedAt
+            if (locator == null || modifiedAt == null) {
+                remoteProgressWriteAllowed = true
+                val currentLocator = latestLocator
+                val localChangedDuringCheck = localLocatorAtCheck != null &&
+                    !localLocatorAtCheck.isSamePaginationLocation(currentLocator)
+                if (localChangedDuringCheck && currentLocator != null && currentProgress != null) {
+                    remoteProgressWriteBaseline = null
+                    syncPersistedProgress(checkNotNull(currentProgress), currentLocator)
+                } else {
+                    remoteProgressWriteBaseline = currentLocator
+                    logcat(LogPriority.DEBUG) {
+                        "Confirmed no remote EPUB progress; waiting for local navigation before upload chapterId=$chapterId"
+                    }
+                }
+                return@launch
+            }
             val acceptedRemoteLocator = initiallyAcceptedRemoteLocator
             if (acceptedRemoteLocator != null && locator.isSamePaginationLocation(acceptedRemoteLocator)) {
                 val acceptedRemoteModifiedAt = initiallyAcceptedRemoteModifiedAt
@@ -1165,42 +1193,68 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     "Ignoring already accepted initial EPUB remote progress chapterId=$chapterId " +
                         "remote=${locator.debugProgress()} current=${latestLocator.debugProgress()}"
                 }
-                return@launch
-            }
-            val localUpdatedAt = currentProgress?.updatedAt?.time
-            if (localUpdatedAt != null && modifiedAt.time <= localUpdatedAt) {
-                logcat(LogPriority.DEBUG) {
-                    "Ignoring stale EPUB remote progress chapterId=$chapterId " +
-                        "remoteModified=${modifiedAt.time} localUpdated=$localUpdatedAt"
+                remoteProgressWriteAllowed = true
+                val currentLocator = latestLocator
+                val localChangedDuringCheck = localLocatorAtCheck != null &&
+                    !localLocatorAtCheck.isSamePaginationLocation(currentLocator)
+                if (localChangedDuringCheck && currentLocator != null && currentProgress != null) {
+                    remoteProgressWriteBaseline = null
+                    syncPersistedProgress(checkNotNull(currentProgress), currentLocator)
+                } else {
+                    remoteProgressWriteBaseline = currentLocator
                 }
                 return@launch
             }
-            if (localLocatorAtCheck != null &&
-                !localLocatorAtCheck.isSamePaginationLocation(latestLocator)
-            ) {
-                logcat(LogPriority.DEBUG) {
-                    "Ignoring EPUB remote progress after local navigation chapterId=$chapterId"
-                }
-                return@launch
-            }
-            if (preserveLocalProgressAfterLayoutChange || checkLayoutRevision != layoutChangeRevision) {
-                logcat(LogPriority.DEBUG) {
-                    "Ignoring EPUB remote progress conflict after local layout change " +
-                        "chapterId=$chapterId remoteModified=${modifiedAt.time}"
-                }
-                return@launch
-            }
-            if (locator.isSamePaginationLocation(latestLocator)) return@launch
-            mutableState.update {
-                it.copy(
-                    serverTimeOffsetMinutes = remote.serverDate?.serverTimeOffsetMinutes(),
-                    remoteProgressConflict = EpubRemoteProgressConflict(
-                        locatorJson = locator.toJSON().toString(),
-                        progressionPercent = locator.progressionPercent(),
-                        sectionTitle = locator.title,
-                        modifiedAtMillis = modifiedAt.time,
-                    ),
+            val currentLocator = latestLocator
+            val localChangedDuringCheck = localLocatorAtCheck != null &&
+                !localLocatorAtCheck.isSamePaginationLocation(currentLocator)
+            when (
+                EpubRemoteProgressPolicy.decide(
+                    localUpdatedAtMillis = localProgressUpdatedAtSessionOpen,
+                    remoteModifiedAtMillis = modifiedAt.time,
+                    sameLocation = locator.isSamePaginationLocation(currentLocator),
+                    localChangedDuringCheck = localChangedDuringCheck,
                 )
+            ) {
+                EpubRemoteProgressDecision.SAME_LOCATION -> {
+                    val acceptedLocator = currentLocator ?: locator
+                    val syncedProgress = buildProgress(
+                        locator = acceptedLocator,
+                        updatedAt = modifiedAt,
+                        lastSyncedAt = modifiedAt,
+                    )
+                    currentProgress = syncedProgress
+                    upsertEpubProgress.await(syncedProgress)
+                    remoteProgressWriteBaseline = acceptedLocator
+                    remoteProgressWriteAllowed = true
+                }
+                EpubRemoteProgressDecision.KEEP_LOCAL -> {
+                    remoteProgressWriteBaseline = null
+                    remoteProgressWriteAllowed = true
+                    val localLocator = currentLocator ?: return@launch
+                    val localProgress = currentProgress ?: return@launch
+                    val progressToSync = if (localChangedDuringCheck) {
+                        localProgress
+                    } else {
+                        localProgressUpdatedAtSessionOpen
+                            ?.let { localProgress.copy(updatedAt = Date(it)) }
+                            ?: localProgress
+                    }
+                    syncPersistedProgress(progressToSync, localLocator)
+                }
+                EpubRemoteProgressDecision.KEEP_REMOTE -> {
+                    mutableState.update {
+                        it.copy(
+                            serverTimeOffsetMinutes = remote.serverDate?.serverTimeOffsetMinutes(),
+                            remoteProgressConflict = EpubRemoteProgressConflict(
+                                locatorJson = locator.toJSON().toString(),
+                                progressionPercent = locator.progressionPercent(),
+                                sectionTitle = locator.title,
+                                modifiedAtMillis = modifiedAt.time,
+                            ),
+                        )
+                    }
+                }
             }
         }
     }
@@ -1208,7 +1262,6 @@ class EpubReaderViewModel @JvmOverloads constructor(
     fun onLayoutPreferencesChanged() {
         layoutChangeRevision += 1
         preserveLocalProgressAfterLayoutChange = true
-        remoteProgressChecked = true
         mutableState.update { state ->
             state.copy(remoteProgressConflict = null)
         }
@@ -1219,12 +1272,32 @@ class EpubReaderViewModel @JvmOverloads constructor(
 
     fun acceptRemoteProgress(): Locator? {
         val conflict = mutableState.value.remoteProgressConflict ?: return null
+        val locator = runCatching { Locator.fromJSON(JSONObject(conflict.locatorJson)) }.getOrNull() ?: return null
         mutableState.update { it.copy(remoteProgressConflict = null) }
-        return runCatching { Locator.fromJSON(JSONObject(conflict.locatorJson)) }.getOrNull()
+        val modifiedAt = Date(conflict.modifiedAtMillis)
+        val syncedProgress = buildProgress(
+            locator = locator,
+            updatedAt = modifiedAt,
+            lastSyncedAt = modifiedAt,
+        )
+        currentProgress = syncedProgress
+        remoteProgressWriteBaseline = locator
+        remoteProgressWriteAllowed = true
+        viewModelScope.launch {
+            upsertEpubProgress.await(syncedProgress)
+        }
+        return locator
     }
 
     fun dismissRemoteProgressConflict() {
         mutableState.update { it.copy(remoteProgressConflict = null) }
+        remoteProgressWriteBaseline = null
+        remoteProgressWriteAllowed = true
+        val localProgress = currentProgress ?: return
+        val localLocator = latestLocator ?: return
+        viewModelScope.launch {
+            syncPersistedProgress(localProgress, localLocator)
+        }
     }
 
     fun invalidatePaginationDisplay() {
@@ -1952,6 +2025,7 @@ class EpubReaderViewModel @JvmOverloads constructor(
         localProgress: EpubProgress,
         locator: Locator,
     ) {
+        if (!remoteProgressWriteAllowed) return
         val progressAdapter = currentEpubProgressAdapter ?: return
         val bookUrl = localProgress.bookUrl ?: currentBookUrl ?: return
         val positions = authoritativePublicationPositions() ?: return
@@ -1978,11 +2052,17 @@ class EpubReaderViewModel @JvmOverloads constructor(
     ) = progressPersistenceMutex.withLock {
         val chapterId = chapterId.takeIf { it > 0 } ?: return@withLock
         mangaId.takeIf { it > 0 } ?: return@withLock
-        val now = Date()
+        val previousProgress = currentProgress
+        val previousLocator = previousProgress?.toLocatorOrNull()
+        val progressUpdatedAt = if (previousLocator != null && locator.isSamePaginationLocation(previousLocator)) {
+            previousProgress.updatedAt
+        } else {
+            Date()
+        }
         val progress = buildProgress(
             locator = locator,
-            updatedAt = now,
-            lastSyncedAt = currentProgress?.lastSyncedAt,
+            updatedAt = progressUpdatedAt,
+            lastSyncedAt = previousProgress?.lastSyncedAt,
         )
         upsertEpubProgress.await(progress)
         currentProgress = progress
@@ -1995,7 +2075,10 @@ class EpubReaderViewModel @JvmOverloads constructor(
         markChapterCompletedIfNeeded(locator)
 
         val bookUrl = progress.bookUrl
-        if (bookUrl != null && epubReaderPreferences.syncRemoteProgression.get()) {
+        if (bookUrl != null && epubReaderPreferences.syncRemoteProgression.get() && remoteProgressWriteAllowed) {
+            val writeBaseline = remoteProgressWriteBaseline
+            if (writeBaseline != null && locator.isSamePaginationLocation(writeBaseline)) return@withLock
+            remoteProgressWriteBaseline = null
             val progressAdapter = currentEpubProgressAdapter ?: return@withLock
             val positions = positionsOverride ?: authoritativePublicationPositions() ?: return@withLock
             runCatching {
@@ -2003,9 +2086,9 @@ class EpubReaderViewModel @JvmOverloads constructor(
                     resourceId = bookUrl,
                     locator = locator,
                     positions = positions,
-                    modifiedAt = now,
+                    modifiedAt = progressUpdatedAt,
                 )
-                val syncedProgress = progress.copy(lastSyncedAt = now)
+                val syncedProgress = progress.copy(lastSyncedAt = progressUpdatedAt)
                 upsertEpubProgress.await(syncedProgress)
                 currentProgress = syncedProgress
             }.onFailure { error ->

--- a/app/src/main/java/koharia/epub/progress/EpubRemoteProgressPolicy.kt
+++ b/app/src/main/java/koharia/epub/progress/EpubRemoteProgressPolicy.kt
@@ -1,0 +1,28 @@
+package koharia.epub.progress
+
+internal enum class EpubRemoteProgressDecision {
+    KEEP_LOCAL,
+    KEEP_REMOTE,
+    SAME_LOCATION,
+}
+
+internal object EpubRemoteProgressPolicy {
+
+    fun isFreshResult(
+        checkStartedAtMillis: Long,
+        checkedAtMillis: Long,
+    ): Boolean = checkedAtMillis >= checkStartedAtMillis
+
+    fun decide(
+        localUpdatedAtMillis: Long?,
+        remoteModifiedAtMillis: Long,
+        sameLocation: Boolean,
+        localChangedDuringCheck: Boolean,
+    ): EpubRemoteProgressDecision = when {
+        sameLocation -> EpubRemoteProgressDecision.SAME_LOCATION
+        localChangedDuringCheck -> EpubRemoteProgressDecision.KEEP_LOCAL
+        localUpdatedAtMillis != null && localUpdatedAtMillis > remoteModifiedAtMillis ->
+            EpubRemoteProgressDecision.KEEP_LOCAL
+        else -> EpubRemoteProgressDecision.KEEP_REMOTE
+    }
+}

--- a/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
+++ b/app/src/main/java/koharia/epub/progress/KomgaEpubProgressSyncService.kt
@@ -8,6 +8,7 @@ import koharia.epub.alignToEpubPositions
 import koharia.source.komga.KomgaScopedPreferenceStoreFactory
 import koharia.source.komga.KomgaSource
 import logcat.LogPriority
+import okhttp3.CacheControl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -41,7 +42,12 @@ class KomgaEpubProgressSyncService(
     ): PullResult = withIOContext {
         val source = sourceManager.get(sourceId) as? KomgaSource ?: return@withIOContext PullResult()
         val normalizedBookUrl = normalizeBookUrl(bookUrl)
-        source.client.newCall(GET("$normalizedBookUrl/progression", source.currentReadiumHeaders()))
+        source.client.newCall(
+            GET("$normalizedBookUrl/progression", source.currentReadiumHeaders())
+                .newBuilder()
+                .cacheControl(CacheControl.FORCE_NETWORK)
+                .build(),
+        )
             .await()
             .use { response ->
                 response.requireSuccess("pull")

--- a/app/src/main/java/koharia/komga/api/KomgaActiveServerSseManager.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaActiveServerSseManager.kt
@@ -31,6 +31,10 @@ class KomgaActiveServerSseManager(
         networkHelper = networkHelper,
         komgaProgressSyncService = komgaProgressSyncService,
         baseUrlProvider = { currentSource()?.baseUrl.orEmpty() },
+        sourceIdProvider = {
+            komgaServerPreferences.activeServerId.get()
+                .takeIf { it != KomgaServerPreferences.NO_ACTIVE_SERVER }
+        },
         headersProvider = { currentSource()?.currentHeaders() ?: Headers.Builder().build() },
         cachedOnlyProvider = { basePreferences.downloadedOnly.get() },
     )

--- a/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaApiClient.kt
@@ -12,6 +12,7 @@ import koharia.komga.api.dto.LibraryDto
 import koharia.komga.api.dto.PageWrapperDto
 import koharia.source.komga.KomgaCachePolicy
 import koharia.source.komga.komgaCachePolicy
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromJsonElement
@@ -218,6 +219,23 @@ class KomgaApiClient(
 
     suspend fun execute(request: Request): Response = client.newCall(request).awaitSuccess()
 
+    fun bookReadStatusRequest(bookUrl: String, read: Boolean): Request {
+        val builder = Request.Builder()
+            .url("$bookUrl/read-progress")
+            .headers(headers)
+
+        return if (read) {
+            val payload = json.encodeToString(BookReadStatusUpdateDto(completed = true))
+            builder.patch(payload.toRequestBody(JSON_MEDIA_TYPE)).build()
+        } else {
+            builder.delete().build()
+        }
+    }
+
+    suspend fun setBookReadStatus(bookUrl: String, read: Boolean) {
+        client.newCall(bookReadStatusRequest(bookUrl, read)).awaitSuccess().close()
+    }
+
     fun detailsRequest(url: String, cachePolicy: KomgaCachePolicy = KomgaCachePolicy.Default): Request =
         GET(url, headers)
             .newBuilder()
@@ -403,3 +421,8 @@ class KomgaApiClient(
         private val JSON_MEDIA_TYPE = "application/json".toMediaType()
     }
 }
+
+@Serializable
+private data class BookReadStatusUpdateDto(
+    val completed: Boolean,
+)

--- a/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
@@ -8,8 +8,10 @@ import eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService
 import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.util.system.networkStateFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -43,9 +45,10 @@ class KomgaSseClient(
     private var isStarted = false
     private var lastSkippedReason: String? = null
     private val progressSyncLock = Any()
-    private val pendingBookIds = linkedSetOf<String>()
-    private var pendingFullSync = false
+    private val progressSyncQueue = KomgaSseProgressSyncQueue()
     private var progressSyncJob: Job? = null
+    private var connectionGeneration = 0L
+    private var activeTarget: KomgaSseConnectionTarget? = null
 
     fun start(scope: CoroutineScope) {
         if (isStarted) return
@@ -103,7 +106,12 @@ class KomgaSseClient(
         if (isConnecting || eventSource != null) return
         isConnecting = true
 
-        val baseUrl = baseUrlProvider()
+        val sourceId = sourceIdProvider()
+        if (sourceId == null) {
+            isConnecting = false
+            return
+        }
+        val baseUrl = baseUrlProvider().trimEnd('/')
         if (baseUrl.isBlank()) {
             isConnecting = false
             return
@@ -120,6 +128,17 @@ class KomgaSseClient(
             .url(httpUrl)
             .headers(headersProvider())
             .build()
+        if (sourceIdProvider() != sourceId) {
+            isConnecting = false
+            return
+        }
+        val target = synchronized(progressSyncLock) {
+            KomgaSseConnectionTarget(
+                sourceId = sourceId,
+                baseUrl = baseUrl,
+                generation = ++connectionGeneration,
+            ).also { activeTarget = it }
+        }
 
         logcat(LogPriority.INFO) { "Komga SSE connecting to $baseUrl/api/v1/sse/v1/events" }
 
@@ -128,25 +147,25 @@ class KomgaSseClient(
             request,
             object : EventSourceListener() {
                 override fun onOpen(eventSource: EventSource, response: Response) {
+                    if (!isCurrentConnection(target)) return
                     logcat(LogPriority.INFO) { "Komga SSE connected" }
                     isConnecting = false
                 }
 
                 override fun onEvent(eventSource: EventSource, id: String?, type: String?, data: String) {
+                    if (!isCurrentConnection(target)) return
                     logcat(LogPriority.DEBUG) { "Komga SSE event: type=$type, data=$data" }
-                    handleEvent(type, data)
+                    handleEvent(target, type, data)
                 }
 
                 override fun onClosed(eventSource: EventSource) {
+                    if (!finishConnection(target, eventSource)) return
                     logcat(LogPriority.INFO) { "Komga SSE closed" }
-                    this@KomgaSseClient.eventSource = null
-                    isConnecting = false
                 }
 
                 override fun onFailure(eventSource: EventSource, t: Throwable?, response: Response?) {
+                    if (!finishConnection(target, eventSource)) return
                     logcat(LogPriority.ERROR, t) { "Komga SSE failure: ${response?.code}" }
-                    this@KomgaSseClient.eventSource = null
-                    isConnecting = false
                 }
             },
         )
@@ -154,9 +173,17 @@ class KomgaSseClient(
 
     private fun disconnect(reason: String? = null) {
         val hadActiveConnection = eventSource != null || isConnecting
-        eventSource?.cancel()
+        val sourceToCancel = eventSource
         eventSource = null
         isConnecting = false
+        val syncJob = synchronized(progressSyncLock) {
+            connectionGeneration++
+            activeTarget = null
+            progressSyncQueue.clear()
+            progressSyncJob.also { progressSyncJob = null }
+        }
+        syncJob?.cancel()
+        sourceToCancel?.cancel()
         if (hadActiveConnection) {
             logcat(LogPriority.INFO) {
                 buildString {
@@ -170,7 +197,23 @@ class KomgaSseClient(
         }
     }
 
-    private fun handleEvent(type: String?, data: String) {
+    private fun isCurrentConnection(target: KomgaSseConnectionTarget): Boolean =
+        synchronized(progressSyncLock) { activeTarget == target }
+
+    private fun finishConnection(target: KomgaSseConnectionTarget, source: EventSource): Boolean {
+        val syncJob = synchronized(progressSyncLock) {
+            if (activeTarget != target || eventSource !== source) return false
+            activeTarget = null
+            eventSource = null
+            isConnecting = false
+            progressSyncQueue.clear()
+            progressSyncJob.also { progressSyncJob = null }
+        }
+        syncJob?.cancel()
+        return true
+    }
+
+    private fun handleEvent(target: KomgaSseConnectionTarget, type: String?, data: String) {
         if (type == null) return
         when (type) {
             "ReadProgressChanged", "ReadProgressDeleted" -> {
@@ -180,65 +223,59 @@ class KomgaSseClient(
                 logcat(LogPriority.DEBUG) {
                     "Komga SSE: received $type bookId=${bookId ?: "unknown"}, scheduling progress sync"
                 }
-                scheduleProgressSync(bookId)
+                scheduleProgressSync(target, bookId)
             }
         }
     }
 
-    private fun scheduleProgressSync(bookId: String?) {
+    private fun scheduleProgressSync(target: KomgaSseConnectionTarget, bookId: String?) {
         val scope = appScope ?: return
         synchronized(progressSyncLock) {
-            if (bookId == null) {
-                pendingFullSync = true
-            } else {
-                pendingBookIds += bookId
-            }
+            if (activeTarget != target) return
+            progressSyncQueue.add(PendingKomgaProgressSync(target, bookId))
             if (progressSyncJob?.isActive == true) return
-            progressSyncJob = scope.launch(Dispatchers.IO) {
+            val job = scope.launch(Dispatchers.IO, start = CoroutineStart.LAZY) {
                 drainProgressSyncQueue()
             }
+            progressSyncJob = job
+            job.start()
         }
     }
 
     private suspend fun drainProgressSyncQueue() {
+        val currentJob = currentCoroutineContext()[Job]
         while (true) {
             delay(PROGRESS_SYNC_DEBOUNCE_MS)
-            val (bookIds, fullSync) = synchronized(progressSyncLock) {
-                val ids = pendingBookIds.toList()
-                pendingBookIds.clear()
-                val shouldFullSync = pendingFullSync
-                pendingFullSync = false
-                ids to shouldFullSync
-            }
+            val pending = synchronized(progressSyncLock) { progressSyncQueue.drain() }
 
-            if (fullSync) {
-                runCatching {
-                    komgaProgressSyncService.value.syncHistoryFromServer(includeCompleted = true)
-                }.onFailure { error ->
-                    logcat(LogPriority.WARN, error) { "Komga SSE full progress sync failed" }
-                }
-            }
-
-            val sourceId = sourceIdProvider()
-            if (sourceId != null) {
-                val baseUrl = baseUrlProvider().trimEnd('/')
-                bookIds.forEach { bookId ->
-                    runCatching {
-                        komgaProgressSyncService.value.syncBookProgress(
-                            sourceId = sourceId,
-                            chapterUrl = "$baseUrl/api/v1/books/$bookId",
+            pending.forEach { request ->
+                if (!isCurrentConnection(request.target)) return@forEach
+                try {
+                    if (request.bookId == null) {
+                        komgaProgressSyncService.value.syncHistoryFromServer(
+                            sourceId = request.target.sourceId,
+                            includeCompleted = true,
                         )
-                    }.onFailure { error ->
-                        logcat(LogPriority.WARN, error) {
-                            "Komga SSE book progress sync failed bookId=$bookId"
-                        }
+                        komgaProgressSyncService.value.syncEpubProgressFromServer(request.target.sourceId)
+                    } else {
+                        komgaProgressSyncService.value.syncBookProgress(
+                            sourceId = request.target.sourceId,
+                            chapterUrl = "${request.target.baseUrl}/api/v1/books/${request.bookId}",
+                        )
+                    }
+                } catch (error: kotlinx.coroutines.CancellationException) {
+                    throw error
+                } catch (error: Throwable) {
+                    logcat(LogPriority.WARN, error) {
+                        "Komga SSE progress sync failed sourceId=${request.target.sourceId} " +
+                            "bookId=${request.bookId ?: "unknown"}"
                     }
                 }
             }
 
             synchronized(progressSyncLock) {
-                if (pendingBookIds.isEmpty() && !pendingFullSync) {
-                    progressSyncJob = null
+                if (progressSyncQueue.isEmpty()) {
+                    if (progressSyncJob === currentJob) progressSyncJob = null
                     return
                 }
             }
@@ -248,4 +285,29 @@ class KomgaSseClient(
     private companion object {
         const val PROGRESS_SYNC_DEBOUNCE_MS = 300L
     }
+}
+
+internal data class KomgaSseConnectionTarget(
+    val sourceId: Long,
+    val baseUrl: String,
+    val generation: Long,
+)
+
+internal data class PendingKomgaProgressSync(
+    val target: KomgaSseConnectionTarget,
+    val bookId: String?,
+)
+
+internal class KomgaSseProgressSyncQueue {
+    private val pending = linkedSetOf<PendingKomgaProgressSync>()
+
+    fun add(request: PendingKomgaProgressSync) {
+        pending += request
+    }
+
+    fun drain(): List<PendingKomgaProgressSync> = pending.toList().also { pending.clear() }
+
+    fun clear() = pending.clear()
+
+    fun isEmpty(): Boolean = pending.isEmpty()
 }

--- a/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
+++ b/app/src/main/java/koharia/komga/api/KomgaSseClient.kt
@@ -9,6 +9,8 @@ import eu.kanade.tachiyomi.network.NetworkHelper
 import eu.kanade.tachiyomi.util.system.networkStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -20,6 +22,7 @@ import okhttp3.Response
 import okhttp3.sse.EventSource
 import okhttp3.sse.EventSourceListener
 import okhttp3.sse.EventSources
+import org.json.JSONObject
 import tachiyomi.core.common.util.system.logcat
 
 class KomgaSseClient(
@@ -27,6 +30,7 @@ class KomgaSseClient(
     private val networkHelper: NetworkHelper,
     private val komgaProgressSyncService: Lazy<KomgaProgressSyncService>,
     private val baseUrlProvider: () -> String,
+    private val sourceIdProvider: () -> Long?,
     private val headersProvider: () -> Headers,
     private val cachedOnlyProvider: () -> Boolean,
 ) : DefaultLifecycleObserver {
@@ -34,10 +38,14 @@ class KomgaSseClient(
     private var appScope: CoroutineScope? = null
     private var eventSource: EventSource? = null
     private var isForeground = false
-    private var isWifi = false
+    private var isNetworkConnected = false
     private var isConnecting = false
     private var isStarted = false
     private var lastSkippedReason: String? = null
+    private val progressSyncLock = Any()
+    private val pendingBookIds = linkedSetOf<String>()
+    private var pendingFullSync = false
+    private var progressSyncJob: Job? = null
 
     fun start(scope: CoroutineScope) {
         if (isStarted) return
@@ -47,7 +55,10 @@ class KomgaSseClient(
 
         context.networkStateFlow()
             .onEach { state ->
-                isWifi = state.isWifi && state.isOnline
+                // Komga is commonly hosted on a LAN without Android's validated
+                // internet capability. A connected network is sufficient here;
+                // the SSE request itself remains the reachability check.
+                isNetworkConnected = state.isConnected || state.isWifi || state.isValidated
                 checkAndReconnect()
             }
             .launchIn(scope)
@@ -70,14 +81,14 @@ class KomgaSseClient(
 
     private fun checkAndReconnect() {
         val cachedOnly = cachedOnlyProvider()
-        if (isForeground && isWifi && !cachedOnly) {
+        if (isForeground && isNetworkConnected && !cachedOnly) {
             lastSkippedReason = null
             connect()
         } else {
             disconnect()
             val reason = when {
                 !isForeground -> "app not in foreground"
-                !isWifi -> "network is not validated Wi-Fi"
+                !isNetworkConnected -> "no connected network"
                 cachedOnly -> "cached-only mode enabled"
                 else -> "connection requirements not met"
             }
@@ -163,11 +174,78 @@ class KomgaSseClient(
         if (type == null) return
         when (type) {
             "ReadProgressChanged", "ReadProgressDeleted" -> {
-                logcat(LogPriority.DEBUG) { "Komga SSE: received $type, scheduling history sync" }
-                appScope?.launch(Dispatchers.IO) {
-                    komgaProgressSyncService.value.syncHistoryFromServer()
+                val bookId = runCatching { JSONObject(data).optString("bookId") }
+                    .getOrNull()
+                    ?.takeIf(String::isNotBlank)
+                logcat(LogPriority.DEBUG) {
+                    "Komga SSE: received $type bookId=${bookId ?: "unknown"}, scheduling progress sync"
+                }
+                scheduleProgressSync(bookId)
+            }
+        }
+    }
+
+    private fun scheduleProgressSync(bookId: String?) {
+        val scope = appScope ?: return
+        synchronized(progressSyncLock) {
+            if (bookId == null) {
+                pendingFullSync = true
+            } else {
+                pendingBookIds += bookId
+            }
+            if (progressSyncJob?.isActive == true) return
+            progressSyncJob = scope.launch(Dispatchers.IO) {
+                drainProgressSyncQueue()
+            }
+        }
+    }
+
+    private suspend fun drainProgressSyncQueue() {
+        while (true) {
+            delay(PROGRESS_SYNC_DEBOUNCE_MS)
+            val (bookIds, fullSync) = synchronized(progressSyncLock) {
+                val ids = pendingBookIds.toList()
+                pendingBookIds.clear()
+                val shouldFullSync = pendingFullSync
+                pendingFullSync = false
+                ids to shouldFullSync
+            }
+
+            if (fullSync) {
+                runCatching {
+                    komgaProgressSyncService.value.syncHistoryFromServer(includeCompleted = true)
+                }.onFailure { error ->
+                    logcat(LogPriority.WARN, error) { "Komga SSE full progress sync failed" }
+                }
+            }
+
+            val sourceId = sourceIdProvider()
+            if (sourceId != null) {
+                val baseUrl = baseUrlProvider().trimEnd('/')
+                bookIds.forEach { bookId ->
+                    runCatching {
+                        komgaProgressSyncService.value.syncBookProgress(
+                            sourceId = sourceId,
+                            chapterUrl = "$baseUrl/api/v1/books/$bookId",
+                        )
+                    }.onFailure { error ->
+                        logcat(LogPriority.WARN, error) {
+                            "Komga SSE book progress sync failed bookId=$bookId"
+                        }
+                    }
+                }
+            }
+
+            synchronized(progressSyncLock) {
+                if (pendingBookIds.isEmpty() && !pendingFullSync) {
+                    progressSyncJob = null
+                    return
                 }
             }
         }
+    }
+
+    private companion object {
+        const val PROGRESS_SYNC_DEBOUNCE_MS = 300L
     }
 }

--- a/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
+++ b/app/src/main/java/koharia/komga/ui/library/KomgaLibraryScreenModel.kt
@@ -24,6 +24,8 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.source.CatalogueSource
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
+import koharia.connection.ConnectionEpubHistorySyncAdapter
+import koharia.connection.ConnectionHistorySyncAdapter
 import koharia.connection.ConnectionPublicationAdapter
 import koharia.epub.cache.EpubCacheManager
 import koharia.komga.api.dto.KOMGA_LIBRARY_IDS_MEMO_KEY
@@ -567,13 +569,28 @@ class KomgaLibraryScreenModel(
         val komgaSource = source as? KomgaSource
         if (komgaSource != null) {
             screenModelScope.launchIO {
-                komgaSource.invalidateBrowseCache()
-                reloadKomgaState(
-                    komgaSource = komgaSource,
-                    showRefreshing = true,
-                    resetSelection = false,
-                    forceRefresh = true,
-                )
+                try {
+                    komgaSource.invalidateBrowseCache()
+                    reloadKomgaState(
+                        komgaSource = komgaSource,
+                        showRefreshing = true,
+                        resetSelection = false,
+                        forceRefresh = true,
+                        finishRefreshing = false,
+                        emitRefreshSignal = false,
+                    )
+                    runCatching {
+                        (komgaSource as? ConnectionHistorySyncAdapter)?.syncConnectionHistory()
+                        (komgaSource as? ConnectionEpubHistorySyncAdapter)?.syncConnectionEpubProgress()
+                    }.onFailure { error ->
+                        logcat(LogPriority.WARN, error) {
+                            "Failed to sync Komga progress during manual library refresh sourceId=$sourceId"
+                        }
+                    }
+                } finally {
+                    mutableState.update { it.copy(isRefreshing = false) }
+                    refreshSignal.value += 1
+                }
             }
         } else {
             refreshSignal.value += 1
@@ -622,6 +639,8 @@ class KomgaLibraryScreenModel(
         resetSelection: Boolean,
         forceRefresh: Boolean,
         forceShelfLibrarySelection: Boolean = false,
+        finishRefreshing: Boolean = true,
+        emitRefreshSignal: Boolean = true,
     ) {
         if (resetSelection) {
             libraryFilterBeforeQuickSelection = null
@@ -638,7 +657,7 @@ class KomgaLibraryScreenModel(
                     filters = filters,
                     komgaLibraries = persistentListOf(),
                     selectedKomgaLibraryId = null,
-                    isRefreshing = false,
+                    isRefreshing = if (finishRefreshing) false else it.isRefreshing,
                     isServerConfigured = false,
                     isLibraryScopeEmpty = false,
                     toolbarQuery = null,
@@ -646,7 +665,9 @@ class KomgaLibraryScreenModel(
                     persistentFilteringEnabled = komgaSource.isPersistentFilteringEnabled(libraryScope),
                 )
             }
-            refreshSignal.value += 1
+            if (emitRefreshSignal) {
+                refreshSignal.value += 1
+            }
             return
         }
 
@@ -715,8 +736,12 @@ class KomgaLibraryScreenModel(
             }
             Log.e("KomgaLibraryScreenModel", "Failed to refresh Komga libraries", e)
         } finally {
-            mutableState.update { it.copy(isRefreshing = false) }
-            refreshSignal.value += 1
+            if (finishRefreshing) {
+                mutableState.update { it.copy(isRefreshing = false) }
+            }
+            if (emitRefreshSignal) {
+                refreshSignal.value += 1
+            }
         }
     }
 

--- a/app/src/main/java/koharia/source/komga/KomgaSource.kt
+++ b/app/src/main/java/koharia/source/komga/KomgaSource.kt
@@ -22,6 +22,7 @@ import eu.kanade.tachiyomi.source.sourcePreferences
 import koharia.connection.ConnectionAccountAdapter
 import koharia.connection.ConnectionBrowseAdapter
 import koharia.connection.ConnectionDownloadStorageAdapter
+import koharia.connection.ConnectionEpubHistorySyncAdapter
 import koharia.connection.ConnectionEpubProgressAdapter
 import koharia.connection.ConnectionHealthAdapter
 import koharia.connection.ConnectionHistorySyncAdapter
@@ -33,6 +34,7 @@ import koharia.connection.ConnectionPageProgressAdapter
 import koharia.connection.ConnectionPagePublication
 import koharia.connection.ConnectionPublicationAdapter
 import koharia.connection.ConnectionRawDownloadAdapter
+import koharia.connection.ConnectionReadStatusAdapter
 import koharia.connection.ConnectionSource
 import koharia.connection.ConnectionViewerSettingsAdapter
 import koharia.connection.LibraryConnectionProfile
@@ -94,7 +96,9 @@ class KomgaSource(
     ConnectionPublicationAdapter,
     ConnectionViewerSettingsAdapter,
     ConnectionMangaProgressAdapter,
+    ConnectionReadStatusAdapter,
     ConnectionHistorySyncAdapter,
+    ConnectionEpubHistorySyncAdapter,
     ConnectionPageProgressAdapter,
     ConnectionEpubProgressAdapter {
 
@@ -383,8 +387,19 @@ class KomgaSource(
         Injekt.get<eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService>().syncFromServer(manga)
     }
 
+    override suspend fun setChapterReadStatus(chapterUrl: String, read: Boolean) {
+        if (!apiClient.isBook(chapterUrl)) return
+        apiClient.setBookReadStatus(chapterUrl, read)
+    }
+
     override suspend fun syncConnectionHistory() {
-        Injekt.get<eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService>().syncHistoryFromServer(id)
+        Injekt.get<eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService>()
+            .syncHistoryFromServer(sourceId = id, includeCompleted = true)
+    }
+
+    override suspend fun syncConnectionEpubProgress() {
+        Injekt.get<eu.kanade.tachiyomi.data.track.komga.KomgaProgressSyncService>()
+            .syncEpubProgressFromServer(sourceId = id)
     }
 
     override suspend fun pullPageProgress(

--- a/app/src/test/java/eu/kanade/domain/chapter/interactor/SetReadStatusTest.kt
+++ b/app/src/test/java/eu/kanade/domain/chapter/interactor/SetReadStatusTest.kt
@@ -1,0 +1,114 @@
+package eu.kanade.domain.chapter.interactor
+
+import eu.kanade.domain.download.interactor.DeleteDownload
+import eu.kanade.tachiyomi.source.Source
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import koharia.connection.ConnectionReadStatusAdapter
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.model.Chapter
+import tachiyomi.domain.chapter.repository.ChapterRepository
+import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.manga.model.Manga
+import tachiyomi.domain.manga.repository.MangaRepository
+import tachiyomi.domain.source.service.SourceManager
+
+class SetReadStatusTest {
+
+    private abstract class ReadStatusSource : Source, ConnectionReadStatusAdapter
+
+    @Test
+    fun `marking a connection chapter unread updates the provider`() = runTest {
+        val downloadPreferences = mockk<DownloadPreferences>(relaxed = true)
+        val deleteDownload = mockk<DeleteDownload>(relaxed = true)
+        val mangaRepository = mockk<MangaRepository>()
+        val chapterRepository = mockk<ChapterRepository>()
+        val sourceManager = mockk<SourceManager>()
+        val source = mockk<ReadStatusSource>()
+        val manga = Manga.create().copy(id = 9L, source = 42L)
+        val chapter = Chapter.create().copy(
+            id = 7L,
+            mangaId = manga.id,
+            read = true,
+            lastPageRead = 12L,
+            url = "https://komga.test/api/v1/books/book-1",
+        )
+
+        coEvery { chapterRepository.updateAll(any()) } just runs
+        coEvery { mangaRepository.getMangaById(manga.id) } returns manga
+        every { sourceManager.get(manga.source) } returns source
+        coEvery { source.setChapterReadStatus(chapter.url, false) } just runs
+
+        val result = interactor(
+            downloadPreferences = downloadPreferences,
+            deleteDownload = deleteDownload,
+            mangaRepository = mangaRepository,
+            chapterRepository = chapterRepository,
+            sourceManager = sourceManager,
+        ).await(read = false, chapter)
+
+        assertSame(SetReadStatus.Result.Success, result)
+        coVerify(exactly = 1) {
+            chapterRepository.updateAll(
+                match { updates ->
+                    updates.single().id == chapter.id &&
+                        updates.single().read == false &&
+                        updates.single().lastPageRead == 0L
+                },
+            )
+        }
+        coVerify(exactly = 1) { source.setChapterReadStatus(chapter.url, false) }
+    }
+
+    @Test
+    fun `a failed provider update does not prevent remaining chapters from syncing`() = runTest {
+        val mangaRepository = mockk<MangaRepository>()
+        val chapterRepository = mockk<ChapterRepository>()
+        val sourceManager = mockk<SourceManager>()
+        val source = mockk<ReadStatusSource>()
+        val manga = Manga.create().copy(id = 9L, source = 42L)
+        val first = Chapter.create().copy(
+            id = 7L,
+            mangaId = manga.id,
+            read = true,
+            url = "https://komga.test/api/v1/books/book-1",
+        )
+        val second = first.copy(id = 8L, url = "https://komga.test/api/v1/books/book-2")
+
+        coEvery { chapterRepository.updateAll(any()) } just runs
+        coEvery { mangaRepository.getMangaById(manga.id) } returns manga
+        every { sourceManager.get(manga.source) } returns source
+        coEvery { source.setChapterReadStatus(first.url, false) } throws IllegalStateException("offline")
+        coEvery { source.setChapterReadStatus(second.url, false) } just runs
+
+        val result = interactor(
+            mangaRepository = mangaRepository,
+            chapterRepository = chapterRepository,
+            sourceManager = sourceManager,
+        ).await(read = false, first, second)
+
+        assertSame(SetReadStatus.Result.Success, result)
+        coVerify(exactly = 1) { source.setChapterReadStatus(first.url, false) }
+        coVerify(exactly = 1) { source.setChapterReadStatus(second.url, false) }
+    }
+
+    private fun interactor(
+        downloadPreferences: DownloadPreferences = mockk(relaxed = true),
+        deleteDownload: DeleteDownload = mockk(relaxed = true),
+        mangaRepository: MangaRepository,
+        chapterRepository: ChapterRepository,
+        sourceManager: SourceManager,
+    ) = SetReadStatus(
+        downloadPreferences = downloadPreferences,
+        deleteDownload = deleteDownload,
+        mangaRepository = mangaRepository,
+        chapterRepository = chapterRepository,
+        sourceManager = sourceManager,
+    )
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncServiceTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncServiceTest.kt
@@ -1,0 +1,65 @@
+package eu.kanade.tachiyomi.data.track.komga
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.chapter.model.Chapter
+
+class KomgaProgressSyncServiceTest {
+
+    @Test
+    fun `missing Komga read progress is applied as unread`() {
+        val localChapter = Chapter.create().copy(
+            id = 7L,
+            read = true,
+            lastPageRead = 12L,
+        )
+        val remoteBook = KomgaApi.SeriesBookProgress(
+            seriesUrl = "https://komga.test/api/v1/series/series-1",
+            url = "https://komga.test/api/v1/books/book-1",
+            readProgress = null,
+        )
+
+        val update = remoteBook.toChapterUpdate(localChapter)
+
+        assertNotNull(update)
+        assertFalse(update!!.read!!)
+        assertEquals(0L, update.lastPageRead)
+    }
+
+    @Test
+    fun `remote page progress remains one based when present`() {
+        val localChapter = Chapter.create().copy(id = 7L)
+        val remoteBook = KomgaApi.SeriesBookProgress(
+            seriesUrl = "https://komga.test/api/v1/series/series-1",
+            url = "https://komga.test/api/v1/books/book-1",
+            readProgress = BookReadProgressDto(completed = true, page = 4),
+        )
+
+        val update = remoteBook.toChapterUpdate(localChapter)
+
+        assertNotNull(update)
+        assertEquals(3L, update!!.lastPageRead)
+        assertEquals(true, update.read)
+    }
+
+    @Test
+    fun `completed progress without a page does not reset local page`() {
+        val localChapter = Chapter.create().copy(
+            id = 7L,
+            lastPageRead = 12L,
+        )
+        val remoteBook = KomgaApi.SeriesBookProgress(
+            seriesUrl = "https://komga.test/api/v1/series/series-1",
+            url = "https://komga.test/api/v1/books/book-1",
+            readProgress = BookReadProgressDto(completed = true, page = null),
+        )
+
+        val update = remoteBook.toChapterUpdate(localChapter)
+
+        assertNotNull(update)
+        assertEquals(true, update!!.read)
+        assertEquals(null, update.lastPageRead)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncServiceTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/komga/KomgaProgressSyncServiceTest.kt
@@ -1,10 +1,15 @@
 package eu.kanade.tachiyomi.data.track.komga
 
+import koharia.domain.epub.model.EpubProgress
+import koharia.domain.epub.model.EpubRemoteProgressCache
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import tachiyomi.domain.chapter.model.Chapter
+import java.util.Date
 
 class KomgaProgressSyncServiceTest {
 
@@ -61,5 +66,96 @@ class KomgaProgressSyncServiceTest {
         assertNotNull(update)
         assertEquals(true, update!!.read)
         assertEquals(null, update.lastPageRead)
+    }
+
+    @Test
+    fun `manual EPUB refresh selects only entries with relevant progress`() {
+        val untouched = epubChapter(id = 1L, bookId = "untouched")
+        val remoteInProgress = epubChapter(id = 2L, bookId = "remote")
+        val localInProgress = epubChapter(id = 3L, bookId = "local")
+        val cachedInProgress = epubChapter(id = 4L, bookId = "cached")
+        val completedWithCache = epubChapter(id = 5L, bookId = "completed", read = true)
+
+        val selected = selectRelevantKomgaEpubChapters(
+            chapters = listOf(
+                untouched,
+                remoteInProgress,
+                localInProgress,
+                cachedInProgress,
+                completedWithCache,
+            ),
+            remoteInProgressBookUrls = setOf(remoteInProgress.url),
+            localProgressChapterIds = setOf(localInProgress.id),
+            remoteProgressChapterIds = setOf(cachedInProgress.id, completedWithCache.id),
+        )
+
+        assertEquals(listOf(2L, 3L, 4L), selected.map(Chapter::id))
+    }
+
+    @Test
+    fun `server progress can identify EPUB when chapter memo is stale`() {
+        val chapter = Chapter.create().copy(
+            id = 7L,
+            url = "https://komga.test/api/v1/books/remote#cached-version",
+        )
+
+        val selected = selectRelevantKomgaEpubChapters(
+            chapters = listOf(chapter),
+            remoteInProgressBookUrls = setOf("https://komga.test/api/v1/books/remote"),
+            localProgressChapterIds = emptySet(),
+            remoteProgressChapterIds = emptySet(),
+        )
+
+        assertEquals(listOf(chapter), selected)
+    }
+
+    @Test
+    fun `unread reset only clears effective EPUB progress`() {
+        val local = epubProgress(updatedAt = 200L)
+        val staleEmptyRemote = remoteProgress(checkedAt = 100L)
+        val currentEmptyRemote = remoteProgress(checkedAt = 300L)
+        val populatedRemote = remoteProgress(checkedAt = 300L, progression = 0.5)
+
+        assertFalse(hasEpubProgressToClear(null, null))
+        assertEquals(true, hasEpubProgressToClear(local, null))
+        assertEquals(true, hasEpubProgressToClear(local, staleEmptyRemote))
+        assertFalse(hasEpubProgressToClear(local, currentEmptyRemote))
+        assertEquals(true, hasEpubProgressToClear(null, populatedRemote))
+    }
+
+    private fun epubChapter(id: Long, bookId: String, read: Boolean = false): Chapter {
+        return Chapter.create().copy(
+            id = id,
+            read = read,
+            url = "https://komga.test/api/v1/books/$bookId",
+            memo = buildJsonObject { put("isEpub", true) },
+        )
+    }
+
+    private fun epubProgress(updatedAt: Long): EpubProgress {
+        return EpubProgress(
+            chapterId = 1L,
+            mangaId = 1L,
+            bookUrl = "https://komga.test/api/v1/books/book-1",
+            locatorJson = "{}",
+            progression = 0.25,
+            positionIndex = 1L,
+            updatedAt = Date(updatedAt),
+            lastSyncedAt = null,
+        )
+    }
+
+    private fun remoteProgress(checkedAt: Long, progression: Double? = null): EpubRemoteProgressCache {
+        return EpubRemoteProgressCache(
+            chapterId = 1L,
+            mangaId = 1L,
+            bookUrl = "https://komga.test/api/v1/books/book-1",
+            locatorJson = null,
+            progression = progression,
+            positionIndex = null,
+            modifiedAt = null,
+            checkedAt = Date(checkedAt),
+            serverDate = null,
+        )
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicyTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicyTest.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.ui.reader
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -35,6 +36,54 @@ class RemoteProgressConflictPolicyTest {
                 openingPageIndex = 20,
                 currentPageIndex = 24,
                 remotePageIndex = 18,
+            ),
+        )
+    }
+
+    @Test
+    fun `newer local progress may be written when positions differ`() {
+        assertEquals(
+            RemoteProgressDecision.KEEP_LOCAL,
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = 2_000L,
+                remoteUpdatedAtMillis = 1_000L,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `newer or unknown remote progress requires confirmation`() {
+        assertEquals(
+            RemoteProgressDecision.KEEP_REMOTE,
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteUpdatedAtMillis = 2_000L,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+        assertEquals(
+            RemoteProgressDecision.KEEP_REMOTE,
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteUpdatedAtMillis = null,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `navigation during refresh makes local progress newest`() {
+        assertEquals(
+            RemoteProgressDecision.KEEP_LOCAL,
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteUpdatedAtMillis = 2_000L,
+                sameLocation = false,
+                localChangedDuringCheck = true,
             ),
         )
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicyTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/RemoteProgressConflictPolicyTest.kt
@@ -1,44 +1,9 @@
 package eu.kanade.tachiyomi.ui.reader
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class RemoteProgressConflictPolicyTest {
-
-    @Test
-    fun `layout-only progress change does not conflict with opening server position`() {
-        assertFalse(
-            RemoteProgressConflictPolicy.hasConflict(
-                openingPageIndex = 20,
-                currentPageIndex = 22,
-                remotePageIndex = 20,
-            ),
-        )
-    }
-
-    @Test
-    fun `server position matching current navigation does not conflict`() {
-        assertFalse(
-            RemoteProgressConflictPolicy.hasConflict(
-                openingPageIndex = 20,
-                currentPageIndex = 24,
-                remotePageIndex = 24,
-            ),
-        )
-    }
-
-    @Test
-    fun `server position differing from opening and current positions conflicts`() {
-        assertTrue(
-            RemoteProgressConflictPolicy.hasConflict(
-                openingPageIndex = 20,
-                currentPageIndex = 24,
-                remotePageIndex = 18,
-            ),
-        )
-    }
 
     @Test
     fun `newer local progress may be written when positions differ`() {
@@ -69,6 +34,19 @@ class RemoteProgressConflictPolicyTest {
             RemoteProgressConflictPolicy.decide(
                 localUpdatedAtMillis = 1_000L,
                 remoteUpdatedAtMillis = null,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown local progress timestamp requires confirmation`() {
+        assertEquals(
+            RemoteProgressDecision.KEEP_REMOTE,
+            RemoteProgressConflictPolicy.decide(
+                localUpdatedAtMillis = null,
+                remoteUpdatedAtMillis = 2_000L,
                 sameLocation = false,
                 localChangedDuringCheck = false,
             ),

--- a/app/src/test/java/koharia/connection/ConnectionArchitectureTest.kt
+++ b/app/src/test/java/koharia/connection/ConnectionArchitectureTest.kt
@@ -277,6 +277,7 @@ class ConnectionArchitectureTest {
         assertTrue(source is ConnectionHistorySyncAdapter)
         assertFalse(source is ConnectionViewerSettingsAdapter)
         assertFalse(source is ConnectionMangaProgressAdapter)
+        assertFalse(source is ConnectionReadStatusAdapter)
         assertFalse(source is ConnectionPageProgressAdapter)
         assertFalse(source is ConnectionBrowseAdapter)
         assertFalse(source is ConnectionLibraryRefreshAdapter)

--- a/app/src/test/java/koharia/epub/progress/EpubRemoteProgressPolicyTest.kt
+++ b/app/src/test/java/koharia/epub/progress/EpubRemoteProgressPolicyTest.kt
@@ -1,0 +1,77 @@
+package koharia.epub.progress
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EpubRemoteProgressPolicyTest {
+
+    @Test
+    fun `cached fallback is not accepted as a successful refresh`() {
+        assertFalse(
+            EpubRemoteProgressPolicy.isFreshResult(
+                checkStartedAtMillis = 2_000L,
+                checkedAtMillis = 1_999L,
+            ),
+        )
+        assertTrue(
+            EpubRemoteProgressPolicy.isFreshResult(
+                checkStartedAtMillis = 2_000L,
+                checkedAtMillis = 2_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun `newer remote progress is kept when locations differ`() {
+        assertEquals(
+            EpubRemoteProgressDecision.KEEP_REMOTE,
+            EpubRemoteProgressPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteModifiedAtMillis = 2_000L,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `newer local progress is kept when locations differ`() {
+        assertEquals(
+            EpubRemoteProgressDecision.KEEP_LOCAL,
+            EpubRemoteProgressPolicy.decide(
+                localUpdatedAtMillis = 2_000L,
+                remoteModifiedAtMillis = 1_000L,
+                sameLocation = false,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `matching locations accept remote timestamp`() {
+        assertEquals(
+            EpubRemoteProgressDecision.SAME_LOCATION,
+            EpubRemoteProgressPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteModifiedAtMillis = 2_000L,
+                sameLocation = true,
+                localChangedDuringCheck = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `navigation during refresh keeps local progress`() {
+        assertEquals(
+            EpubRemoteProgressDecision.KEEP_LOCAL,
+            EpubRemoteProgressPolicy.decide(
+                localUpdatedAtMillis = 1_000L,
+                remoteModifiedAtMillis = 2_000L,
+                sameLocation = false,
+                localChangedDuringCheck = true,
+            ),
+        )
+    }
+}

--- a/app/src/test/java/koharia/komga/api/KomgaApiReadStatusTest.kt
+++ b/app/src/test/java/koharia/komga/api/KomgaApiReadStatusTest.kt
@@ -1,0 +1,45 @@
+package koharia.komga.api
+
+import kotlinx.serialization.json.Json
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okio.Buffer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class KomgaApiReadStatusTest {
+
+    private val api = KomgaApiClient(
+        baseUrl = "https://komga.test",
+        headers = Headers.Builder().build(),
+        client = OkHttpClient(),
+        json = Json,
+    )
+
+    @Test
+    fun `marking a book read patches completed status`() {
+        val request = api.bookReadStatusRequest(
+            bookUrl = "https://komga.test/api/v1/books/book-1",
+            read = true,
+        )
+
+        assertEquals("PATCH", request.method)
+        assertEquals("/api/v1/books/book-1/read-progress", request.url.encodedPath)
+        assertEquals(
+            "{\"completed\":true}",
+            Buffer().also { request.body!!.writeTo(it) }.readUtf8(),
+        )
+    }
+
+    @Test
+    fun `marking a book unread deletes its read progress`() {
+        val request = api.bookReadStatusRequest(
+            bookUrl = "https://komga.test/api/v1/books/book-1",
+            read = false,
+        )
+
+        assertEquals("DELETE", request.method)
+        assertEquals("/api/v1/books/book-1/read-progress", request.url.encodedPath)
+        assertEquals(0L, request.body?.contentLength() ?: 0L)
+    }
+}

--- a/app/src/test/java/koharia/komga/api/KomgaSseProgressSyncQueueTest.kt
+++ b/app/src/test/java/koharia/komga/api/KomgaSseProgressSyncQueueTest.kt
@@ -1,0 +1,40 @@
+package koharia.komga.api
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KomgaSseProgressSyncQueueTest {
+
+    @Test
+    fun `book events remain bound to their originating connection`() {
+        val queue = KomgaSseProgressSyncQueue()
+        val serverA = KomgaSseConnectionTarget(1L, "https://a.test", generation = 1L)
+        val serverB = KomgaSseConnectionTarget(2L, "https://b.test", generation = 2L)
+
+        queue.add(PendingKomgaProgressSync(serverA, "shared-book-id"))
+        queue.add(PendingKomgaProgressSync(serverA, "shared-book-id"))
+        queue.add(PendingKomgaProgressSync(serverB, "shared-book-id"))
+
+        assertEquals(
+            listOf(
+                PendingKomgaProgressSync(serverA, "shared-book-id"),
+                PendingKomgaProgressSync(serverB, "shared-book-id"),
+            ),
+            queue.drain(),
+        )
+    }
+
+    @Test
+    fun `clearing queue drops pending full and incremental syncs`() {
+        val queue = KomgaSseProgressSyncQueue()
+        val target = KomgaSseConnectionTarget(1L, "https://komga.test", generation = 1L)
+        queue.add(PendingKomgaProgressSync(target, null))
+        queue.add(PendingKomgaProgressSync(target, "book-1"))
+
+        queue.clear()
+
+        assertTrue(queue.isEmpty())
+        assertTrue(queue.drain().isEmpty())
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1445,7 +1445,7 @@
     <string name="epub_reader_remote_progress_title">Server reading progress</string>
     <string name="epub_reader_remote_progress_message">The server has a different saved position (%1$d%%). Jump to it?</string>
     <string name="reader_remote_progress_message">Local: page %1$d of %2$d (%3$d%%)\nServer: page %4$d of %5$d (%6$d%%)</string>
-    <string name="epub_reader_keep_local_progress">Keep current position</string>
+    <string name="epub_reader_keep_local_progress">Keep local position and sync</string>
     <string name="epub_reader_jump_remote_progress">Jump to server position</string>
     <string name="label_comics">Comics</string>
     <string name="label_books">Books</string>

--- a/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -1306,7 +1306,7 @@
     <string name="epub_reader_remote_progress_title">服务器阅读进度</string>
     <string name="epub_reader_remote_progress_message">服务器保存了不同的阅读位置（%1$d%%），是否跳转？</string>
     <string name="reader_remote_progress_message">本地：第 %1$d/%2$d 页（%3$d%%）\n服务器：第 %4$d/%5$d 页（%6$d%%）</string>
-    <string name="epub_reader_keep_local_progress">保留当前位置</string>
+    <string name="epub_reader_keep_local_progress">保留本地位置并同步</string>
     <string name="epub_reader_jump_remote_progress">跳转至服务器进度</string>
     <string name="label_comics">漫画</string>
     <string name="label_books">书籍</string>


### PR DESCRIPTION
## 中文

### 修改内容

- 将客户端标记已读/未读的操作同步到 Komga，并正确处理服务端删除阅读进度的事件。
- 完善 SSE 单本增量同步、手动刷新和 EPUB 定位同步，使网页端与其他设备的进度能主动拉取到客户端。
- 阅读器写入前先获取最新远端进度；本地页码时间不可靠时要求用户明确选择，避免旧本地进度自动覆盖服务器。
- 漫画与 EPUB 冲突弹窗必须显式选择“保留本地位置并同步”或“跳转至服务器进度”。
- 将 Komga 进度同步服务改为单例，使 SSE、手动刷新和系列页共享同一互斥锁。

## English

### Changes

- Synchronize read and unread actions with Komga and correctly handle deleted server read progress.
- Improve incremental SSE updates, manual refresh synchronization, and EPUB locator refreshes so web and other-device progress is pulled into the app.
- Fetch fresh remote progress before reader uploads; require an explicit choice when the local page timestamp is not reliable, preventing stale local progress from silently overwriting the server.
- Require an explicit choice between keeping and syncing the local position or jumping to the server position in comic and EPUB readers.
- Register the Komga progress synchronization service as a singleton so SSE, manual refresh, and series refreshes share the same mutex.

## Verification / 验证

- `spotlessCheck`
- `:app:compileDebugKotlin`
- Progress synchronization unit tests: 17 passed
- Full app unit suite: 320/321 passed; the remaining existing MockK source-membership test passed when rerun in isolation and appears order-dependent

Closes #72