### PR TITLE
优化冷启动初始化与启动页 / Optimize cold-start initialization and splash readiness

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -105,8 +105,10 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         }
 
         Injekt.importModule(PreferenceModule(this))
-        Injekt.importModule(AppModule(this))
+        val appModule = AppModule(this)
+        Injekt.importModule(appModule)
         Injekt.importModule(DomainModule())
+        appModule.initializeInBackground()
 
         setupNotificationChannels()
 
@@ -292,7 +294,13 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
     override fun getPackageName(): String {
         try {
             // Override the value passed as X-Requested-With in WebView requests
-            val stackTrace = Looper.getMainLooper().thread.stackTrace
+            val currentThread = Thread.currentThread()
+            val mainThread = Looper.getMainLooper().thread
+            val stackTrace = if (currentThread === mainThread) {
+                currentThread.stackTrace
+            } else {
+                mainThread.stackTrace + currentThread.stackTrace
+            }
             val isChromiumCall = stackTrace.any { trace ->
                 trace.className.lowercase() in setOf("org.chromium.base.buildinfo", "org.chromium.base.apkinfo") &&
                     trace.methodName.lowercase() in setOf("getall", "getpackagename", "<init>")

--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.di
 
 import android.app.Application
+import android.webkit.CookieManager
 import androidx.core.content.ContextCompat
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import app.cash.sqldelight.db.QueryResult
@@ -44,6 +45,10 @@ import koharia.source.komga.KomgaConnectionProvider
 import koharia.source.komga.KomgaLocalConfigManager
 import koharia.source.komga.KomgaServerPreferences
 import koharia.source.local.LocalFolderConnectionProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
@@ -69,6 +74,7 @@ import tachiyomi.data.UpdateStrategyColumnAdapter
 import tachiyomi.data.migration.LegacyDatabaseSchemaBridge
 import tachiyomi.domain.source.service.SourceManager
 import tachiyomi.domain.storage.service.StorageManager
+import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.InjektModule
 import uy.kohesive.injekt.api.InjektRegistrar
 import uy.kohesive.injekt.api.addSingleton
@@ -81,6 +87,7 @@ private val lock = Any()
 class AppModule(val app: Application) : InjektModule {
 
     private var sqlDriverRef: WeakReference<SqlDriver>? = null
+    private val startupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     override fun InjektRegistrar.registerInjectables() {
         addSingleton(app)
@@ -267,21 +274,33 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { EpubReaderSupportResolver() }
         addSingletonFactory { KomgaEpubProgressSyncService(get(), get(), get()) }
         addSingletonFactory { KomgaEpubRemoteProgressCoordinator(get(), get(), get(), get()) }
+    }
 
-        // Asynchronously init expensive components for a faster cold start
+    /** Starts process-scoped singleton prewarming after all DI modules have been registered. */
+    fun initializeInBackground() {
         ContextCompat.getMainExecutor(app).execute {
-            get<NetworkHelper>()
+            // WebView provider initialization must happen on the main thread. NetworkHelper's
+            // AndroidCookieJar will reuse this initialized CookieManager from the I/O scope.
+            CookieManager.getInstance()
 
-            get<ConnectionPreferences>()
-            get<KomgaServerPreferences>()
-            get<KomgaLocalConfigManager>()
+            startupScope.launch {
+                Injekt.get<NetworkHelper>()
 
-            get<SourceManager>()
-            get<KomgaActiveServerSseManager>()
+                Injekt.get<ConnectionPreferences>()
+                Injekt.get<KomgaServerPreferences>()
+                Injekt.get<KomgaLocalConfigManager>()
 
-            get<Database>()
+                Injekt.get<SourceManager>()
+                // KomgaActiveServerSseManager registers a ProcessLifecycle observer and must be
+                // constructed on the main thread. Keep the surrounding I/O-heavy initialization off it.
+                ContextCompat.getMainExecutor(app).execute {
+                    Injekt.get<KomgaActiveServerSseManager>()
+                }
 
-            get<DownloadManager>()
+                Injekt.get<Database>()
+
+                Injekt.get<DownloadManager>()
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -176,6 +176,9 @@ class MainActivity : BaseActivity() {
                     if (isLaunch) {
                         // Set start screen
                         handleIntentAction(intent, navigator)
+                        // The launcher intent has no tab action, but the initial screen is ready
+                        // after intent handling regardless of whether a specific action was found.
+                        ready = true
 
                         // Reset Incognito Mode on relaunch
                         preferences.incognitoMode.set(false)
@@ -438,7 +441,6 @@ class MainActivity : BaseActivity() {
             lifecycleScope.launch { HomeScreen.openTab(tabToOpen) }
         }
 
-        ready = true
         return true
     }
 


### PR DESCRIPTION
## 中文
### 变更摘要
- 修复桌面 `ACTION_MAIN` 启动时启动页可能无条件等待 5 秒的问题。
- 在主线程首次初始化 `CookieManager`，避免 `NetworkHelper` 在 IO 线程触发 WebView provider 初始化。
- 将 IO 密集型依赖预热放到后台，并保持 `KomgaActiveServerSseManager` 在主线程构造。
- 扩展 Chromium 调用栈识别，避免错误暴露真实应用包名。

### 验证
- `./gradlew.bat spotlessApply`
- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- 已在实体设备和模拟器安装 Debug APK，并完成冷启动冒烟验证。

## English
### Summary
- Fix the launcher `ACTION_MAIN` path so the splash screen does not wait for the five-second fallback.
- Initialize `CookieManager` for the first time on the main thread so `NetworkHelper` cannot initialize the WebView provider from the IO thread.
- Move IO-heavy dependency prewarming to the background while keeping `KomgaActiveServerSseManager` construction on the main thread.
- Broaden Chromium stack detection to avoid exposing the real application package name.

### Validation
- `./gradlew.bat spotlessApply`
- `./gradlew.bat spotlessCheck`
- `./gradlew.bat :app:compileDebugKotlin`
- Installed the Debug APK on a physical device and an emulator, then completed cold-start smoke validation.